### PR TITLE
chore: Introduce docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,19 @@ For VS Code users, we higlhy recommand the [official extension](https://nx.dev/c
 ## Environment variables in Nx
 
 Nx task runner comes with [a built in opinionated way to handle env variables](https://nx.dev/recipes/environment-variables/define-environment-variables)
+
+## Developer
+
+### Run locally
+
+Vscode command: NX Console: Focus On Debug Console View
+
+```
+NX Project Tab > builder > dev > debug
+```
+
+Manually:
+
+```
+npx nx run builder:dev --configuration=debug
+```

--- a/apps/builder/.env.docker-compose
+++ b/apps/builder/.env.docker-compose
@@ -1,0 +1,11 @@
+ENV=development
+
+APP_DOMAIN=http://localhost:3000
+SESSION_SECRET=SESSION_SECRET
+SESSION_MAX_AGE=43200
+
+MARBLE_API_DOMAIN=http://host.docker.internal:8080
+
+# Google OAuth2
+GOOGLE_CLIENT_ID=230167238776-ve9vscbgt4q814toa3oosblhpcdpf4is.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=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

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  marble-frontend:
+    env_file: ./apps/builder/.env.docker-compose
+    build:
+      context: .
+      dockerfile: ./apps/builder/Dockerfile
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
A simple docker-compose that works out of the box.

It targets the backend on the host machine: see `.env.docker-compose` for more information. 