### PR TITLE
fix: switch score colors

### DIFF
--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/edit/rules.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/edit/rules.tsx
@@ -60,14 +60,19 @@ export default function Rules() {
       },
       {
         id: 'score',
-        accessorFn: (row) => {
-          const scoreIncrease = row.scoreModifier;
-
-          if (!scoreIncrease) return '';
-
-          return Intl.NumberFormat(language, {
-            signDisplay: 'exceptZero',
-          }).format(scoreIncrease);
+        accessorFn: (row) => row.scoreModifier,
+        cell: ({ getValue }) => {
+          const scoreModifier = getValue<number>();
+          if (!scoreModifier) return '';
+          return (
+            <span
+              className={scoreModifier < 0 ? 'text-green-100' : 'text-red-100'}
+            >
+              {Intl.NumberFormat(language, {
+                signDisplay: 'exceptZero',
+              }).format(scoreModifier)}
+            </span>
+          );
         },
         header: t('scenarios:rules.score'),
         size: 100,

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/view/rules.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/view/rules.tsx
@@ -64,7 +64,7 @@ export default function Rules() {
 
           return (
             <span
-              className={scoreModifier > 0 ? 'text-green-100' : 'text-red-100'}
+              className={scoreModifier < 0 ? 'text-green-100' : 'text-red-100'}
             >
               {Intl.NumberFormat(language, {
                 signDisplay: 'exceptZero',


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-258/display-positive-scores-as-red-in-the-rules-list-builder-and-viewer)

<img width="161" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/17145012/eed24d92-eaf2-4f63-97c1-450731f64209">
