### PR TITLE
Operand editor: stringify ast in builder

### DIFF
--- a/packages/app-builder/src/components/AstBuilder/TwoOperandsLine/OperandEditor.tsx
+++ b/packages/app-builder/src/components/AstBuilder/TwoOperandsLine/OperandEditor.tsx
@@ -1,11 +1,7 @@
 import {
-  adaptAggregationViewModel,
-  AggregationEditModal,
-} from '@app-builder/components/Edit';
-import { stringifyConstant } from '@app-builder/components/Scenario/Formula/Operators';
-import {
   adaptLabelledAstFromIdentifier,
   type AstNode,
+  getAstNodeDisplayName,
   isAggregation,
   type LabelledAst,
   NewAstNode,
@@ -20,6 +16,10 @@ import {
 import { Combobox } from '@ui-design-system';
 import { useCallback, useState } from 'react';
 
+import {
+  adaptAggregationViewModel,
+  AggregationEditModal,
+} from '../AggregationEdit';
 import { ErrorMessage } from '../ErrorMessage';
 import { getBorderColor } from '../utils';
 
@@ -43,7 +43,7 @@ export function OperandEditor({
   const [editViewModel, setEditViewModel] = useState<EditOperandViewModel>(
     () => {
       const initialOption: LabelledAst = {
-        label: adaptOperandLabel(
+        label: getAstNodeDisplayName(
           adaptAstNodeFromEditorViewModel(operandViewModel)
         ),
         tooltip: '(initial value)',
@@ -206,19 +206,4 @@ function coerceToConstantsLabelledAst(search: string): LabelledAst[] {
   });
 
   return results;
-}
-
-function shortAstDescription(node: AstNode): string {
-  return node.name === null
-    ? `constant: ${stringifyConstant(node.constant)}`
-    : `func: ${node.name}`;
-}
-
-function adaptOperandLabel(node: AstNode) {
-  // TODO: merge with getAstNodeDisplayName()
-  return node.name === null
-    ? stringifyConstant(node.constant)
-    : node.name === 'Payload'
-    ? `Payload ${stringifyConstant(node.children[0].constant)}`
-    : shortAstDescription(node);
 }

--- a/packages/app-builder/src/models/ast-node.ts
+++ b/packages/app-builder/src/models/ast-node.ts
@@ -119,12 +119,23 @@ export interface AggregationAstNode {
   };
 }
 
+export interface PayloadAstNode {
+  name: 'Payload';
+  constant: undefined;
+  children: [ConstantAstNode<string>];
+  namedChildren: Record<string, never>;
+}
+
 export function isDatabaseAccess(node: AstNode): node is DatabaseAccessAstNode {
   return node.name === 'DatabaseAccess';
 }
 
 export function isAggregation(node: AstNode): node is AggregationAstNode {
   return node.name === 'Aggregator';
+}
+
+export function isPayload(node: AstNode): node is PayloadAstNode {
+  return node.name === 'Payload';
 }
 
 export interface OrAndGroupAstNode {

--- a/packages/app-builder/src/models/ast-view-model.ts
+++ b/packages/app-builder/src/models/ast-view-model.ts
@@ -5,6 +5,7 @@ import {
   isAstNodeUnknown,
   isConstant,
   isDatabaseAccess,
+  isPayload,
 } from './ast-node';
 import {
   type EditorIdentifier,
@@ -82,7 +83,7 @@ function getConstantDisplayName(constant: ConstantType) {
   return constant.toString();
 }
 
-function getAstNodeDisplayName(astNode: AstNode) {
+export function getAstNodeDisplayName(astNode: AstNode): string {
   if (isConstant(astNode)) {
     return getConstantDisplayName(astNode.constant);
   }
@@ -90,6 +91,11 @@ function getAstNodeDisplayName(astNode: AstNode) {
   if (isDatabaseAccess(astNode)) {
     const { path, fieldName } = astNode.namedChildren;
     return [...path.constant, fieldName.constant].join('.');
+  }
+
+  if (isPayload(astNode)) {
+    const payload = astNode.children[0].constant;
+    return payload;
   }
 
   if (isAggregation(astNode)) {
@@ -108,7 +114,7 @@ function getAstNodeDisplayName(astNode: AstNode) {
   if (process.env.NODE_ENV === 'development') {
     console.warn('Unhandled astNode', astNode);
   }
-  return '';
+  return astNode.name ?? '??';
 }
 
 export const getAggregatorName = (aggregatorName: string): string => {

--- a/packages/app-builder/src/models/operators.ts
+++ b/packages/app-builder/src/models/operators.ts
@@ -36,11 +36,6 @@ export function isMathAst(node: AstNode) {
   }
 }
 
-export function isPayload(node: AstNode) {
-  if (node.name === 'Payload') return true;
-  return false;
-}
-
 export function isIdentifier(
   node: AstNode,
   identifiers: EditorIdentifiersByType

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/edit/trigger.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/edit/trigger.tsx
@@ -80,6 +80,7 @@ export default function Trigger() {
   const { t } = useTranslation(handle.i18n);
   const fetcher = useFetcher<typeof action>();
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const formMethods = useForm({
     defaultValues: {


### PR DESCRIPTION
Operand editor stringify ast in builder.

`Ast` are build using the following spec:

[stringify ast in builder
](https://www.notion.so/checkmarble/Builder-Operand-editor-0562974ec35c451a8c4d90ba60a72d39)