### PR TITLE
feat(operators): add new model for operators

### DIFF
--- a/libs/operators/src/lib/index.ts
+++ b/libs/operators/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './constant-operator';
 export * from './data-field-operator';
 export * from './math-operator';
+export * from './models';

--- a/libs/operators/src/lib/models/index.ts
+++ b/libs/operators/src/lib/models/index.ts
@@ -1,0 +1,1 @@
+export * from './nodes';

--- a/libs/operators/src/lib/models/nodes/and.ts
+++ b/libs/operators/src/lib/models/nodes/and.ts
@@ -1,0 +1,14 @@
+import { type OperatorNode } from '..';
+import { type OperatorDeclaration } from './types';
+
+export interface AndNode {
+  operatorName: 'AND';
+  children: OperatorNode[];
+}
+
+export const andDeclaration = {
+  returnType: 'boolean',
+  minOperands: 2,
+  maxOperands: Infinity,
+  operandsType: 'boolean',
+} satisfies OperatorDeclaration<AndNode>;

--- a/libs/operators/src/lib/models/nodes/constants.ts
+++ b/libs/operators/src/lib/models/nodes/constants.ts
@@ -1,0 +1,64 @@
+import { type OperatorNode } from '.';
+import { type OperatorDeclaration, type OperatorDeclarationMap } from './types';
+
+export interface BoolConstantNode {
+  operatorName: 'BOOL_CONSTANT';
+  constant: boolean;
+}
+
+export const boolConstantDeclaration = {
+  returnType: 'boolean',
+} satisfies OperatorDeclaration<BoolConstantNode>;
+
+export interface FloatConstantNode {
+  operatorName: 'FLOAT_CONSTANT';
+  constant: number;
+}
+
+export const floatConstantDeclaration = {
+  returnType: 'float',
+} satisfies OperatorDeclaration<FloatConstantNode>;
+
+export interface StringConstantNode {
+  operatorName: 'STRING_CONSTANT';
+  constant: string;
+}
+
+export const stringConstantDeclaration = {
+  returnType: 'string',
+} satisfies OperatorDeclaration<StringConstantNode>;
+
+export interface StringListConstantNode {
+  operatorName: 'STRING_LIST_CONSTANT';
+  constant: string[];
+}
+
+export const stringListConstantDeclaration = {
+  returnType: { type: 'array', items: 'string' },
+} satisfies OperatorDeclaration<StringConstantNode>;
+
+export type ConstantNodeMap = {
+  STRING_CONSTANT: StringConstantNode;
+  BOOL_CONSTANT: BoolConstantNode;
+  FLOAT_CONSTANT: FloatConstantNode;
+  STRING_LIST_CONSTANT: StringListConstantNode;
+};
+
+export type ConstantNodeName = keyof ConstantNodeMap;
+export type ConstantNode = ConstantNodeMap[ConstantNodeName];
+
+export function isConstantNode(node: OperatorNode): node is ConstantNode {
+  return (
+    node.operatorName === 'BOOL_CONSTANT' ||
+    node.operatorName === 'FLOAT_CONSTANT' ||
+    node.operatorName === 'STRING_CONSTANT' ||
+    node.operatorName === 'STRING_LIST_CONSTANT'
+  );
+}
+
+export const constantDeclarationsMap = {
+  STRING_CONSTANT: stringConstantDeclaration,
+  BOOL_CONSTANT: boolConstantDeclaration,
+  FLOAT_CONSTANT: floatConstantDeclaration,
+  STRING_LIST_CONSTANT: stringListConstantDeclaration,
+} satisfies OperatorDeclarationMap<ConstantNodeMap>;

--- a/libs/operators/src/lib/models/nodes/data-field.ts
+++ b/libs/operators/src/lib/models/nodes/data-field.ts
@@ -1,0 +1,107 @@
+import { type OperatorNode } from '.';
+import {
+  type StringConstantNode,
+  type StringListConstantNode,
+} from './constants';
+import {
+  type ArgType,
+  type OperatorDeclaration,
+  type OperatorDeclarationMap,
+} from './types';
+
+type DataFieldType = 'BOOL' | 'FLOAT' | 'STRING';
+
+export interface DbFieldNode<T extends DataFieldType> {
+  operatorName: `DB_FIELD_${T}`;
+  namedChildren: {
+    triggerTableName: StringConstantNode;
+    path: StringListConstantNode;
+    fieldName: StringConstantNode;
+  };
+}
+
+export function getDbFieldDeclaration({ returnType }: { returnType: ArgType }) {
+  return {
+    returnType,
+    namedArgs: {
+      triggerTableName: 'string',
+      path: { type: 'array', items: 'string' },
+      fieldName: 'string',
+    },
+  } satisfies OperatorDeclaration<DbFieldNode<'BOOL'>>;
+}
+
+export type AnyDbFieldNodeMap = {
+  DB_FIELD_BOOL: DbFieldNode<'BOOL'>;
+  DB_FIELD_FLOAT: DbFieldNode<'FLOAT'>;
+  DB_FIELD_STRING: DbFieldNode<'STRING'>;
+};
+
+export type AnyDbFieldNodeName = keyof AnyDbFieldNodeMap;
+export type AnyDbFieldNode = AnyDbFieldNodeMap[AnyDbFieldNodeName];
+
+export function isDbFieldNode(node: OperatorNode): node is AnyDbFieldNode {
+  return node.operatorName.startsWith('DB_FIELD_');
+}
+
+export const anyDbFieldDeclarationsMap = {
+  DB_FIELD_BOOL: getDbFieldDeclaration({ returnType: 'boolean' }),
+  DB_FIELD_FLOAT: getDbFieldDeclaration({ returnType: 'float' }),
+  DB_FIELD_STRING: getDbFieldDeclaration({ returnType: 'string' }),
+} satisfies OperatorDeclarationMap<AnyDbFieldNodeMap>;
+
+export interface PayloadFieldNode<T extends DataFieldType> {
+  operatorName: `PAYLOAD_FIELD_${T}`;
+  namedChildren: {
+    fieldName: StringConstantNode;
+  };
+}
+
+export function getPayloadFieldDeclaration({
+  returnType,
+}: {
+  returnType: ArgType;
+}) {
+  return {
+    returnType,
+    namedArgs: {
+      fieldName: 'string',
+    },
+  } satisfies OperatorDeclaration<PayloadFieldNode<'BOOL'>>;
+}
+
+export type AnyPayloadFieldNodeMap = {
+  PAYLOAD_FIELD_BOOL: PayloadFieldNode<'BOOL'>;
+  PAYLOAD_FIELD_FLOAT: PayloadFieldNode<'FLOAT'>;
+  PAYLOAD_FIELD_STRING: PayloadFieldNode<'STRING'>;
+};
+
+export type AnyPayloadFieldNodeName = keyof AnyPayloadFieldNodeMap;
+export type AnyPayloadFieldNode =
+  AnyPayloadFieldNodeMap[AnyPayloadFieldNodeName];
+
+export function isPayloadFieldNode(
+  node: OperatorNode
+): node is AnyPayloadFieldNode {
+  return node.operatorName.startsWith('PAYLOAD_FIELD_');
+}
+
+export const anyPayloadFieldDeclarationsMap = {
+  PAYLOAD_FIELD_BOOL: getPayloadFieldDeclaration({ returnType: 'boolean' }),
+  PAYLOAD_FIELD_FLOAT: getPayloadFieldDeclaration({ returnType: 'float' }),
+  PAYLOAD_FIELD_STRING: getPayloadFieldDeclaration({ returnType: 'string' }),
+} satisfies OperatorDeclarationMap<AnyPayloadFieldNodeMap>;
+
+export type DataFieldNodeMap = AnyDbFieldNodeMap & AnyPayloadFieldNodeMap;
+
+export type DataFieldNodeName = keyof DataFieldNodeMap;
+export type DataFieldNode = DataFieldNodeMap[DataFieldNodeName];
+
+export function isDataFieldNode(node: OperatorNode): node is DataFieldNode {
+  return isDbFieldNode(node) || isPayloadFieldNode(node);
+}
+
+export const dataFieldDeclarationsMap = {
+  ...anyPayloadFieldDeclarationsMap,
+  ...anyDbFieldDeclarationsMap,
+} satisfies OperatorDeclarationMap<DataFieldNodeMap>;

--- a/libs/operators/src/lib/models/nodes/greater.ts
+++ b/libs/operators/src/lib/models/nodes/greater.ts
@@ -1,0 +1,14 @@
+import { type OperatorNode } from '.';
+import { type OperatorDeclaration } from './types';
+
+export interface GreaterNode {
+  operatorName: 'GREATER';
+  children: [OperatorNode, OperatorNode];
+}
+
+export const greaterDeclaration = {
+  returnType: 'boolean',
+  minOperands: 2,
+  maxOperands: 2,
+  operandsType: 'number',
+} satisfies OperatorDeclaration<GreaterNode>;

--- a/libs/operators/src/lib/models/nodes/index.ts
+++ b/libs/operators/src/lib/models/nodes/index.ts
@@ -1,0 +1,43 @@
+import {
+  constantDeclarationsMap,
+  type ConstantNode,
+  type ConstantNodeMap,
+  isConstantNode,
+} from './constants';
+import {
+  dataFieldDeclarationsMap,
+  type DataFieldNode,
+  type DataFieldNodeMap,
+  isDataFieldNode,
+  isDbFieldNode,
+} from './data-field';
+import {
+  isMathOperatorNode,
+  mathOperatorDeclarationsMap,
+  type MathOperatorNode,
+  type MathOperatorNodeMap,
+  type MathOperatorNodeName,
+} from './math-operator';
+import { type OperatorDeclarationMap } from './types';
+
+export {
+  type ConstantNode,
+  type DataFieldNode,
+  isConstantNode,
+  isDataFieldNode,
+  isDbFieldNode,
+  isMathOperatorNode,
+  type MathOperatorNode,
+  type MathOperatorNodeName,
+};
+
+type OperatorNodeMap = MathOperatorNodeMap & ConstantNodeMap & DataFieldNodeMap;
+
+export type OperatorNodeName = keyof OperatorNodeMap;
+export type OperatorNode = OperatorNodeMap[OperatorNodeName];
+
+export const operatorDeclarationsMap = {
+  ...mathOperatorDeclarationsMap,
+  ...constantDeclarationsMap,
+  ...dataFieldDeclarationsMap,
+} satisfies OperatorDeclarationMap<OperatorNodeMap>;

--- a/libs/operators/src/lib/models/nodes/is-in-list.ts
+++ b/libs/operators/src/lib/models/nodes/is-in-list.ts
@@ -1,0 +1,27 @@
+import {
+  type StringConstantNode,
+  type StringListConstantNode,
+} from './constants';
+import { type OperatorDeclaration, type PrimitiveArgType } from './types';
+
+export interface IsInListNode<T extends 'STRING'> {
+  operatorName: `${T}_IS_IN_LIST`;
+  namedChildren: {
+    value: T extends 'STRING' ? StringConstantNode : never;
+    list: T extends 'STRING' ? StringListConstantNode : never;
+  };
+}
+
+export function getIsInListDeclaration({
+  valueType,
+}: {
+  valueType: PrimitiveArgType;
+}) {
+  return {
+    returnType: 'boolean',
+    namedArgs: {
+      value: valueType,
+      list: { type: 'array', items: valueType },
+    },
+  } satisfies OperatorDeclaration<IsInListNode<'STRING'>>;
+}

--- a/libs/operators/src/lib/models/nodes/math-operator.ts
+++ b/libs/operators/src/lib/models/nodes/math-operator.ts
@@ -1,0 +1,34 @@
+import { type OperatorNode } from '.';
+import { andDeclaration, type AndNode } from './and';
+import { greaterDeclaration, type GreaterNode } from './greater';
+import { getIsInListDeclaration, type IsInListNode } from './is-in-list';
+import { orDeclaration, type OrNode } from './or';
+import { type OperatorDeclarationMap } from './types';
+
+export type MathOperatorNodeMap = {
+  AND: AndNode;
+  OR: OrNode;
+  GREATER: GreaterNode;
+  STRING_IS_IN_LIST: IsInListNode<'STRING'>;
+};
+
+export type MathOperatorNodeName = keyof MathOperatorNodeMap;
+export type MathOperatorNode = MathOperatorNodeMap[MathOperatorNodeName];
+
+export function isMathOperatorNode(
+  operator: OperatorNode
+): operator is MathOperatorNode {
+  return (
+    operator.operatorName === 'AND' ||
+    operator.operatorName === 'OR' ||
+    operator.operatorName === 'GREATER' ||
+    operator.operatorName === 'STRING_IS_IN_LIST'
+  );
+}
+
+export const mathOperatorDeclarationsMap = {
+  AND: andDeclaration,
+  OR: orDeclaration,
+  GREATER: greaterDeclaration,
+  STRING_IS_IN_LIST: getIsInListDeclaration({ valueType: 'string' }),
+} satisfies OperatorDeclarationMap<MathOperatorNodeMap>;

--- a/libs/operators/src/lib/models/nodes/or.ts
+++ b/libs/operators/src/lib/models/nodes/or.ts
@@ -1,0 +1,14 @@
+import { type OperatorNode } from '.';
+import { type OperatorDeclaration } from './types';
+
+export interface OrNode {
+  operatorName: 'OR';
+  children: OperatorNode[];
+}
+
+export const orDeclaration = {
+  returnType: 'boolean',
+  minOperands: 2,
+  maxOperands: Infinity,
+  operandsType: 'boolean',
+} satisfies OperatorDeclaration<OrNode>;

--- a/libs/operators/src/lib/models/nodes/types.ts
+++ b/libs/operators/src/lib/models/nodes/types.ts
@@ -1,0 +1,81 @@
+// Subset of JS built-in types we support
+type PrimitiveType = string | boolean | number;
+
+// Subset of built-in types we support
+export type PrimitiveArgType =
+  | 'float'
+  | 'int'
+  | 'string'
+  | 'boolean'
+  | 'number';
+export type ArgType =
+  | PrimitiveArgType
+  | { type: 'array'; items: PrimitiveArgType };
+
+export interface OperatorWithChildren {
+  operatorName: string;
+  children: OperatorSkeleton[];
+}
+interface OperatorWithNamedChildren {
+  operatorName: string;
+  namedChildren: Record<string, OperatorSkeleton>;
+}
+interface OperatorWithChildrenAndNamedChildren {
+  operatorName: string;
+  children: OperatorSkeleton[];
+  namedChildren: Record<string, OperatorSkeleton>;
+}
+type OperatorConstant = {
+  operatorName: string;
+  constant: PrimitiveType | PrimitiveType[];
+};
+
+export type OperatorSkeleton =
+  | OperatorWithChildren
+  | OperatorWithNamedChildren
+  | OperatorWithChildrenAndNamedChildren
+  | OperatorConstant;
+
+interface OperatorWithChildrenDeclaration {
+  returnType: ArgType;
+  minOperands: number;
+  maxOperands: number;
+  operandsType: ArgType;
+}
+interface OperatorWithNamedChildrenDeclaration<
+  Operator extends OperatorWithNamedChildren
+> {
+  returnType: ArgType;
+  namedArgs: Record<keyof Operator['namedChildren'], ArgType>;
+}
+interface OperatorWithChildrenAndNamedChildrenDeclaration<
+  Operator extends OperatorWithChildrenAndNamedChildren
+> {
+  returnType: ArgType;
+  minOperands: number;
+  maxOperands: number;
+  operandsType: ArgType;
+  namedArgs: Record<keyof Operator['namedChildren'], ArgType>;
+}
+interface OperatorConstantDeclaration {
+  returnType: ArgType;
+}
+
+// If you want to use this type, you need to use the `satisfies` keyword.
+// If a never branch occure, check the provided Operator match OperatorSkeleton.
+export type OperatorDeclaration<Operator extends OperatorSkeleton> =
+  Operator extends OperatorWithChildrenAndNamedChildren
+    ? OperatorWithChildrenAndNamedChildrenDeclaration<Operator>
+    : Operator extends OperatorWithChildren
+    ? OperatorWithChildrenDeclaration
+    : Operator extends OperatorWithNamedChildren
+    ? OperatorWithNamedChildrenDeclaration<Operator>
+    : Operator extends OperatorConstant
+    ? OperatorConstantDeclaration
+    : never;
+
+export type OperatorDeclarationMap<
+  OperatorNodeMap extends Record<string, OperatorSkeleton>
+> = {
+  [Name in keyof OperatorNodeMap]: OperatorDeclaration<OperatorNodeMap[Name]>;
+};


### PR DESCRIPTION
> Initial work will be split in "small" iterations

This PR introduce the new operator model. It lives inside an existing operator lib of the monorepo, side by side with what can be considered "legacy" code (should be replaced totally by the new model, to prevent maintaining view + builder models separately)