### PR TITLE
Rename frontend cloud run service

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -55,11 +55,4 @@ jobs:
         run: |
           gcloud run deploy marble-frontend \
             --quiet \
-            --image="${{ env.TAG }}" \
-            --region="europe-west1" \
-            --allow-unauthenticated \
-            --service-account=${{ env.SERVICE_ACCOUNT }} \
-            --set-env-vars=ENV=${{ vars.ENV }},FIREBASE_API_KEY=${{ vars.FIREBASE_API_KEY }},FIREBASE_APP_ID=${{ vars.FIREBASE_APP_ID }},FIREBASE_AUTH_DOMAIN=${{ vars.FIREBASE_AUTH_DOMAIN }},FIREBASE_MESSAGING_SENDER_ID=${{ vars.FIREBASE_MESSAGING_SENDER_ID }},FIREBASE_PROJECT_ID=${{ vars.FIREBASE_PROJECT_ID }},FIREBASE_STORAGE_BUCKET=${{ vars.FIREBASE_STORAGE_BUCKET }},MARBLE_API_DOMAIN=${{ vars.MARBLE_API_DOMAIN }},NODE_ENV=${{ vars.NODE_ENV }},SESSION_MAX_AGE=${{ vars.SESSION_MAX_AGE }} \
-            --set-secrets=SESSION_SECRET=COOKIE_SESSION_SECRET:latest \
-            --port=8080 \
-            --min-instances=1
+            --image="${{ env.TAG }}"


### PR DESCRIPTION

cloud run service is now named `marble-frontend`

Also: simplify cloud run deployment by removing what is already configured by terraform