### PR TITLE
feat(Scenario): handle red-25 border colors

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Default.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Default.tsx
@@ -2,11 +2,11 @@ import {
   adaptAstNodeFromEditorViewModel,
   type AstBuilder,
   type EditorNodeViewModel,
+  getBorderColor,
 } from '@app-builder/services/editor/ast-editor';
 import clsx from 'clsx';
 
 import { stringifyAstNode } from '../utils';
-import { computeOperandErrors } from './Operand';
 
 export function Default({
   builder,
@@ -27,9 +27,7 @@ export function Default({
     <div
       aria-label={ariaLabel}
       data-border-color={
-        displayErrors && computeOperandErrors(editorNodeViewModel).length > 0
-          ? 'red-100'
-          : 'grey-10'
+        displayErrors ? getBorderColor(editorNodeViewModel) : 'grey-10'
       }
       className={clsx(
         'bg-grey-02 border-grey-02 flex h-fit min-h-[40px] w-fit min-w-[40px] items-center justify-between rounded border px-2 outline-none',

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
@@ -12,6 +12,7 @@ import { allAggregators } from '@app-builder/services/editor';
 import {
   adaptEditorNodeViewModel,
   type AstBuilder,
+  getBorderColor,
 } from '@app-builder/services/editor/ast-editor';
 import { Input } from '@ui-design-system';
 import { Search } from '@ui-icons';
@@ -28,7 +29,7 @@ import {
   isTimeAddEditorNodeViewModel,
   useEditTimeAdd,
 } from '../../TimeAddEdit/Modal';
-import { computeOperandErrors, type OperandViewModel } from '../Operand';
+import { type OperandViewModel } from '../Operand';
 import { OperandViewer } from '../OperandViewer';
 import { OperandDropdownMenu } from './OperandDropdownMenu';
 import { OperandEditorDiscoveryResults } from './OperandEditorDiscoveryResults';
@@ -61,11 +62,7 @@ export function OperandEditor({
           aria-label={ariaLabel}
         >
           <OperandViewer
-            borderColor={
-              computeOperandErrors(operandViewModel).length > 0
-                ? 'red-100'
-                : 'grey-10'
-            }
+            borderColor={getBorderColor(operandViewModel)}
             operandLabelledAst={labelledAst}
           />
         </OperandDropdownMenu.Trigger>

--- a/packages/app-builder/src/models/scenario-validation.ts
+++ b/packages/app-builder/src/models/scenario-validation.ts
@@ -3,6 +3,7 @@ import {
   findArgumentNameErrorsFromParent,
 } from '@app-builder/services/editor/ast-editor';
 import {
+  type EvaluationErrorCodeDto,
   type EvaluationErrorDto,
   type NodeEvaluationDto,
   type ScenarioValidationDto,
@@ -13,20 +14,7 @@ import invariant from 'tiny-invariant';
 
 import type { ConstantType } from './ast-node';
 
-export type EvaluationErrorCode =
-  | 'UNEXPECTED_ERROR'
-  | 'UNDEFINED_FUNCTION'
-  | 'WRONG_NUMBER_OF_ARGUMENTS'
-  | 'MISSING_NAMED_ARGUMENT'
-  | 'ARGUMENTS_MUST_BE_INT_OR_FLOAT'
-  | 'ARGUMENT_MUST_BE_INTEGER'
-  | 'ARGUMENT_MUST_BE_STRING'
-  | 'ARGUMENT_MUST_BE_BOOLEAN'
-  | 'ARGUMENT_MUST_BE_LIST'
-  | 'ARGUMENT_MUST_BE_CONVERTIBLE_TO_DURATION'
-  | 'ARGUMENT_MUST_BE_TIME'
-  | 'ARGUMENT_REQUIRED'
-  | 'FUNCTION_ERROR';
+export type EvaluationErrorCode = EvaluationErrorCodeDto | 'FUNCTION_ERROR';
 
 export interface EvaluationError {
   error: EvaluationErrorCode;

--- a/packages/app-builder/src/services/validation/scenario-validation-error-messages.ts
+++ b/packages/app-builder/src/services/validation/scenario-validation-error-messages.ts
@@ -1,5 +1,6 @@
 import { type EvaluationError } from '@app-builder/models';
 import { type ScenarioValidationErrorCodeDto } from '@marble-api';
+import { assertNever } from '@typescript-utils';
 import { type TFunction } from 'i18next';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -69,9 +70,15 @@ const commonErrorMessages =
         return t('scenarios:validation.evaluation_error.argument_must_be_time');
       case 'FUNCTION_ERROR':
         return t('scenarios:validation.evaluation_error.function_error');
-
-      default:
+      case 'ARGUMENT_REQUIRED':
+        return t('scenarios:validation.evaluation_error.argument_required');
+      case 'UNEXPECTED_ERROR':
         return `${evaluationError.error}:${evaluationError.message}`;
+      default:
+        assertNever(
+          '[EvaluationError] unhandled error code',
+          evaluationError.error
+        );
     }
   };
 


### PR DESCRIPTION
In this PR :
- handle `'red-25'` specific border display (= indexed or named errors for operands)
- use `assertNever` to identify unhandled error codes
- use generic for helpers on validation