### PR TITLE
feat: better errors on ingestion fail

### DIFF
--- a/packages/app-builder/public/locales/en/upload.json
+++ b/packages/app-builder/public/locales/en/upload.json
@@ -6,7 +6,7 @@
   "drop_file_cta": "Drop your filled .csv here",
   "pick_file_cta": "Pick a file",
   "success_message": "{{linesProcessed}} {{objectType}} will be added to your data",
-  "failure_message": "We found an error : {{errorMessage}}.",
+  "failure_message": "We found an error:",
   "failure_additional_message": "No {{objectType}} were added to your data",
   "results": "Results",
   "past_uploads": "Past uploads",

--- a/packages/app-builder/src/routes/__builder/upload/$objectType.tsx
+++ b/packages/app-builder/src/routes/__builder/upload/$objectType.tsx
@@ -58,6 +58,7 @@ export async function loader({ request, params }: LoaderArgs) {
 type ModalContent = {
   message: string;
   success: boolean;
+  error?: string;
 };
 
 const UploadForm = ({ objectType }: { objectType: string }) => {
@@ -92,7 +93,8 @@ const UploadForm = ({ objectType }: { objectType: string }) => {
         });
       } else {
         setModalContent({
-          message: t('upload:failure_message', { replace: { errorMessage } }),
+          message: t('upload:failure_message'),
+          error: errorMessage,
           success: false,
         });
       }
@@ -226,11 +228,14 @@ const ResultModal = ({
             <p className="text-l font-semibold">{t('upload:results')}</p>
             <p>{modalContent.message}</p>
             {!modalContent.success && (
-              <p className="mt-6">
-                {t('upload:failure_additional_message', {
-                  replace: { objectType },
-                })}
-              </p>
+              <>
+                <p>{modalContent.error}</p>
+                <p className="mt-6">
+                  {t('upload:failure_additional_message', {
+                    replace: { objectType },
+                  })}
+                </p>
+              </>
             )}
           </div>
           <Modal.Close asChild>


### PR DESCRIPTION
## Context

Now that we have more detailed error messages, it needed a little space to be displayed. So here it goes

[See back-end PR for details](https://github.com/checkmarble/marble-backend/pull/291)

<img width="800" alt="Capture d’écran 2023-10-09 à 10 56 06" src="https://github.com/checkmarble/marble-frontend/assets/17145012/ecce258c-822a-4620-9e51-6bee0dcd4e1e">
