### PR TITLE
fix(labels): link labels to components

### DIFF
--- a/packages/app-builder/src/components/Scenario/Trigger/ScheduleOption.tsx
+++ b/packages/app-builder/src/components/Scenario/Trigger/ScheduleOption.tsx
@@ -140,6 +140,7 @@ export const ScheduleOption = ({
     <>
       <div className="text-s flex items-center gap-1">
         <Checkbox
+          id="scheduleScenario"
           name="scheduleScenario"
           defaultChecked={scheduleOption.isScenarioScheduled}
           onCheckedChange={() =>

--- a/packages/app-builder/src/routes/ressources/scenarios/create.tsx
+++ b/packages/app-builder/src/routes/ressources/scenarios/create.tsx
@@ -81,14 +81,20 @@ export function CreateScenario({ dataModel }: { dataModel: TableModel[] }) {
           <Modal.Title>{t('scenarios:create_scenario.title')}</Modal.Title>
           <div className="bg-grey-00 flex flex-col gap-8 p-8">
             <div className="flex flex-1 flex-col gap-4">
-              <label>{t('scenarios:create_scenario.name')}</label>
+              <label htmlFor="name">
+                {t('scenarios:create_scenario.name')}
+              </label>
               <Input
+                id="name"
                 name="name"
                 type="text"
                 placeholder={t('scenarios:create_scenario.name_placeholder')}
               />
-              <label>{t('scenarios:create_scenario.description')}</label>
+              <label htmlFor="description">
+                {t('scenarios:create_scenario.description')}
+              </label>
               <Input
+                id="description"
                 name="description"
                 type="text"
                 placeholder={t(


### PR DESCRIPTION
Add missing links between labels and components :
- fix accessibility (make writing tests easier: you can interact with a field using the displayed label)
- in practice: clicking on a label interact with the component
  - input: clicking on a label focus the input
  - checkbox: clicking on a label is equivalent to clicking the checkbox
 
The core reason I did this is for that (before, I needed to click on the checkbox to change the current state)
![output](https://github.com/checkmarble/marble-frontend/assets/40292402/15830718-c07b-423b-b2de-0543cce57525)
