### PR TITLE
Zoe/and or errors

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootAnd.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootAnd.tsx
@@ -8,12 +8,12 @@ import {
   type AstBuilder,
   type EditorNodeViewModel,
 } from '@app-builder/services/editor/ast-editor';
+import { useGetOrAndNodeEvaluationErrorMessage } from '@app-builder/services/validation';
 import clsx from 'clsx';
 import { Fragment } from 'react';
 
 import { ScenarioValidationError } from '../../ScenarioValidatioError';
 import { AstBuilderNode } from '../AstBuilderNode/AstBuilderNode';
-import { useGetNodeEvaluationErrorMessage } from '../ErrorMessage';
 import { RemoveButton } from '../RemoveButton';
 import { AddLogicalOperatorButton } from './AddLogicalOperatorButton';
 
@@ -54,7 +54,7 @@ export function RootAnd({
   rootAndViewModel: RootAndViewModel;
   viewOnly?: boolean;
 }) {
-  const getNodeEvaluationErrorMessage = useGetNodeEvaluationErrorMessage();
+  const getEvaluationErrorMessage = useGetOrAndNodeEvaluationErrorMessage();
   const [andChildrenErrors, andNonChildrenErrors] = separateChildrenErrors(
     rootAndViewModel.validation
   );
@@ -133,15 +133,15 @@ export function RootAnd({
             </Fragment>
           );
         })}
-
+      </div>
+      <div className="flex flex-row flex-wrap gap-2">
         {!viewOnly && (
           <AddLogicalOperatorButton onClick={appendAndChild} operator="and" />
         )}
-      </div>
-      <div className="flex flex-row flex-wrap gap-2">
+
         {andNonChildrenErrors.map((error, index) => (
           <ScenarioValidationError key={index}>
-            {getNodeEvaluationErrorMessage(error)}
+            {getEvaluationErrorMessage(error)}
           </ScenarioValidationError>
         ))}
       </div>

--- a/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootOrWithAnd.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootOrWithAnd.tsx
@@ -9,12 +9,12 @@ import {
   type AstBuilder,
   type EditorNodeViewModel,
 } from '@app-builder/services/editor/ast-editor';
+import { useGetOrAndNodeEvaluationErrorMessage } from '@app-builder/services/validation';
 import clsx from 'clsx';
 import React from 'react';
 
 import { ScenarioValidationError } from '../../ScenarioValidatioError';
 import { AstBuilderNode } from '../AstBuilderNode/AstBuilderNode';
-import { useGetNodeEvaluationErrorMessage } from '../ErrorMessage';
 import { RemoveButton } from '../RemoveButton';
 import { AddLogicalOperatorButton } from './AddLogicalOperatorButton';
 
@@ -72,7 +72,7 @@ export function RootOrWithAnd({
   rootOrWithAndViewModel: RootOrWithAndViewModel;
   viewOnly?: boolean;
 }) {
-  const getNodeEvaluationErrorMessage = useGetNodeEvaluationErrorMessage();
+  const getEvaluationErrorMessage = useGetOrAndNodeEvaluationErrorMessage();
   function appendOrChild() {
     builder.appendChild(rootOrWithAndViewModel.orNodeId, NewOrChild());
   }
@@ -143,33 +143,34 @@ export function RootOrWithAnd({
               );
             })}
 
-            {!viewOnly && (
-              <div className={clsx('my-1', !isFirstAndChild && 'ml-[50px]')}>
-                <AddLogicalOperatorButton
-                  onClick={appendAndChild}
-                  operator="and"
-                />
-              </div>
-            )}
-
             <div className="flex flex-row flex-wrap gap-2">
+              {!viewOnly && (
+                <div className={clsx('my-1', !isFirstAndChild && 'ml-[50px]')}>
+                  <AddLogicalOperatorButton
+                    onClick={appendAndChild}
+                    operator="and"
+                  />
+                </div>
+              )}
+
               {andNonChildrenErrors.map((error, index) => (
                 <ScenarioValidationError key={index}>
-                  {getNodeEvaluationErrorMessage(error)}
+                  {getEvaluationErrorMessage(error)}
                 </ScenarioValidationError>
               ))}
             </div>
           </React.Fragment>
         );
       })}
-      {!viewOnly && (
-        <AddLogicalOperatorButton onClick={appendOrChild} operator="or" />
-      )}
 
       <div className="flex flex-row flex-wrap gap-2">
+        {!viewOnly && (
+          <AddLogicalOperatorButton onClick={appendOrChild} operator="or" />
+        )}
+
         {rootOrNonChildrenErrors.map((error, index) => (
           <ScenarioValidationError key={index}>
-            {getNodeEvaluationErrorMessage(error)}
+            {getEvaluationErrorMessage(error)}
           </ScenarioValidationError>
         ))}
       </div>

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view/trigger.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view/trigger.tsx
@@ -239,11 +239,13 @@ export default function Trigger() {
 
       <div className="flex flex-row items-end justify-between gap-2">
         <div className="flex min-h-[40px] flex-row flex-wrap gap-1">
-          {scenarioValidation.trigger.errors.map((error) => (
-            <ScenarioValidationError key={error}>
-              {getScenarioEvaluationErrorMessage(error)}
-            </ScenarioValidationError>
-          ))}
+          {scenarioValidation.trigger.errors
+            .filter((error) => error != 'TRIGGER_CONDITION_REQUIRED')
+            .map((error) => (
+              <ScenarioValidationError key={error}>
+                {getScenarioEvaluationErrorMessage(error)}
+              </ScenarioValidationError>
+            ))}
         </div>
         <span>
           {editorMode === 'edit' && (

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/rules.$ruleId.tsx
@@ -200,7 +200,6 @@ export default function RuleEdit() {
   const errors = data?.errors;
 
   useEffect(() => {
-    validate(initialAst);
     if (!errors) return;
 
     R.forEachObj.indexed(errors.fieldErrors, (err, name) => {
@@ -385,11 +384,13 @@ function RuleEditContent({
 
         {ruleValidation.errors && (
           <div className="flex flex-row flex-wrap gap-1">
-            {ruleValidation.errors.map((error) => (
-              <ScenarioValidationError key={error}>
-                {getScenarioEvaluationErrorMessage(error)}
-              </ScenarioValidationError>
-            ))}
+            {ruleValidation.errors
+              .filter((error) => error != 'RULE_FORMULA_REQUIRED')
+              .map((error) => (
+                <ScenarioValidationError key={error}>
+                  {getScenarioEvaluationErrorMessage(error)}
+                </ScenarioValidationError>
+              ))}
           </div>
         )}
       </Paper.Container>

--- a/packages/app-builder/src/routes/ressources/scenarios/$scenarioId/$iterationId/rules/create.tsx
+++ b/packages/app-builder/src/routes/ressources/scenarios/$scenarioId/$iterationId/rules/create.tsx
@@ -1,4 +1,3 @@
-import { adaptNodeDto, NewEmptyRuleAstNode } from '@app-builder/models';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -26,7 +25,7 @@ export async function action({ request, params }: ActionArgs) {
     const { rule } = await apiClient.createScenarioIterationRule({
       scenarioIterationId: iterationId,
       displayOrder: 1,
-      formula_ast_expression: adaptNodeDto(NewEmptyRuleAstNode()),
+      formula_ast_expression: null,
       name: t('create_rule.default_name'),
       description: '',
       scoreModifier: 0,

--- a/packages/app-builder/src/services/editor/ast-editor.ts
+++ b/packages/app-builder/src/services/editor/ast-editor.ts
@@ -166,6 +166,11 @@ export function useAstBuilder({
     [onValidate]
   );
 
+  useEffect(() => {
+    validate(editorNodeViewModel);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const replaceOneNode = useCallback(
     (
       nodeId: string,

--- a/packages/app-builder/src/services/validation/scenario-validation-error-messages.ts
+++ b/packages/app-builder/src/services/validation/scenario-validation-error-messages.ts
@@ -1,5 +1,6 @@
 import { type EvaluationError } from '@app-builder/models';
 import { type ScenarioValidationErrorCodeDto } from '@marble-api';
+import { type TFunction } from 'i18next';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,54 +8,70 @@ export function useGetNodeEvaluationErrorMessage() {
   const { t } = useTranslation(['scenarios']);
 
   return useCallback(
+    (evaluationError: EvaluationError) =>
+      commonErrorMessages(t)(evaluationError),
+    [t]
+  );
+}
+
+export function useGetOrAndNodeEvaluationErrorMessage() {
+  const { t } = useTranslation(['scenarios']);
+
+  return useCallback(
     (evaluationError: EvaluationError) => {
       switch (evaluationError.error) {
-        case 'UNDEFINED_FUNCTION':
-          return t('scenarios:validation.evaluation_error.unknown_function');
         case 'WRONG_NUMBER_OF_ARGUMENTS':
-          return t(
-            'scenarios:validation.evaluation_error.wrong_number_of_arguments'
-          );
-        case 'MISSING_NAMED_ARGUMENT':
-          return t(
-            'scenarios:validation.evaluation_error.missing_named_argument'
-          );
-        case 'ARGUMENTS_MUST_BE_INT_OR_FLOAT':
-          return t(
-            'scenarios:validation.evaluation_error.arguments_must_be_int_or_float'
-          );
-        case 'ARGUMENT_MUST_BE_INTEGER':
-          return t(
-            'scenarios:validation.evaluation_error.argument_must_be_integer'
-          );
-        case 'ARGUMENT_MUST_BE_STRING':
-          return t(
-            'scenarios:validation.evaluation_error.argument_must_be_string'
-          );
-        case 'ARGUMENT_MUST_BE_BOOLEAN':
-          return t(
-            'scenarios:validation.evaluation_error.argument_must_be_boolean'
-          );
-        case 'ARGUMENT_MUST_BE_LIST':
-          return t(
-            'scenarios:validation.evaluation_error.argument_must_be_list'
-          );
-        case 'ARGUMENT_MUST_BE_CONVERTIBLE_TO_DURATION':
-          return t(
-            'scenarios:validation.evaluation_error.argument_must_be_convertible_to_duration'
-          );
-        case 'ARGUMENT_MUST_BE_TIME':
-          return t(
-            'scenarios:validation.evaluation_error.argument_must_be_time'
-          );
-
+          return t('scenarios:validation.decision.rule_formula_required');
         default:
-          return `${evaluationError.error}:${evaluationError.message}`;
+          return commonErrorMessages(t)(evaluationError);
       }
     },
     [t]
   );
 }
+
+const commonErrorMessages =
+  (t: TFunction<['scenarios']>) => (evaluationError: EvaluationError) => {
+    switch (evaluationError.error) {
+      case 'UNDEFINED_FUNCTION':
+        return t('scenarios:validation.evaluation_error.unknown_function');
+      case 'WRONG_NUMBER_OF_ARGUMENTS':
+        return t(
+          'scenarios:validation.evaluation_error.wrong_number_of_arguments'
+        );
+      case 'MISSING_NAMED_ARGUMENT':
+        return t(
+          'scenarios:validation.evaluation_error.missing_named_argument'
+        );
+      case 'ARGUMENTS_MUST_BE_INT_OR_FLOAT':
+        return t(
+          'scenarios:validation.evaluation_error.arguments_must_be_int_or_float'
+        );
+      case 'ARGUMENT_MUST_BE_INTEGER':
+        return t(
+          'scenarios:validation.evaluation_error.argument_must_be_integer'
+        );
+      case 'ARGUMENT_MUST_BE_STRING':
+        return t(
+          'scenarios:validation.evaluation_error.argument_must_be_string'
+        );
+      case 'ARGUMENT_MUST_BE_BOOLEAN':
+        return t(
+          'scenarios:validation.evaluation_error.argument_must_be_boolean'
+        );
+      case 'ARGUMENT_MUST_BE_LIST':
+        return t('scenarios:validation.evaluation_error.argument_must_be_list');
+      case 'ARGUMENT_MUST_BE_CONVERTIBLE_TO_DURATION':
+        return t(
+          'scenarios:validation.evaluation_error.argument_must_be_convertible_to_duration'
+        );
+      case 'ARGUMENT_MUST_BE_TIME':
+        return t('scenarios:validation.evaluation_error.argument_must_be_time');
+
+      default:
+        return `${evaluationError.error}:${evaluationError.message}`;
+    }
+  };
 
 export function useGetScenarioEvaluationErrorMessage() {
   const { t } = useTranslation(['scenarios']);


### PR DESCRIPTION
## 1st commit

- on init, validate the form so we have the validation associated to `NewEmptyRuleAstNode` (put by the front)
<img width="750" alt="on create" src="https://github.com/checkmarble/marble-frontend/assets/17145012/95ac00b5-9203-497c-802f-8e279f04bc76">

- when i save without modification, I can still see the rooOr error
<img width="741" alt="on save, without modification" src="https://github.com/checkmarble/marble-frontend/assets/17145012/8e98e857-78de-41ac-98ca-651d01978c08">

## 2nd commit
To avoid the double errors, we can send `NewEmptyRuleAstNode` to the backend when creating a rule (open to discussion)