### PR TITLE
fix(storybook): fix storybook tsconfig alias path

### DIFF
--- a/libs/ui/design-system/.storybook/main.ts
+++ b/libs/ui/design-system/.storybook/main.ts
@@ -18,13 +18,7 @@ const config: StorybookConfig = {
   },
   async viteFinal(config) {
     return mergeConfig(config, {
-      // For now, this seems bugged with Storybook (so we need to specify manually resolve.alias)
       plugins: [viteTsConfigPaths()],
-      resolve: {
-        alias: {
-          '@marble-front/ui/icons': 'libs/ui/icons/src/index.ts',
-        },
-      },
     });
   },
 };

--- a/libs/ui/design-system/tsconfig.lib.json
+++ b/libs/ui/design-system/tsconfig.lib.json
@@ -17,11 +17,7 @@
     "**/*.spec.js",
     "**/*.test.js",
     "**/*.spec.jsx",
-    "**/*.test.jsx",
-    "**/*.stories.ts",
-    "**/*.stories.js",
-    "**/*.stories.jsx",
-    "**/*.stories.tsx"
+    "**/*.test.jsx"
   ],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
During the migration from webpack to vite, I faced some issues in the alias path resolution. The workaround was to explicitly redeclare the path alias.

I subscribed to [this issue](https://github.com/nrwl/nx/issues/17156#issuecomment-1603958601) that finally explained how to solve this today.