### PR TITLE
feat: openapi add argument_index and argument_name to EvaluationErrorDto

### DIFF
--- a/packages/app-builder/src/models/scenario-validation.ts
+++ b/packages/app-builder/src/models/scenario-validation.ts
@@ -23,6 +23,8 @@ export type EvaluationErrorCode =
 export interface EvaluationError {
   error: EvaluationErrorCode;
   message: string;
+  argumentIndex?: number;
+  argumentName?: string;
 }
 
 export function isUndefinedFunctionError(evaluationError: {
@@ -66,6 +68,8 @@ function adaptEvaluationError(dto: EvaluationErrorDto): EvaluationError {
   return {
     error: dto.error,
     message: dto.message,
+    argumentIndex: dto.argument_index,
+    argumentName: dto.argument_name,
   };
 }
 

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -2106,6 +2106,10 @@ components:
           $ref: '#/components/schemas/EvaluationErrorCodeDto'
         message:
           type: string
+        argument_index:
+          type: integer
+        argument_name:
+          type: string
     EvaluationErrorCodeDto:
       type: string
       enum:

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -171,6 +171,8 @@ export type EvaluationErrorCodeDto = "UNEXPECTED_ERROR" | "UNDEFINED_FUNCTION" |
 export type EvaluationErrorDto = {
     error: EvaluationErrorCodeDto;
     message: string;
+    argument_index?: number;
+    argument_name?: string;
 };
 export type NodeEvaluationDto = {
     return_value: ConstantDto;


### PR DESCRIPTION
Evaluation error now have optional `argumentIndex` and `argumentError`

Match this [PR in the backend](https://github.com/checkmarble/marble-backend/pull/214)

```
export interface EvaluationError {
  error: EvaluationErrorCode;
  message: string;
  argumentIndex?: number;
  argumentName?: string;
}
```
