### PR TITLE
Thomas/fix console error

### DIFF
--- a/packages/app-builder/src/routes/__builder/api.tsx
+++ b/packages/app-builder/src/routes/__builder/api.tsx
@@ -5,7 +5,6 @@ import { json, type LinksFunction, type LoaderArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { Button } from '@ui-design-system';
 import { Download, Harddrive } from '@ui-icons';
-import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import SwaggerUI from 'swagger-ui-react';


### PR DESCRIPTION
Fix a small console.error issue on the `/api` page.
Using a `<a/>` with `href` create an SSR incompatibility (a blob is created server side, that do not match the browser one).

Currently, when clicking on the link before the end of hydration, an error occure (cf first error in the screen capture) when trying to download the SSR blob created data.
Using a `Button` with the `downloadBlob` method fix the issues :
- Button is unclickable until hydration complete
- The blob is created asynchronously (on button click)

As a side effect, we now use a component from the DS.

<img width="716" alt="Screenshot 2023-10-17 at 15 39 21" src="https://github.com/checkmarble/marble-frontend/assets/40292402/20f669b8-a593-43e0-ad5d-f701f0c275e3">

Bonus: fix alignment issue using negative margin trick
<img width="469" alt="Screenshot 2023-10-17 at 16 00 34" src="https://github.com/checkmarble/marble-frontend/assets/40292402/96bb9678-ad8c-408f-8a71-fb0cc8144fcf">


NB: Another error occure on this page, due to the swagger package ([cf here for more information](https://github.com/swagger-api/swagger-ui/issues/5729))