### PR TITLE
fix: use SENTRY_AUTH_TOKEN on tag push

### DIFF
--- a/.github/workflows/tags_push.yaml
+++ b/.github/workflows/tags_push.yaml
@@ -27,3 +27,4 @@ jobs:
       version: ${{ github.ref_name }}
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY_PRODUCTION }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Prod build is failing