### PR TITLE
refactor(dom-events-sync): useSyncExternalStore hook

### DIFF
--- a/packages/app-builder/src/utils/hooks/use-visibility-change.ts
+++ b/packages/app-builder/src/utils/hooks/use-visibility-change.ts
@@ -1,18 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
+
+function subscribe(
+  listener: (this: Document, ev: DocumentEventMap['visibilitychange']) => void
+) {
+  document.addEventListener('visibilitychange', listener);
+  return () => {
+    document.removeEventListener('visibilitychange', listener);
+  };
+}
 
 export function useVisibilityChange() {
-  const [visibilityState, setVisibilityState] =
-    useState<DocumentVisibilityState>('visible');
-
-  useEffect(() => {
-    function listener() {
-      setVisibilityState(document.visibilityState);
-    }
-    document.addEventListener('visibilitychange', listener);
-    return () => {
-      document.removeEventListener('visibilitychange', listener);
-    };
-  }, []);
-
-  return visibilityState;
+  return useSyncExternalStore<DocumentVisibilityState>(
+    subscribe,
+    () => document.visibilityState,
+    () => 'visible'
+  );
 }


### PR DESCRIPTION
Small refactoring, in order to use new `useSyncExternalStore` (source, the official documentation [here](https://react.dev/learn/you-might-not-need-an-effect#subscribing-to-an-external-store))