### PR TITLE
Improve recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "lokalise.i18n-ally"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,20 @@
   "i18n-ally.localesPaths": ["packages/app-builder/public/locales"],
   "i18n-ally.keystyle": "flat",
   "i18n-ally.enabledFrameworks": ["react", "i18next"],
-  "i18n-ally.namespace": true
+  "i18n-ally.namespace": true,
+
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
+  "editor.quickSuggestions": {
+    "strings": "on"
+  },
+  "tailwindCSS.classAttributes": ["class", "className", "ngClass", "style"]
 }

--- a/README.md
+++ b/README.md
@@ -30,25 +30,7 @@ pnpm install
 
 There is a recommended extensions list in the `.vscode/extensions.json` file.
 
-You can read README pages in the extension marketplace for each extensions.
-**TL;DR: you should add those settings to your (global/workspace) VSCode settings:**
-
-```json
-"editor.codeActionsOnSave": {
-  "source.fixAll": true
-},
-
-"editor.formatOnSave": true,
-"editor.defaultFormatter": "esbenp.prettier-vscode",
-
-"files.associations": {
-  "*.css": "tailwindcss",
-},
-"editor.quickSuggestions": {
-  "strings": "on"
-},
-"tailwindCSS.classAttributes": ["class", "className", "ngClass", "style"],
-```
+All required configuration settings are already included inside the `.vscode/settings.json` file.
 
 ### Work in a package
 


### PR DESCRIPTION
Add usefull extension. It will improve the DX for people writing CSS (I already make use of it and forgot to list the extension in the recommended ones)

**open question**: In order to ease new onboarding + harmonise workspace settings, I commit the recommended extension settings.

Pros:
- ease onboarding
- harmonise each dev setup
- prevent some noise in git diff resulting of file missing format + auto fix on save

Caveat:
- can override some specific user settings for some people (only in the marble frontend workspace)