### PR TITLE
fix: remount page on version change

### DIFF
--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId.tsx
@@ -50,7 +50,7 @@ export default function CurrentScenarioIterationProvider() {
     <CurrentScenarioIterationContextProvider value={scenarioIteration}>
       <CurrentScenarioValidationContextProvider value={scenarioValidation}>
         <EditorModeContextProvider value={editorMode}>
-          <Outlet />
+          <Outlet key={scenarioIteration.id} />
         </EditorModeContextProvider>
       </CurrentScenarioValidationContextProvider>
     </CurrentScenarioIterationContextProvider>


### PR DESCRIPTION
## Context

When we change the version, we navigate to a new url, which successfully re-trigger the loaders, but Remix does not remount the component on navigation.
The value of `scenarioIteration` was correct but the values contained in the state (for instead the schedule or the trigger rule) would not change, because React was not "notified" something had changed.

The fix consists of setting a key depending on the navigation on the Outlet element for React knows when something changes and it has to re-mount the page.

More info on this [Remix discussion](https://github.com/remix-run/remix/discussions/4535)