### PR TITLE
feat: useBackendInfo returns backendUrl and accessToken (clientOnly)

### DIFF
--- a/packages/app-builder/src/infra/firebase.ts
+++ b/packages/app-builder/src/infra/firebase.ts
@@ -8,7 +8,6 @@ import {
   connectAuthEmulator,
   getAuth,
   GoogleAuthProvider,
-  inMemoryPersistence,
   signInWithPopup,
 } from 'firebase/auth';
 
@@ -19,17 +18,16 @@ export type FirebaseClientWrapper = {
   signIn: typeof signInWithPopup;
 };
 
-export async function initializeFirebaseClient({
+export function initializeFirebaseClient({
   firebaseOptions,
   authEmulatorHost,
 }: {
   firebaseOptions: FirebaseOptions;
   authEmulatorHost?: string;
-}): Promise<FirebaseClientWrapper> {
+}): FirebaseClientWrapper {
   const app = initializeApp(firebaseOptions);
 
   const clientAuth = getAuth(app);
-  await clientAuth.setPersistence(inMemoryPersistence);
 
   if (authEmulatorHost && !('emulator' in clientAuth.config)) {
     connectAuthEmulator(clientAuth, authEmulatorHost);
@@ -38,5 +36,10 @@ export async function initializeFirebaseClient({
   const googleAuthProvider = new GoogleAuthProvider();
   googleAuthProvider.setCustomParameters({ prompt: 'select_account' });
 
-  return { app, clientAuth, googleAuthProvider, signIn: signInWithPopup };
+  return {
+    app,
+    clientAuth,
+    googleAuthProvider,
+    signIn: signInWithPopup,
+  };
 }

--- a/packages/app-builder/src/repositories/AuthenticationRepository.ts
+++ b/packages/app-builder/src/repositories/AuthenticationRepository.ts
@@ -1,7 +1,8 @@
 import { type FirebaseClientWrapper } from '@app-builder/infra/firebase';
 
 export interface AuthenticationClientRepository {
-  googleSignIn: (locale: string) => Promise<string | undefined>;
+  googleSignIn: (locale: string) => Promise<string>;
+  firebaseIdToken: () => Promise<string>;
 }
 
 export function getAuthenticationClientRepository({
@@ -24,5 +25,13 @@ export function getAuthenticationClientRepository({
     return credential.user.getIdToken();
   }
 
-  return { googleSignIn };
+  const firebaseIdToken = () => {
+    const currentUser = clientAuth.currentUser;
+    if (currentUser === null) {
+      throw Error('No authenticated user, no token');
+    }
+    return currentUser.getIdToken();
+  };
+
+  return { googleSignIn, firebaseIdToken };
 }

--- a/packages/app-builder/src/repositories/init.client.ts
+++ b/packages/app-builder/src/repositories/init.client.ts
@@ -6,15 +6,14 @@ import {
 } from './AuthenticationRepository';
 
 export interface ClientRepositories {
-  authenticationClientRepositoryPromise: Promise<AuthenticationClientRepository>;
+  authenticationClientRepository: AuthenticationClientRepository;
 }
 
 export function makeClientRepositories(
-  firebaseClientPromise: Promise<FirebaseClientWrapper>
+  firebaseClient: FirebaseClientWrapper
 ): ClientRepositories {
   return {
-    authenticationClientRepositoryPromise: firebaseClientPromise.then(
-      (firebaseClient) => getAuthenticationClientRepository(firebaseClient)
-    ),
+    authenticationClientRepository:
+      getAuthenticationClientRepository(firebaseClient),
   };
 }

--- a/packages/app-builder/src/services/auth/auth.client.ts
+++ b/packages/app-builder/src/services/auth/auth.client.ts
@@ -1,12 +1,14 @@
 import { type AuthenticationClientRepository } from '@app-builder/repositories/AuthenticationRepository';
+import { getClientEnv } from '@app-builder/utils/environment.client';
+import { marbleApi } from '@marble-api';
 import { useTranslation } from 'react-i18next';
 import { useAuthenticityToken } from 'remix-utils';
 
 export function makeAuthenticationClientService(
-  authenticationClientRepositoryPromise: Promise<AuthenticationClientRepository>
+  authenticationClientRepository: AuthenticationClientRepository
 ) {
   return {
-    authenticationClientRepositoryPromise,
+    authenticationClientRepository,
   };
 }
 
@@ -15,16 +17,13 @@ export type AuthenticationClientService = ReturnType<
 >;
 
 export function useGoogleSignIn({
-  authenticationClientRepositoryPromise,
+  authenticationClientRepository,
 }: AuthenticationClientService) {
   const { i18n } = useTranslation();
   const csrf = useAuthenticityToken();
 
   return async () => {
     try {
-      const authenticationClientRepository =
-        await authenticationClientRepositoryPromise;
-
       const idToken = await authenticationClientRepository.googleSignIn(
         i18n.language
       );
@@ -33,5 +32,31 @@ export function useGoogleSignIn({
       //TODO: handle errors correctly for UI
       console.error(error);
     }
+  };
+}
+
+export function useBackendInfo({
+  authenticationClientRepository,
+}: AuthenticationClientService) {
+  const backendUrl = getClientEnv('MARBLE_API_DOMAIN');
+
+  const accessToken = async () => {
+    const firebaseIdToken =
+      await authenticationClientRepository.firebaseIdToken();
+    const token = await marbleApi.postToken(
+      {
+        authorization: `Bearer ${firebaseIdToken}`,
+      },
+      {
+        baseUrl: backendUrl,
+      }
+    );
+
+    return token.access_token;
+  };
+
+  return {
+    accessToken,
+    backendUrl,
   };
 }

--- a/packages/app-builder/src/services/init.client.ts
+++ b/packages/app-builder/src/services/init.client.ts
@@ -11,18 +11,18 @@ import { makeI18nextClientService } from './i18n/i18next.client';
 function makeClientServices(repositories: ClientRepositories) {
   return {
     authenticationClientService: makeAuthenticationClientService(
-      repositories.authenticationClientRepositoryPromise
+      repositories.authenticationClientRepository
     ),
     i18nextClientService: makeI18nextClientService(),
   };
 }
 
 function initClientServices() {
-  const firebaseClientPromise = initializeFirebaseClient({
+  const firebaseClient = initializeFirebaseClient({
     firebaseOptions: getClientEnv('FIREBASE_OPTIONS'),
     authEmulatorHost: getClientEnv('AUTH_EMULATOR_HOST', ''),
   });
-  const clientRepositories = makeClientRepositories(firebaseClientPromise);
+  const clientRepositories = makeClientRepositories(firebaseClient);
   return makeClientServices(clientRepositories);
 }
 

--- a/packages/app-builder/src/utils/environment.client.ts
+++ b/packages/app-builder/src/utils/environment.client.ts
@@ -10,6 +10,7 @@ export type ClientEnvVars = {
   ENV: string;
   AUTH_EMULATOR_HOST?: string;
   FIREBASE_OPTIONS: FirebaseOptions;
+  MARBLE_API_DOMAIN: string;
 };
 
 export function getClientEnv<K extends keyof ClientEnvVars>(

--- a/packages/app-builder/src/utils/environment.server.ts
+++ b/packages/app-builder/src/utils/environment.server.ts
@@ -83,5 +83,6 @@ export function getClientEnvVars(): ClientEnvVars {
       messagingSenderId: getServerEnv('FIREBASE_MESSAGING_SENDER_ID'),
       appId: getServerEnv('FIREBASE_APP_ID'),
     },
+    MARBLE_API_DOMAIN: getServerEnv('MARBLE_API_DOMAIN'),
   };
 }


### PR DESCRIPTION
Goal: Allow the js frontend to make special call to the backend directly:

big file upload in javascript (csv)
download in blob (big zip)

Usage:
```
const {accessToken, backendUrl} = useBackendInfo()
```

⚠️ The component that use `useBackendInfo` must be in a `<ClientOnly>`

See: Example https://github.com/checkmarble/marble-frontend/pull/146