### PR TITLE
fix(auth): remove firebase/admin

### DIFF
--- a/apps/builder/app/routes/ressources/auth/logout.tsx
+++ b/apps/builder/app/routes/ressources/auth/logout.tsx
@@ -1,8 +1,8 @@
 import { authenticator } from '@marble-front/builder/services/auth/auth.server';
-import { type ActionArgs, redirect } from '@remix-run/node';
+import { type ActionArgs, type LoaderArgs } from '@remix-run/node';
 
-export async function loader() {
-  return redirect('/login');
+export async function loader({ request }: LoaderArgs) {
+  await authenticator.logout(request, { redirectTo: '/login' });
 }
 
 export async function action({ request }: ActionArgs) {

--- a/apps/builder/app/services/auth/auth.server.ts
+++ b/apps/builder/app/services/auth/auth.server.ts
@@ -1,5 +1,5 @@
 import { getServerAuth } from './firebase.server';
-import { sessionStorage, userSessionMaxAge } from './session.server';
+import { sessionStorage } from './session.server';
 
 const authErrors = ['NoAccount', 'Unknown'] as const;
 export type AuthErrors = (typeof authErrors)[number];
@@ -20,6 +20,5 @@ export type User = {
 };
 
 export const authenticator = getServerAuth({
-  maxAge: userSessionMaxAge,
   sessionStorage,
 });

--- a/apps/builder/app/services/auth/session.server.ts
+++ b/apps/builder/app/services/auth/session.server.ts
@@ -1,10 +1,8 @@
 import { getServerEnv } from '@marble-front/builder/utils/environment.server';
 import { createCookie, createCookieSessionStorage } from '@remix-run/node';
 
-export const userSessionMaxAge = Number(getServerEnv('SESSION_MAX_AGE'));
-
 const sessionCookie = createCookie('user_session', {
-  maxAge: userSessionMaxAge,
+  maxAge: getServerEnv('SESSION_MAX_AGE'),
   sameSite: 'lax', // this helps with CSRF
   path: '/', // remember to add this so the cookie will work in all routes
   httpOnly: true,

--- a/apps/builder/app/services/routes/routes.ts
+++ b/apps/builder/app/services/routes/routes.ts
@@ -20,19 +20,14 @@ export const routes = [
         file: "routes/ressources/user/language.tsx",
       },
       {
-        id: "routes/auth/$provider.callback",
-        path: "auth/:provider/callback",
-        file: "routes/auth/$provider.callback.tsx",
+        id: "routes/ressources/auth/logout",
+        path: "ressources/auth/logout",
+        file: "routes/ressources/auth/logout.tsx",
       },
       {
-        id: "routes/auth/$provider",
-        path: "auth/:provider",
-        file: "routes/auth/$provider.tsx",
-      },
-      {
-        id: "routes/auth/logout",
-        path: "auth/logout",
-        file: "routes/auth/logout.tsx",
+        id: "routes/ressources/auth/login",
+        path: "ressources/auth/login",
+        file: "routes/ressources/auth/login.tsx",
       },
       {
         id: "routes/healthcheck",


### PR DESCRIPTION
The goal is to :
- remove the firebase/admin sdk (need permissions to work and I do not have the rights)
- extends the lifetime of marble token
- logout on 401 or when token expires