### PR TITLE
fix(rules): fix double click on create a rule

### DIFF
--- a/packages/app-builder/src/routes/ressources/scenarios/$scenarioId/$iterationId/rules/create.tsx
+++ b/packages/app-builder/src/routes/ressources/scenarios/$scenarioId/$iterationId/rules/create.tsx
@@ -2,14 +2,14 @@ import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionArgs, json, redirect } from '@remix-run/node';
-import { Form, useFetcher } from '@remix-run/react';
+import { useFetcher } from '@remix-run/react';
 import { Button } from '@ui-design-system';
 import { Plus } from '@ui-icons';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
 export const handle = {
-  i18n: ['scenarios', 'navigation', 'common'] satisfies Namespace,
+  i18n: ['scenarios'] satisfies Namespace,
 };
 
 export async function action({ request, params }: ActionArgs) {
@@ -57,20 +57,16 @@ export function CreateRule({
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <Form
-      onSubmit={() => {
-        fetcher.submit(null, {
-          method: 'POST',
-          action: `/ressources/scenarios/${fromUUID(scenarioId)}/${fromUUID(
-            iterationId
-          )}/rules/create`,
-        });
-      }}
+    <fetcher.Form
+      method="POST"
+      action={`/ressources/scenarios/${fromUUID(scenarioId)}/${fromUUID(
+        iterationId
+      )}/rules/create`}
     >
-      <Button type="submit">
+      <Button type="submit" disabled={fetcher.state === 'submitting'}>
         <Plus width={'24px'} height={'24px'} />
         {t('scenarios:create_rule.title')}
       </Button>
-    </Form>
+    </fetcher.Form>
   );
 }

--- a/packages/app-builder/src/utils/sleep.ts
+++ b/packages/app-builder/src/utils/sleep.ts
@@ -1,0 +1,8 @@
+/**
+ * Sleep for a given number of milliseconds.
+ *
+ * This is a useful utility function for testing.
+ */
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
In this PR :
- introduce a `sleep` util (for testing)
- fix a double issue on create rule screen :
  - spam click is now prevented (to only create one rule)
  - creating a rule succesfully trigger a redirect to the edit rule page 

> NB: for demonstration purpose, the rule creation is slowed on purpose during 3s

![output](https://github.com/checkmarble/marble-frontend/assets/40292402/65411bea-afdd-4491-bca5-44bcdf70ddc8)
