### PR TITLE
fix: move validation error callout inside the scrollable container

### DIFF
--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/edit.rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/edit.rules.$ruleId.tsx
@@ -253,13 +253,12 @@ export default function RuleEdit() {
         </Button>
       </ScenarioPage.Header>
 
-      <Callout variant="error">
-        {t('common:validation_error', {
-          count: countNodeEvaluationErrors(rule.validation),
-        })}
-      </Callout>
-
       <ScenarioPage.Content className="max-w-3xl">
+        <Callout variant="error">
+          {t('common:validation_error', {
+            count: countNodeEvaluationErrors(rule.validation),
+          })}
+        </Callout>
         <Paper.Container scrollable={false}>
           <FormProvider {...formMethods}>
             <FormField


### PR DESCRIPTION
Small fix to fix this visual regression :
<img width="1285" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/4d801764-7cf6-47f1-885d-c23fb3cddcdf">
