### PR TITLE
feat: error boundary

### DIFF
--- a/packages/app-builder/public/locales/en/common.json
+++ b/packages/app-builder/public/locales/en/common.json
@@ -19,5 +19,8 @@
   "success.save": "Saved successfully",
   "name": "Name",
   "description": "Description",
-  "edit": "Edit"
+  "edit": "Edit",
+  "go_back": "Go back",
+  "error_boundary.default.title": "Did you lose your marbles?",
+  "error_boundary.default.subtitle": "It looks like something went wrong."
 }

--- a/packages/app-builder/src/components/ErrorComponent.tsx
+++ b/packages/app-builder/src/components/ErrorComponent.tsx
@@ -1,0 +1,53 @@
+import { isRouteErrorResponse, useNavigate } from '@remix-run/react';
+import { Button } from '@ui-design-system';
+import { type Namespace } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+export const handle = {
+  i18n: ['common'] satisfies Namespace,
+};
+
+export const ErrorComponent = ({ error }: { error: unknown }) => {
+  const navigate = useNavigate();
+  const { t } = useTranslation(handle.i18n);
+
+  // eslint-disable-next-line no-restricted-properties
+  const isDevMode = process.env.NODE_ENV === 'development';
+
+  return (
+    <div className="m-auto flex flex-col items-center gap-4">
+      <h1 className="text-l text-purple-110 font-semibold">
+        {t('common:error_boundary.default.title')}
+      </h1>
+      <p className="text-s mb-6">
+        {t('common:error_boundary.default.subtitle')}
+      </p>
+
+      <div className="mb-1">
+        <Button onClick={() => navigate(-1)}>{t('common:go_back')}</Button>
+      </div>
+      {isDevMode && <ErrorDetail error={error} />}
+    </div>
+  );
+};
+
+const ErrorDetail = ({ error }: { error: unknown }) => {
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div className="text-xs">
+        <p>
+          Error status: {error.status} {error.statusText}
+        </p>
+        <p>{error.data}</p>
+      </div>
+    );
+  } else if (error instanceof Error) {
+    return (
+      <div className="text-xs">
+        <pre>{error.stack}</pre>
+      </div>
+    );
+  } else {
+    return <h1>Unknown Error</h1>;
+  }
+};

--- a/packages/app-builder/src/components/index.ts
+++ b/packages/app-builder/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Callout';
 export * from './Decision';
+export * from './ErrorComponent';
 export * from './Navigation';
 export * from './Page';
 export * from './Paper';

--- a/packages/app-builder/src/root.tsx
+++ b/packages/app-builder/src/root.tsx
@@ -12,8 +12,10 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useRouteError,
 } from '@remix-run/react';
 import { Tooltip } from '@ui-design-system';
+import { LogoStandard } from '@ui-icons';
 import { type Namespace } from 'i18next';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +24,7 @@ import {
   createAuthenticityToken,
 } from 'remix-utils';
 
+import { ErrorComponent } from './components/ErrorComponent';
 import { getToastMessage, MarbleToaster } from './components/MarbleToaster';
 import { serverServices } from './services/init.server';
 import tailwindStyles from './tailwind.css';
@@ -95,6 +98,41 @@ export const meta: V2_MetaFunction = () => [
     content: 'width=device-width,initial-scale=1',
   },
 ];
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body className="selection:text-grey-00 h-screen w-full overflow-hidden antialiased selection:bg-purple-100">
+        <div className="from-purple-10 to-grey-02 flex h-full w-full flex-col items-center bg-gradient-to-r">
+          <div className="flex h-full w-full flex-col items-center bg-[url('/img/login_background.svg')] bg-no-repeat">
+            <div className="flex h-full max-h-80 flex-col justify-center">
+              <a href="/login">
+                <LogoStandard
+                  className="w-auto"
+                  width={undefined}
+                  height="40px"
+                  preserveAspectRatio="xMinYMid meet"
+                />
+              </a>
+            </div>
+            <div className="bg-grey-00 min-w-xs mb-10 flex flex-shrink-0 rounded-2xl p-10 text-center shadow-md ">
+              <ErrorComponent error={error} />
+            </div>
+          </div>
+        </div>
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
 
 export default function App() {
   const { locale, ENV, toastMessage, csrf } = useLoaderData<typeof loader>();

--- a/packages/app-builder/src/routes/__builder/decisions.tsx
+++ b/packages/app-builder/src/routes/__builder/decisions.tsx
@@ -1,11 +1,16 @@
-import { Outcome, type OutcomeProps, Page } from '@app-builder/components';
+import {
+  ErrorComponent,
+  Outcome,
+  type OutcomeProps,
+  Page,
+} from '@app-builder/components';
 import { serverServices } from '@app-builder/services/init.server';
 import { formatCreatedAt } from '@app-builder/utils/format';
 import { useVisibilityChange } from '@app-builder/utils/hooks';
 import { type Decision } from '@marble-api';
 import { Label } from '@radix-ui/react-label';
 import { json, type LoaderArgs } from '@remix-run/node';
-import { useLoaderData, useRevalidator } from '@remix-run/react';
+import { useLoaderData, useRevalidator, useRouteError } from '@remix-run/react';
 import { type ColumnDef, getCoreRowModel } from '@tanstack/react-table';
 import { Checkbox, Input, Table, useVirtualTable } from '@ui-design-system';
 import { Decision as DecisionIcon, Search } from '@ui-icons';
@@ -187,4 +192,8 @@ function ToggleLiveUpdate() {
       </Label>
     </div>
   );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent error={useRouteError()} />;
 }

--- a/packages/app-builder/src/routes/__builder/lists/$listId.tsx
+++ b/packages/app-builder/src/routes/__builder/lists/$listId.tsx
@@ -1,4 +1,9 @@
-import { Callout, Page, usePermissionsContext } from '@app-builder/components';
+import {
+  Callout,
+  ErrorComponent,
+  Page,
+  usePermissionsContext,
+} from '@app-builder/components';
 import { DeleteList } from '@app-builder/routes/ressources/lists/delete';
 import { EditList } from '@app-builder/routes/ressources/lists/edit';
 import { NewListValue } from '@app-builder/routes/ressources/lists/value_create';
@@ -6,7 +11,7 @@ import { DeleteListValue } from '@app-builder/routes/ressources/lists/value_dele
 import { serverServices } from '@app-builder/services/init.server';
 import { fromParams } from '@app-builder/utils/short-uuid';
 import { json, type LoaderArgs } from '@remix-run/node';
-import { Link, useLoaderData } from '@remix-run/react';
+import { Link, useLoaderData, useRouteError } from '@remix-run/react';
 import {
   type ColumnDef,
   getCoreRowModel,
@@ -145,6 +150,10 @@ export default function Lists() {
       </Page.Content>
     </Page.Container>
   );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent error={useRouteError()} />;
 }
 
 // Correspond to this part of the UI : https://www.figma.com/file/JW6QvnhBtdZDcKvLdg9s5T/Marble-Portal?node-id=6377%3A53150&mode=dev

--- a/packages/app-builder/src/routes/__builder/lists/index.tsx
+++ b/packages/app-builder/src/routes/__builder/lists/index.tsx
@@ -1,11 +1,11 @@
-import { Page } from '@app-builder/components';
+import { ErrorComponent, Page } from '@app-builder/components';
 import { usePermissionsContext } from '@app-builder/components/PermissionsContext';
 import { CreateList } from '@app-builder/routes/ressources/lists/create';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderArgs } from '@remix-run/node';
-import { useLoaderData, useNavigate } from '@remix-run/react';
+import { useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
 import {
   type ColumnDef,
   getCoreRowModel,
@@ -113,4 +113,8 @@ export default function ListsPage() {
       </Page.Content>
     </Page.Container>
   );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent error={useRouteError()} />;
 }

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId.tsx
@@ -1,7 +1,8 @@
+import { ErrorComponent } from '@app-builder/components';
 import { serverServices } from '@app-builder/services/init.server';
 import { fromParams } from '@app-builder/utils/short-uuid';
 import { json, type LoaderArgs, type SerializeFrom } from '@remix-run/node';
-import { Outlet, useRouteLoaderData } from '@remix-run/react';
+import { Outlet, useRouteError, useRouteLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 
 export const handle = {
@@ -28,4 +29,8 @@ export const useCurrentScenario = () =>
 
 export default function CurrentScenarioProvider() {
   return <Outlet />;
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent error={useRouteError()} />;
 }

--- a/packages/app-builder/src/routes/__builder/scenarios/index.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/index.tsx
@@ -1,11 +1,11 @@
-import { Page } from '@app-builder/components';
+import { ErrorComponent, Page } from '@app-builder/components';
 import { adaptDataModelDto } from '@app-builder/models/data-model';
 import { CreateScenario } from '@app-builder/routes/ressources/scenarios/create';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderArgs } from '@remix-run/node';
-import { Link, useLoaderData } from '@remix-run/react';
+import { Link, useLoaderData, useRouteError } from '@remix-run/react';
 import { Tag } from '@ui-design-system';
 import { Scenarios } from '@ui-icons';
 import { type Namespace } from 'i18next';
@@ -28,6 +28,7 @@ export async function loader({ request }: LoaderArgs) {
     ({ createdAt }) => createdAt,
     'desc',
   ]);
+
   return json({
     scenarios: sortedScenarios,
     dataModel: adaptDataModelDto(data_model),
@@ -87,4 +88,8 @@ export default function ScenariosPage() {
       </Page.Content>
     </Page.Container>
   );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent error={useRouteError()} />;
 }


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-250/handle-errors-in-a-dedicated-page)

ErrorBoundary at the root level
![image](https://github.com/checkmarble/marble-frontend/assets/17145012/f764de6c-c6ef-4301-9ccf-8a29211e0729)

ErrorBoundary at the page level (which you can use on any piece of UI you want)
![image (1)](https://github.com/checkmarble/marble-frontend/assets/17145012/19c6950d-671c-4a7a-8727-debd60968143)


Bonus : with the stack trace in dev mode
<img width="1507" alt="Capture d’écran 2023-09-15 à 11 41 17" src="https://github.com/checkmarble/marble-frontend/assets/17145012/d8a8c75a-f395-4b94-81cc-074fdd2d1fb3">
