### PR TITLE
fix(select): add border color on trigger focus

### DIFF
--- a/packages/ui-design-system/src/Select/Select.tsx
+++ b/packages/ui-design-system/src/Select/Select.tsx
@@ -73,7 +73,7 @@ const SelectTrigger = forwardRef<HTMLButtonElement, SelectTriggerProps>(
         ref={ref}
         className={clsx(
           'bg-grey-00 border-grey-10 text-s text-grey-100 group flex h-10 items-center justify-between border font-medium outline-none',
-          'radix-state-open:border-purple-100 radix-state-open:text-purple-100',
+          'radix-state-open:border-purple-100 radix-state-open:text-purple-100 focus:border-purple-100',
           'radix-disabled:border-grey-10 radix-disabled:bg-grey-05 radix-disabled:text-grey-50',
           {
             'rounded px-2': border === 'square',


### PR DESCRIPTION
Small improvement to be coherent with classic input focus (help to know which form field is focussed using TAB in form completion)

Before :
![test2](https://github.com/checkmarble/marble-frontend/assets/40292402/e99a7d2e-ff7c-49e3-a998-b67135382708)

After:
![test](https://github.com/checkmarble/marble-frontend/assets/40292402/d178cb1a-678d-4999-82ae-75fd490400bf)
