### PR TITLE
chore(lint): rm warnings to reduce noise in github

### DIFF
--- a/apps/builder/app/routes/auth/$provider.callback.tsx
+++ b/apps/builder/app/routes/auth/$provider.callback.tsx
@@ -1,4 +1,3 @@
-import { setLanguage } from '@marble-front/builder/config/i18n/i18next.server';
 import { authenticator } from '@marble-front/builder/services/auth/auth.server';
 import {
   commitSession,

--- a/apps/builder/app/routes/ressources/user/language.tsx
+++ b/apps/builder/app/routes/ressources/user/language.tsx
@@ -1,6 +1,5 @@
 import { supportedLngs } from '@marble-front/builder/config/i18n/i18n-config';
 import { setLanguage } from '@marble-front/builder/config/i18n/i18next.server';
-import { authenticator } from '@marble-front/builder/services/auth/auth.server';
 import {
   commitSession,
   getSession,
@@ -24,7 +23,7 @@ export async function action({ request }: ActionArgs) {
   try {
     const { preferredLanguage } = await parseForm(request, formSchema);
 
-    const user = await authenticator.isAuthenticated(request);
+    // const user = await authenticator.isAuthenticated(request);
     // if (user)
     //   await usersApi.putUsersUserId({
     //     userId: user.id,

--- a/libs/ui/design-system/jest-setup.ts
+++ b/libs/ui/design-system/jest-setup.ts
@@ -13,7 +13,8 @@ class MockPointerEvent extends Event {
   }
 }
 
-window.PointerEvent = MockPointerEvent as any;
+//@ts-expect-error Mock is missing some properties but the current implementation cover our needs
+window.PointerEvent = MockPointerEvent;
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 window.HTMLElement.prototype.releasePointerCapture = jest.fn();
 window.HTMLElement.prototype.hasPointerCapture = jest.fn();


### PR DESCRIPTION
Address the lint warnings displayed by Github (after CI run, Github grab warnings from the lint task and display them at the end of the changes).

![image](https://github.com/checkmarble/marble-frontend/assets/40292402/182a1b24-c95d-432e-8aff-5898d0928576)

NB: I could configure the CI to cap the number of warnings (ex: max 10 or 0 warnings) but I think we shouldn't use the 0 warnings policy (there are a good reasons to distinguish warnings from errors). Still, we can think about allowing a max number of warnings. Experience proves when the number is too hight, no one pay attention to them anymore.