### PR TITLE
feat: backend url and access token available through a context

### DIFF
--- a/packages/app-builder/src/components/BackendInfoContext.tsx
+++ b/packages/app-builder/src/components/BackendInfoContext.tsx
@@ -1,0 +1,20 @@
+import { type BackendInfo } from '@app-builder/models';
+import { createSimpleContext } from '@app-builder/utils/create-context';
+import { type PropsWithChildren } from 'react';
+
+const BackendInfoContext = createSimpleContext<BackendInfo>(
+  'BackendInfoProvider'
+);
+
+export const BackendInfoProvider = ({
+  backendInfo,
+  children,
+}: PropsWithChildren<{ backendInfo: BackendInfo }>) => {
+  return (
+    <BackendInfoContext.Provider value={backendInfo}>
+      {children}
+    </BackendInfoContext.Provider>
+  );
+};
+
+export const useBackendInfoContext = BackendInfoContext.useValue;

--- a/packages/app-builder/src/components/index.ts
+++ b/packages/app-builder/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './BackendInfoContext';
 export * from './Callout';
 export * from './Decision';
 export * from './ErrorComponent';
@@ -7,3 +8,4 @@ export * from './Paper';
 export * from './PermissionsContext';
 export * from './RightPanel';
 export * from './Scenario';
+export * from './ScheduledExecutionsList';

--- a/packages/app-builder/src/models/backend-info.ts
+++ b/packages/app-builder/src/models/backend-info.ts
@@ -1,0 +1,4 @@
+export interface BackendInfo {
+  accessToken: string;
+  backendUrl: string;
+}

--- a/packages/app-builder/src/models/index.ts
+++ b/packages/app-builder/src/models/index.ts
@@ -1,6 +1,7 @@
 export * from './ast-node';
 export * from './ast-operators';
 export * from './auth-errors';
+export * from './backend-info';
 export * from './data-model';
 export * from './http-errors';
 export * from './identifier';

--- a/packages/app-builder/src/services/auth/auth.server.ts
+++ b/packages/app-builder/src/services/auth/auth.server.ts
@@ -1,5 +1,9 @@
 import { type MarbleApi } from '@app-builder/infra/marble-api';
-import { adaptAuthErrors, type User } from '@app-builder/models';
+import {
+  adaptAuthErrors,
+  type BackendInfo,
+  type User,
+} from '@app-builder/models';
 import { type EditorRepository } from '@app-builder/repositories/EditorRepository';
 import { type MarbleAPIRepository } from '@app-builder/repositories/MarbleAPIRepository';
 import { type OrganizationRepository } from '@app-builder/repositories/OrganizationRepository';
@@ -22,6 +26,7 @@ interface AuthenticatedInfo {
   organization: OrganizationRepository;
   scenario: ScenarioRepository;
   user: User;
+  backendInfo: BackendInfo;
 }
 
 export interface AuthenticationServerService {
@@ -73,6 +78,8 @@ export function makeAuthenticationServerService(
     return marbleAPIClient(tokenService);
   }
 
+  const backendUrl = getServerEnv('MARBLE_API_DOMAIN');
+
   async function authenticate(
     request: Request,
     options: {
@@ -97,7 +104,7 @@ export function makeAuthenticationServerService(
         {
           authorization: `Bearer ${idToken}`,
         },
-        { baseUrl: getServerEnv('MARBLE_API_DOMAIN') }
+        { baseUrl: backendUrl }
       );
 
       const apiClient = getMarbleAPIClient(marbleToken.access_token);
@@ -166,6 +173,10 @@ export function makeAuthenticationServerService(
       scenario: scenarioRepository(apiClient),
       organization: organizationRepository(apiClient, user.organizationId),
       user,
+      backendInfo: {
+        accessToken: marbleToken.access_token,
+        backendUrl,
+      },
     };
   }
 


### PR DESCRIPTION
## Pass backend information to the frontend
 
Goal: Allow the js frontend to make special call to the backend directly:
- big file upload in javascript (csv)
- download in blob (big zip)

`BackendInfoContext` contains the backend url and access_token.

Potential problem: the access_token could be outdated.
