### PR TITLE
feat(decisions): add input to edit decision id

### DIFF
--- a/apps/builder/app/routes/__builder/decisions.tsx
+++ b/apps/builder/app/routes/__builder/decisions.tsx
@@ -6,16 +6,15 @@ import {
 } from '@marble-front/builder/components';
 import { authenticator } from '@marble-front/builder/services/auth/auth.server';
 import { formatCreatedAt } from '@marble-front/builder/utils/format';
-import { Table, useVirtualTable } from '@marble-front/ui/design-system';
-import { Decision as DecisionIcon } from '@marble-front/ui/icons';
-import { json, type LinksFunction, type LoaderArgs } from '@remix-run/node';
+import { Input, Table, useVirtualTable } from '@marble-front/ui/design-system';
+import { Decision as DecisionIcon, Search } from '@marble-front/ui/icons';
+import { json, type LoaderArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { type ColumnDef, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import cssBundleHref from 'react-json-view-lite/dist/index.css';
 import * as R from 'remeda';
 
 import {
@@ -25,10 +24,6 @@ import {
 
 export const handle = {
   i18n: ['decisions', 'navigation'] satisfies Namespace,
-};
-
-export const links: LinksFunction = () => {
-  return [{ rel: 'stylesheet', href: cssBundleHref }];
 };
 
 export async function loader({ request }: LoaderArgs) {
@@ -111,23 +106,44 @@ export default function DecisionsPage() {
       </Page.Header>
       <DecisionsRightPanel.Root>
         <Page.Content scrollable={false}>
+          <Input
+            type="search"
+            className="max-w-sm"
+            aria-label={t('decisions:search.placeholder')}
+            placeholder={t('decisions:search.placeholder')}
+            startAdornment={<Search />}
+            value={decisionId ?? ''}
+            onKeyDownCapture={(e) => {
+              if (e.code === 'Escape') {
+                setDecisionId();
+              }
+            }}
+            onChange={(event) => {
+              setDecisionId(event.target.value);
+            }}
+            onClick={(e) => {
+              e.stopPropagation(); // To prevent DecisionsRightPannel from closing
+            }}
+          />
           <Table.Container {...getContainerProps()}>
             <Table.Header headerGroups={table.getHeaderGroups()} />
             <Table.Body {...getBodyProps()}>
-              {rows.map((row) => (
-                <Table.Row
-                  key={row.id}
-                  className={clsx(
-                    'hover:bg-grey-02 cursor-pointer',
-                    row.original.id === decisionId && 'bg-grey-02'
-                  )}
-                  row={row}
-                  onClick={(e) => {
-                    setDecisionId(row.original.id);
-                    e.stopPropagation();
-                  }}
-                />
-              ))}
+              {rows.map((row) => {
+                return (
+                  <Table.Row
+                    key={row.id}
+                    className={clsx(
+                      'hover:bg-grey-02 cursor-pointer',
+                      row.original.id === decisionId && 'bg-grey-02'
+                    )}
+                    row={row}
+                    onClick={(e) => {
+                      setDecisionId(row.original.id);
+                      e.stopPropagation(); // To prevent DecisionsRightPannel from closing
+                    }}
+                  />
+                );
+              })}
             </Table.Body>
           </Table.Container>
         </Page.Content>

--- a/apps/builder/public/locales/en/decisions.json
+++ b/apps/builder/public/locales/en/decisions.json
@@ -1,6 +1,8 @@
 {
   "scenario.name": "Scenario",
+  "search.placeholder": "Search by id",
   "detail.scenario_name_runs_on": "<ScenarioName>{{scenarioName}}</ScenarioName> (runs on <TriggerObjectType>{{triggerObjectType}}</TriggerObjectType>)",
+  "detail.error": "An error as occured. Make sure the provided decision id is valid.",
   "trigger_object.type": "Trigger object",
   "score": "Score",
   "outcome": "Outcome",

--- a/apps/builder/public/locales/fr/decisions.json
+++ b/apps/builder/public/locales/fr/decisions.json
@@ -1,5 +1,6 @@
 {
   "created_at": "Créé à",
+  "search.placeholder": "Rechercher par id",
   "outcome": "Résultat",
   "scenario.name": "Scénario",
   "detail.scenario_name_runs_on": "<ScenarioName>{{scenarioName}}</ScenarioName> (correspond à <TriggerObjectType>{{triggerObjectType}}</TriggerObjectType>)",
@@ -9,5 +10,6 @@
   "outcome.review": "A revoir",
   "outcome.decline": "Refuser",
   "outcome.null": "Null",
-  "outcome.unknown": "Inconnu"
+  "outcome.unknown": "Inconnu",
+  "detail.error": "Une erreur s'est produite. Assurez-vous que l'ID de décision fourni est valide"
 }


### PR DESCRIPTION
With working `decisionId`:

<img width="1582" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/5814e3cb-7e17-486f-867a-8b6e76174b1b">

With error on `getDecision`:

<img width="1582" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/7eed302c-3bc4-45c1-96da-51f03f4a3e54">

NB: some behaviours :
- selecting a row in the decision array autofill the input with the corresponding `decisionId`
- closing the detail remove the `decisionId` (and clear the input)