### PR TITLE
feat: openapi add endpoint POST /scenario-iteration/{}/validate that …

### DIFF
--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -708,7 +708,57 @@ paths:
             format: uuid
       responses:
         '200':
-          description: The scenario iteration corresponding to the provided `scenarioIterationId`
+          description: The scenario validation of the iteration
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - scenario_validation
+                properties:
+                  scenario_validation:
+                    $ref: '#/components/schemas/ScenarioValidationDto'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+    post:
+      tags:
+        - Scenario Iterations
+      summary: Validate a scenario iteration using the rule or trigger passed in body
+      operationId: validateScenarioIterationWithGivenTriggerOrRule
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: scenarioIterationId
+          description: ID of the scenario iteration
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: 'Trigger or rule to validate'
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - trigger_or_rule
+                - rule_id
+              properties:
+                trigger_or_rule:
+                  $ref: '#/components/schemas/NodeDto'
+                rule_id:
+                  type: string
+                  nullable: true
+                  format: uuid
+        required: true
+      responses:
+        '200':
+          description: The scenario validation of the iteration using the rule or tigger passed in the body
           content:
             application/json:
               schema:

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -758,6 +758,33 @@ export function validateScenarioIteration(scenarioIterationId: string, opts?: Oa
     }));
 }
 /**
+ * Validate a scenario iteration using the rule or trigger passed in body
+ */
+export function validateScenarioIterationWithGivenTriggerOrRule(scenarioIterationId: string, body: {
+    trigger_or_rule: NodeDto;
+    rule_id: string | null;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: {
+            scenario_validation: ScenarioValidationDto;
+        };
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    }>(`/scenario-iterations/${encodeURIComponent(scenarioIterationId)}/validate`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body
+    })));
+}
+/**
  * List rules
  */
 export function listScenarioIterationRules({ scenarioIterationId }: {


### PR DESCRIPTION
`POST /scenario-iteration/{}/validate` validates a scenario without saving it

The rule or trigger to used during the validation is passed in the body.

Related backend request: https://github.com/checkmarble/marble-backend/pull/217