### PR TITLE
refactor: frontend build list of identifiers for aggregators and custom list

### DIFF
--- a/packages/app-builder/src/components/Scenario/Formula/Formula.tsx
+++ b/packages/app-builder/src/components/Scenario/Formula/Formula.tsx
@@ -39,7 +39,7 @@ export function Formula({ formula, isRoot = false }: FormulaProps) {
     return <Identifier node={formula} isRoot={isRoot} />;
   }
 
-  if (isAggregationIdentifier(formula, editorIdentifier)) {
+  if (isAggregationIdentifier(formula)) {
     return <Identifier node={formula} isRoot={isRoot} />;
   }
 

--- a/packages/app-builder/src/components/Scenario/Rule/NestedAggregation.tsx
+++ b/packages/app-builder/src/components/Scenario/Rule/NestedAggregation.tsx
@@ -1,6 +1,5 @@
 import { adaptAggregationViewModel } from '@app-builder/components/AstBuilder/AggregationEdit';
 import { type AstNode, isAggregationIdentifier } from '@app-builder/models';
-import { useEditorIdentifiers } from '@app-builder/services/editor';
 import { adaptAstNodeFromEditorViewModel } from '@app-builder/services/editor/ast-editor';
 import { Fragment, useId } from 'react';
 
@@ -14,9 +13,8 @@ export const NestedAggregation = ({
   formula: AstNode;
   displayRow: number;
 }) => {
-  const editorIdentifier = useEditorIdentifiers();
   const id = useId();
-  if (!isAggregationIdentifier(formula, editorIdentifier)) {
+  if (!isAggregationIdentifier(formula)) {
     return;
   }
   const aggregation = adaptAggregationViewModel(id, formula);

--- a/packages/app-builder/src/models/LabelledAst.ts
+++ b/packages/app-builder/src/models/LabelledAst.ts
@@ -13,7 +13,6 @@ import {
   NewCustomListAstNode,
 } from './ast-node';
 import {
-  type EditorIdentifier,
   type EditorIdentifiersByType,
   getIdentifiersFromAstNode,
 } from './identifier';
@@ -24,9 +23,12 @@ export interface LabelledAst {
   astNode: AstNode;
 }
 
-export function adaptLabelledAst(astNode: AstNode): LabelledAst {
+export function adaptLabelledAst(
+  astNode: AstNode,
+  builder: AstBuilder
+): LabelledAst {
   return {
-    label: getAstNodeDisplayName(astNode),
+    label: getAstNodeLabelName(astNode, builder),
     tooltip: '',
     astNode,
   };
@@ -57,12 +59,12 @@ export function adaptLabelledAstFromAllIdentifiers(
 }
 
 export function adaptLabelledAstFromIdentifier(
-  identifier: EditorIdentifier
+  identifier: AstNode
 ): LabelledAst {
   return {
-    label: getAstNodeDisplayName(identifier.node),
+    label: getAstNodeDisplayName(identifier),
     tooltip: '',
-    astNode: identifier.node,
+    astNode: identifier,
   };
 }
 
@@ -98,7 +100,7 @@ export function getAstNodeLabelName(
   if (isCustomListAccess(astNode)) {
     const customList = builder.customLists.find(
       (customList) =>
-        customList.id === astNode.namedChildren.customListId?.constant
+        customList.id === astNode.namedChildren.customListId.constant
     );
     return customList?.name ?? 'Unknown list';
   }

--- a/packages/app-builder/src/models/ast-node.ts
+++ b/packages/app-builder/src/models/ast-node.ts
@@ -34,13 +34,11 @@ export function NewAstNode({
 }
 
 export function NewUndefinedAstNode({
-  constant,
   children,
   namedChildren,
 }: Partial<Omit<AstNode, 'name'>> = {}): AstNode {
   return NewAstNode({
     name: undefinedAstNodeName,
-    constant,
     children,
     namedChildren,
   });
@@ -158,6 +156,26 @@ export function NewCustomListAstNode(
     children: [],
     namedChildren: {
       customListId: NewConstantAstNode({ constant: customListId }),
+    },
+  };
+}
+
+export function NewAggregatorAstNode(
+  aggregatorName: string
+): AggregationAstNode {
+  return {
+    name: 'Aggregator',
+    constant: undefined,
+    children: [],
+    namedChildren: {
+      aggregator: NewConstantAstNode({ constant: aggregatorName }),
+      tableName: NewConstantAstNode({ constant: '' }),
+      fieldName: NewConstantAstNode({ constant: '' }),
+      label: NewConstantAstNode({ constant: '' }),
+      filters: NewAstNode({
+        name: 'List',
+        children: [],
+      }),
     },
   };
 }

--- a/packages/app-builder/src/models/identifier.ts
+++ b/packages/app-builder/src/models/identifier.ts
@@ -1,24 +1,8 @@
-import { type IdentifierDto } from '@marble-api';
-
-import { adaptAstNode, type AstNode } from './ast-node';
-
-export interface EditorIdentifier {
-  node: AstNode;
-}
+import { type AstNode } from './ast-node';
 
 export interface EditorIdentifiersByType {
-  databaseAccessors: EditorIdentifier[];
-  payloadAccessors: EditorIdentifier[];
-  customListAccessors: EditorIdentifier[];
-  aggregatorAccessors: EditorIdentifier[];
-}
-
-export function adaptEditorIdentifier(
-  identifier: IdentifierDto
-): EditorIdentifier {
-  return {
-    node: adaptAstNode(identifier.node),
-  };
+  databaseAccessors: AstNode[];
+  payloadAccessors: AstNode[];
 }
 
 // This implementation might be problematic in the future, we might need to standartise each node with something like a hash function
@@ -28,32 +12,16 @@ export function getIdentifiersFromAstNode(
 ) {
   const astString = JSON.stringify(node);
   for (const identifier of identifiers.databaseAccessors) {
-    if (astString === JSON.stringify(identifier.node)) {
+    if (astString === JSON.stringify(identifier)) {
       return identifier;
     }
   }
-  for (const identifier of identifiers.customListAccessors) {
-    if (astString === JSON.stringify(identifier.node)) {
-      return identifier;
-    }
-  }
+
   for (const identifier of identifiers.payloadAccessors) {
-    if (astString === JSON.stringify(identifier.node)) {
+    if (astString === JSON.stringify(identifier)) {
       return identifier;
     }
   }
 
-  return null;
-}
-
-export function getAggregationFromAstNode(
-  node: AstNode,
-  identifiers: EditorIdentifiersByType
-) {
-  for (const identifier of identifiers.aggregatorAccessors) {
-    if (node.name === identifier.node.name) {
-      return identifier;
-    }
-  }
   return null;
 }

--- a/packages/app-builder/src/models/operators.ts
+++ b/packages/app-builder/src/models/operators.ts
@@ -1,7 +1,6 @@
 import { type AstNode } from './ast-node';
 import {
   type EditorIdentifiersByType,
-  getAggregationFromAstNode,
   getIdentifiersFromAstNode,
 } from './identifier';
 
@@ -45,10 +44,6 @@ export function isIdentifier(
   return false;
 }
 
-export function isAggregationIdentifier(
-  node: AstNode,
-  identifiers: EditorIdentifiersByType
-) {
-  if (getAggregationFromAstNode(node, identifiers) !== null) return true;
-  return false;
+export function isAggregationIdentifier(node: AstNode) {
+  return node.name === 'Aggregator';
 }

--- a/packages/app-builder/src/repositories/EditorRepository.ts
+++ b/packages/app-builder/src/repositories/EditorRepository.ts
@@ -1,6 +1,6 @@
 import { type MarbleApi } from '@app-builder/infra/marble-api';
 import {
-  adaptEditorIdentifier,
+  adaptAstNode,
   adaptNodeDto,
   type AstNode,
   type EditorIdentifiersByType,
@@ -28,27 +28,14 @@ export interface EditorRepository {
 export function getEditorRepository() {
   return (marbleApiClient: MarbleApi): EditorRepository => ({
     listIdentifiers: async ({ scenarioId }) => {
-      const {
-        database_accessors,
-        payload_accessors,
-        custom_list_accessors,
-        aggregator_accessors,
-      } = await marbleApiClient.listIdentifiers(scenarioId);
-      const databaseAccessors = database_accessors.map(adaptEditorIdentifier);
-      const payloadAccessors = payload_accessors.map(adaptEditorIdentifier);
-      const customListAccessors = custom_list_accessors.map(
-        adaptEditorIdentifier
-      );
-
-      const aggregatorAccessors = aggregator_accessors.map(
-        adaptEditorIdentifier
-      );
+      const { database_accessors, payload_accessors } =
+        await marbleApiClient.listIdentifiers(scenarioId);
+      const databaseAccessors = database_accessors.map(adaptAstNode);
+      const payloadAccessors = payload_accessors.map(adaptAstNode);
 
       return {
         databaseAccessors,
         payloadAccessors,
-        customListAccessors,
-        aggregatorAccessors,
       };
     },
     listOperators: async ({ scenarioId }) => {

--- a/packages/app-builder/src/services/editor/identifiers.tsx
+++ b/packages/app-builder/src/services/editor/identifiers.tsx
@@ -1,12 +1,7 @@
 import { scenarioI18n } from '@app-builder/components';
-import {
-  adaptLabelledAst,
-  adaptLabelledAstFromIdentifier,
-  NewAstNode,
-} from '@app-builder/models';
 import { type EditorIdentifiersByType } from '@app-builder/models/identifier';
 import { createSimpleContext } from '@app-builder/utils/create-context';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const EditorIdentifiersContext =
@@ -27,43 +22,6 @@ export function EditorIdentifiersProvider({
 }
 
 export const useEditorIdentifiers = EditorIdentifiersContext.useValue;
-
-function coerceToConstant(search: string) {
-  const parsedNumber = Number(search);
-  const isNumber = !isNaN(parsedNumber);
-
-  if (isNumber) {
-    return NewAstNode({
-      constant: parsedNumber,
-    });
-  }
-
-  return NewAstNode({
-    constant: search,
-  });
-}
-
-export function useGetIdentifierOptions() {
-  const identifiers = useEditorIdentifiers();
-  const identifiersOptions = useMemo(
-    () => [
-      ...identifiers.databaseAccessors.map(adaptLabelledAstFromIdentifier),
-      ...identifiers.payloadAccessors.map(adaptLabelledAstFromIdentifier),
-      ...identifiers.customListAccessors.map(adaptLabelledAstFromIdentifier),
-      ...identifiers.aggregatorAccessors.map(adaptLabelledAstFromIdentifier),
-    ],
-    [identifiers]
-  );
-
-  return useCallback(
-    (search: string) => {
-      if (!search) return identifiersOptions;
-      const constantNode = coerceToConstant(search);
-      return [...identifiersOptions, adaptLabelledAst(constantNode)];
-    },
-    [identifiersOptions]
-  );
-}
 
 export const allAggregators: string[] = [
   'AVG',

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -1438,25 +1438,15 @@ paths:
                 required:
                   - database_accessors
                   - payload_accessors
-                  - custom_list_accessors
-                  - aggregator_accessors
                 properties:
                   database_accessors:
                     type: array
                     items:
-                      $ref: '#/components/schemas/IdentifierDto'
+                      $ref: '#/components/schemas/NodeDto'
                   payload_accessors:
                     type: array
                     items:
-                      $ref: '#/components/schemas/IdentifierDto'
-                  custom_list_accessors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/IdentifierDto'
-                  aggregator_accessors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/IdentifierDto'
+                      $ref: '#/components/schemas/NodeDto'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -2180,13 +2170,6 @@ components:
         - ARGUMENT_MUST_BE_CONVERTIBLE_TO_DURATION
         - ARGUMENT_MUST_BE_TIME
         - ARGUMENT_REQUIRED
-    IdentifierDto:
-      type: object
-      required:
-        - node
-      properties:
-        node:
-          $ref: '#/components/schemas/NodeDto'
     FuncAttributes:
       type: object
       required:

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -259,9 +259,6 @@ export type UpdateOrganizationBodyDto = {
     name?: string;
     database_name?: string;
 };
-export type IdentifierDto = {
-    node: NodeDto;
-};
 export type FuncAttributes = {
     name: string;
     number_of_arguments: number;
@@ -1236,10 +1233,8 @@ export function listIdentifiers(scenarioId: string, opts?: Oazapfts.RequestOpts)
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: {
-            database_accessors: IdentifierDto[];
-            payload_accessors: IdentifierDto[];
-            custom_list_accessors: IdentifierDto[];
-            aggregator_accessors: IdentifierDto[];
+            database_accessors: NodeDto[];
+            payload_accessors: NodeDto[];
         };
     } | {
         status: 401;


### PR DESCRIPTION
The frontend build list of identifiers itself for:
- aggregators
- custom list

The backend do not return theses identifiers anymore.

Do not merge before:
Backend PR: https://github.com/checkmarble/marble-backend/pull/231