### PR TITLE
docs(readme): update readme with vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,6 @@
 {
   "recommendations": [
-    "nrwl.angular-console",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "firsttris.vscode-jest-runner"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ pnpm install-completion
 pnpm install
 ```
 
+#### (VSCode) Install recommended VSCode extensions
+
+There is a recommended extensions list in the `.vscode/extensions.json` file.
+
+You can read README pages in the extension marketplace for each extensions.
+**TL;DR: you should add those settings to your (global/workspace) VSCode settings:**
+
+```json
+"editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+
+"editor.formatOnSave": true,
+"editor.defaultFormatter": "esbenp.prettier-vscode",
+```
+
 ### Work in a package
 
 Each packages are located in the `packages` folder. To work in a package, you can use the `--filter` option of `pnpm` to trigger the dedicated scripts present in each `packages/*/package.json`. Exemple to start the app builder in dev mode:


### PR DESCRIPTION
Update the project to help people using VS Code setup recommended extensions.

It should prevent friction due to Prettier/ESLint issues :

> Corresponds to `pnpm run format:check` & `pnpm run -r lint` in the CI

Note: next iteration on this will be to configure lint staged and hook git to run those checks before pushing to origin (fail fast + prevent useless CI run)