### PR TITLE
Thomas/mar 285 info popover

### DIFF
--- a/packages/app-builder/public/locales/en/scenarios.json
+++ b/packages/app-builder/public/locales/en/scenarios.json
@@ -123,5 +123,12 @@
   "edit_operand.result_other": "Results",
   "edit_operand.constant.use_data_type.string": "Use string",
   "edit_operand.constant.use_data_type.number": "Use number",
-  "edit_operand.constant.use_data_type.boolean": "Use boolean"
+  "edit_operand.constant.use_data_type.boolean": "Use boolean",
+  "edit_operand.data_type.string": "String",
+  "edit_operand.data_type.number": "Number",
+  "edit_operand.data_type.boolean": "Boolean",
+  "edit_operand.data_type.timestamp": "Timestamp",
+  "edit_operand.operator_type.list": "List",
+  "edit_operand.operator_type.field": "Field",
+  "edit_operand.operator_type.variable": "Variable"
 }

--- a/packages/app-builder/src/components/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandOption/OperandOption.tsx
+++ b/packages/app-builder/src/components/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandOption/OperandOption.tsx
@@ -1,5 +1,7 @@
 import { type LabelledAst } from '@app-builder/models';
+import { Tip } from '@ui-icons';
 
+import { OperandTooltip } from './OperandTooltip';
 import { getDataTypeIcon, Option } from './Option';
 
 export function OperandOption({
@@ -11,13 +13,18 @@ export function OperandOption({
 }) {
   const DataTypeIcon = getDataTypeIcon(option.dataType);
   return (
-    <Option.Container onClick={onClick}>
+    <Option.Container onClick={onClick} className="group">
       {DataTypeIcon && (
         <Option.Icon className="col-start-1">
           <DataTypeIcon />
         </Option.Icon>
       )}
       <Option.Value className="col-start-2">{option.name}</Option.Value>
+      <OperandTooltip option={option} sideOffset={24} alignOffset={-8}>
+        <Option.Icon className="text-grey-00 group-hover:text-purple-50 group-hover:hover:text-purple-100">
+          <Tip />
+        </Option.Icon>
+      </OperandTooltip>
     </Option.Container>
   );
 }

--- a/packages/app-builder/src/components/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandOption/OperandTooltip.tsx
+++ b/packages/app-builder/src/components/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandOption/OperandTooltip.tsx
@@ -1,0 +1,93 @@
+import { type LabelledAst } from '@app-builder/models';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { useTranslation } from 'react-i18next';
+
+import {
+  getDataTypeIcon,
+  getDataTypeTKey,
+  getOperatorTypeIcon,
+  getOperatorTypeTKey,
+} from './Option';
+
+export function OperandTooltip({
+  option,
+  children,
+  side = 'right',
+  align = 'start',
+  sideOffset,
+  alignOffset,
+}: {
+  option: LabelledAst;
+  children: React.ReactNode;
+} & Pick<
+  Tooltip.TooltipContentProps,
+  'sideOffset' | 'side' | 'align' | 'alignOffset'
+>) {
+  const typeInfos = [
+    {
+      Icon: getOperatorTypeIcon(option.operandType),
+      tKey: getOperatorTypeTKey(option.operandType),
+    },
+    {
+      Icon: getDataTypeIcon(option.dataType),
+      tKey: getDataTypeTKey(option.dataType),
+    },
+  ];
+
+  return (
+    <Tooltip.Root delayDuration={0}>
+      <Tooltip.Trigger>{children}</Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          side={side}
+          align={align}
+          sideOffset={sideOffset}
+          alignOffset={alignOffset}
+          className="bg-grey-00 border-grey-10 flex max-w-[200px] flex-col gap-2 rounded border p-4 shadow-md"
+        >
+          <div className="flex flex-col gap-1">
+            <TypeInfos typeInfos={typeInfos} />
+            <p className="text-grey-100 text-s overflow-hidden text-ellipsis font-normal">
+              {option.name}
+            </p>
+          </div>
+          {option.description && (
+            <p className="text-grey-50 text-xs font-normal">
+              {option.description}
+            </p>
+          )}
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+}
+
+function TypeInfos({
+  typeInfos,
+}: {
+  typeInfos: {
+    Icon: ReturnType<typeof getDataTypeIcon>;
+    tKey: ReturnType<typeof getDataTypeTKey>;
+  }[];
+}) {
+  const { t } = useTranslation('scenarios');
+
+  if (typeInfos.filter(({ tKey }) => !!tKey).length === 0) return null;
+
+  return (
+    <div className="flex flex-row gap-2">
+      {typeInfos.map(({ Icon, tKey }) => {
+        if (!tKey) return null;
+        return (
+          <span
+            key={tKey}
+            className="inline-flex items-center gap-[2px] text-xs font-normal text-purple-50"
+          >
+            {Icon && <Icon className="text-[12px]" />}
+            {t(tKey)}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/app-builder/src/components/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandOption/Option.tsx
+++ b/packages/app-builder/src/components/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandOption/Option.tsx
@@ -7,6 +7,7 @@ import {
 } from '@app-builder/models';
 import { Boolean, Field, List, Number, String, Variable } from '@ui-icons';
 import clsx from 'clsx';
+import { type ParseKeys } from 'i18next';
 
 function OptionContainer({ className, ...props }: React.ComponentProps<'div'>) {
   return (
@@ -15,7 +16,8 @@ function OptionContainer({ className, ...props }: React.ComponentProps<'div'>) {
       // TODO(combobox): handle aria-selected when keyboard navigation is implemented (+ style w\ hover:bg-purple-05)
       aria-selected="false"
       className={clsx(
-        'hover:bg-purple-05 grid w-full select-none grid-cols-[20px_1fr_20px] gap-1 rounded-sm p-2 outline-none',
+        'hover:bg-purple-05 grid w-full select-none grid-cols-[20px_1fr_20px] gap-1 rounded-sm p-2 outline-none transition-colors',
+
         className
       )}
       {...props}
@@ -24,13 +26,22 @@ function OptionContainer({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 function OptionIcon({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div className={clsx('shrink-0 text-[21px]', className)} {...props} />;
+  return (
+    <div
+      className={clsx('shrink-0 text-[21px] transition-colors', className)}
+      {...props}
+    />
+  );
 }
 
 function OptionValue({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      className={clsx('text-grey-100 text-s text-start font-normal', className)}
+      className={clsx(
+        'text-grey-100 text-s text-start font-normal transition-colors',
+
+        className
+      )}
       {...props}
     />
   );
@@ -56,6 +67,24 @@ export function getDataTypeIcon(dataType?: DataType) {
   }
 }
 
+export function getDataTypeTKey(
+  dataType?: DataType
+): ParseKeys<'scenarios'> | undefined {
+  switch (dataType) {
+    case 'String':
+      return 'edit_operand.data_type.string';
+    case 'Int':
+    case 'Float':
+      return 'edit_operand.data_type.number';
+    case 'Bool':
+      return 'edit_operand.data_type.boolean';
+    case 'Timestamp':
+      return 'edit_operand.data_type.timestamp';
+    default:
+      return undefined;
+  }
+}
+
 export function getOperatorTypeIcon(operatorType?: string) {
   switch (operatorType) {
     case customListAccessAstNodeName:
@@ -65,6 +94,22 @@ export function getOperatorTypeIcon(operatorType?: string) {
       return Field;
     case aggregationAstNodeName:
       return Variable;
+    default:
+      return undefined;
+  }
+}
+
+export function getOperatorTypeTKey(
+  operatorType?: string
+): ParseKeys<'scenarios'> | undefined {
+  switch (operatorType) {
+    case customListAccessAstNodeName:
+      return 'edit_operand.operator_type.list';
+    case databaseAccessAstNodeName:
+    case payloadAstNodeName:
+      return 'edit_operand.operator_type.field';
+    case aggregationAstNodeName:
+      return 'edit_operand.operator_type.variable';
     default:
       return undefined;
   }


### PR DESCRIPTION
Introduce the info popover component. 
The current implementation will be reused in the inline selected option of a rule.


https://github.com/checkmarble/marble-frontend/assets/40292402/c3d4f764-69d1-4e7a-b207-84a737042e78



