### PR TITLE
feat(toaster): add close button to toast messages

### DIFF
--- a/packages/app-builder/src/components/MarbleToaster.tsx
+++ b/packages/app-builder/src/components/MarbleToaster.tsx
@@ -43,14 +43,17 @@ export function MarbleToaster({
 
   return (
     <Toaster position="bottom-center">
-      {(t) => (
-        <ToastBar toast={t}>
+      {(currentToast) => (
+        <ToastBar toast={currentToast}>
           {({ icon, message }) => (
             <>
               {icon}
               {message}
-              {t.type !== 'loading' && (
-                <button onClick={() => toast.dismiss(t.id)} aria-label="Close">
+              {currentToast.type !== 'loading' && (
+                <button
+                  onClick={() => toast.dismiss(currentToast.id)}
+                  aria-label="Close"
+                >
                   <Cross height="24px" width="24px" />
                 </button>
               )}


### PR DESCRIPTION
The goal is to make certain toast closable.

Typical caveat it will solve : stack of toasts, can't access the save button
<img width="2416" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/fc6ec404-76d5-40e6-891b-ba41ca6333dd">
