### PR TITLE
fix: durationUnit should never fail

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/DurationUnitSelect.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/DurationUnitSelect.tsx
@@ -1,4 +1,3 @@
-import { type EvaluationError } from '@app-builder/models';
 import { Select } from '@ui-design-system';
 import { useTranslation } from 'react-i18next';
 
@@ -8,11 +7,9 @@ export type DurationUnit = (typeof options)[number];
 export const DurationUnitSelect = ({
   value,
   onChange,
-  validation,
 }: {
   value: DurationUnit | null;
   onChange: (value: DurationUnit) => void;
-  validation: { errors: EvaluationError[] };
 }) => {
   const { t } = useTranslation(['scenarios']);
   return (
@@ -24,7 +21,6 @@ export const DurationUnitSelect = ({
       }}
       placeholder="..."
       className="min-w-fit"
-      borderColor={validation.errors.length > 0 ? 'red-100' : 'grey-10'}
     >
       {options.map((option) => (
         <Select.Item key={option} value={option}>

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/Modal.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/Modal.tsx
@@ -39,7 +39,6 @@ export interface TimeAddViewModal {
     timestampField: { errors: EvaluationError[] };
     sign: { errors: EvaluationError[] };
     duration: { errors: EvaluationError[] };
-    durationUnit: { errors: EvaluationError[] };
   };
 }
 
@@ -86,7 +85,6 @@ export const adaptTimeAddViewModal = (
       timestampField: computeValidationForNamedChildren(vm, 'timestampField'),
       sign: computeValidationForNamedChildren(vm, 'sign'),
       duration: computeValidationForNamedChildren(vm, 'duration'),
-      durationUnit: computeValidationForNamedChildren(vm, 'durationUnit'),
     },
   };
 };
@@ -237,7 +235,6 @@ const TimeAddEditModalContent = ({
             <DurationUnitSelect
               value={value.durationUnit}
               onChange={(durationUnit) => setValue({ ...value, durationUnit })}
-              validation={value.validation.durationUnit}
             />
           </div>
           {value.validation.timestampField.errors.length > 0 && (
@@ -248,9 +245,6 @@ const TimeAddEditModalContent = ({
           )}
           {value.validation.duration.errors.length > 0 && (
             <ErrorMessage errors={value.validation.duration.errors} />
-          )}
-          {value.validation.durationUnit.errors.length > 0 && (
-            <ErrorMessage errors={value.validation.durationUnit.errors} />
           )}
         </div>
         <div className="flex flex-1 flex-row gap-2">


### PR DESCRIPTION
## Context

- DurationUnit is a UI concept, it can never be evaluated as an error in the backend
- Since we control its value and set its default, it can never fail