### PR TITLE
try to fix bug

### DIFF
--- a/packages/app-builder/src/services/editor/ast-editor.ts
+++ b/packages/app-builder/src/services/editor/ast-editor.ts
@@ -106,6 +106,14 @@ export function useAstBuilder({
   onSave: (toSave: AstNode) => void;
   onValidate: (ast: AstNode) => void;
 }): AstBuilder {
+  const validate = useCallback(
+    (vm: EditorNodeViewModel) => {
+      const editedAst = adaptAstNodeFromEditorViewModel(vm);
+      onValidate(editedAst);
+    },
+    [onValidate]
+  );
+
   const [editorNodeViewModel, setEditorNodeViewModel] =
     useState<EditorNodeViewModel>(() => {
       if (backendAst === null) {
@@ -123,14 +131,6 @@ export function useAstBuilder({
         validation: backendValidation,
       });
     });
-
-  const validate = useCallback(
-    (vm: EditorNodeViewModel) => {
-      const editedAst = adaptAstNodeFromEditorViewModel(vm);
-      onValidate(editedAst);
-    },
-    [onValidate]
-  );
 
   const replaceOneNode = useCallback(
     (


### PR DESCRIPTION
Seems to fix the error where an empty rule can't be displayed but cases this new error (in browser console)
<img width="763" alt="Capture d’écran 2023-09-07 à 13 56 20" src="https://github.com/checkmarble/marble-frontend/assets/128643171/41936b39-d5ad-48cd-86a2-f6ee68d2daf5">
