### PR TITLE
feat: disable activate button if errors

### DIFF
--- a/packages/app-builder/public/locales/en/common.json
+++ b/packages/app-builder/public/locales/en/common.json
@@ -12,7 +12,7 @@
   "errors.data.duplicate_field_name": "A field with this name already exist",
   "errors.data.duplicate_table_name": "A table with this name already exist",
   "errors.data.duplicate_link_name": "A link with this name already exist",
-  "errors.draft.invalid": "Invalid draft. Please check your draft for error messages, fix them and try again.",
+  "errors.draft.invalid": "This draft can't be published because it contains errors.",
   "cancel": "Cancel",
   "save": "Save",
   "delete": "Delete",

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view.tsx
@@ -9,7 +9,7 @@ import { VersionSelect } from '@app-builder/components/Scenario/Iteration/Versio
 import { sortScenarioIterations } from '@app-builder/models/scenario-iteration';
 import { useCurrentScenario } from '@app-builder/routes/__builder/scenarios/$scenarioId';
 import { CreateDraftIteration } from '@app-builder/routes/ressources/scenarios/$scenarioId/$iterationId/create_draft';
-import { DeploymentModal } from '@app-builder/routes/ressources/scenarios/deployment';
+import { DeploymentActions } from '@app-builder/routes/ressources/scenarios/deployment';
 import { useEditorMode } from '@app-builder/services/editor';
 import { serverServices } from '@app-builder/services/init.server';
 import {
@@ -76,7 +76,7 @@ export default function ScenarioEditLayout() {
   const withEditTag = editorMode === 'edit';
   const withCreateDraftIteration =
     canManageScenario && currentIteration.type !== 'draft';
-  const withDeploymentModal = canPublishScenario;
+  const withDeploymentActions = canPublishScenario;
 
   return (
     <ScenarioPage.Container>
@@ -104,11 +104,16 @@ export default function ScenarioEditLayout() {
               draftId={draftIteration?.id}
             />
           )}
-          {withDeploymentModal && (
-            <DeploymentModal
+          {withDeploymentActions && (
+            <DeploymentActions
               scenarioId={currentScenario.id}
               liveVersionId={currentScenario.liveVersionId}
               currentIteration={currentIteration}
+              hasScenarioErrors={
+                hasTriggerErrors(scenarioValidation) ||
+                hasRulesErrors(scenarioValidation) ||
+                hasDecisionErrors(scenarioValidation)
+              }
             />
           )}
         </div>

--- a/packages/app-builder/src/routes/ressources/scenarios/deployment.tsx
+++ b/packages/app-builder/src/routes/ressources/scenarios/deployment.tsx
@@ -12,6 +12,7 @@ import {
   Checkbox,
   HiddenInputs,
   Modal,
+  Tooltip,
 } from '@ui-design-system';
 import { Play, Pushtolive, Stop, Tick } from '@ui-icons';
 import { type Namespace, type ParseKeys } from 'i18next';
@@ -256,20 +257,19 @@ function ModalContent({
   );
 }
 
-export function DeploymentModal({
+const DeploymentModal = ({
   scenarioId,
   liveVersionId,
   currentIteration,
+  deploymentType,
 }: {
   scenarioId: string;
   liveVersionId?: string;
   currentIteration: SortedScenarioIteration;
-}) {
+  deploymentType: DeploymentType;
+}) => {
   const { t } = useTranslation(handle.i18n);
-
-  const deploymentType = getDeploymentType(currentIteration.type);
   const buttonConfig = getButtonConfig(deploymentType);
-
   return (
     <Modal.Root>
       <Modal.Trigger asChild>
@@ -286,6 +286,56 @@ export function DeploymentModal({
         />
       </Modal.Content>
     </Modal.Root>
+  );
+};
+
+const DisabledDeploymentButton = ({
+  deploymentType,
+}: {
+  deploymentType: DeploymentType;
+}) => {
+  const { t } = useTranslation(handle.i18n);
+  const buttonConfig = getButtonConfig(deploymentType);
+  return (
+    <Tooltip.Default
+      className="text-xs"
+      content={t('common:errors.draft.invalid')}
+    >
+      <Button {...buttonConfig.props} disabled>
+        <buttonConfig.icon.trigger height="24px" width="24px" />
+        {t(buttonConfig.label)}
+      </Button>
+    </Tooltip.Default>
+  );
+};
+
+export function DeploymentActions({
+  scenarioId,
+  liveVersionId,
+  currentIteration,
+  hasScenarioErrors,
+}: {
+  scenarioId: string;
+  liveVersionId?: string;
+  currentIteration: SortedScenarioIteration;
+  hasScenarioErrors: boolean;
+}) {
+  const deploymentType = getDeploymentType(currentIteration.type);
+
+  return (
+    <>
+      {hasScenarioErrors &&
+      ['activate', 'deactivate'].includes(deploymentType) ? (
+        <DisabledDeploymentButton deploymentType={deploymentType} />
+      ) : (
+        <DeploymentModal
+          scenarioId={scenarioId}
+          liveVersionId={liveVersionId}
+          currentIteration={currentIteration}
+          deploymentType={deploymentType}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Context

If there is errors on the scenario, it cannot be published but we don't want people to have to open the modal, etc, to know it. 
Therefore the button is disabled with an explanation tooltip

<img width="443" alt="Capture d’écran 2023-10-19 à 10 58 53" src="https://github.com/checkmarble/marble-frontend/assets/17145012/50740c49-6304-4841-a9b7-28e693472e2c">
