### PR TITLE
fix(auth): fix unhandled promise rejection errors

### DIFF
--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId.tsx
@@ -21,18 +21,16 @@ export async function loader({ request, params }: LoaderArgs) {
 
   const iterationId = fromParams(params, 'iterationId');
 
-  const scenarioIterationPromise = scenario.getScenarioIteration({
-    iterationId,
-  });
+  const [scenarioIteration, scenarioValidation] = await Promise.all([
+    scenario.getScenarioIteration({
+      iterationId,
+    }),
+    scenario.validate({
+      iterationId,
+    }),
+  ]);
 
-  const scenarioValidationPromise = scenario.validate({
-    iterationId,
-  });
-
-  return json({
-    scenarioIteration: await scenarioIterationPromise,
-    scenarioValidation: await scenarioValidationPromise,
-  });
+  return json({ scenarioIteration, scenarioValidation });
 }
 
 export default function CurrentScenarioIterationProvider() {

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view.tsx
@@ -40,12 +40,12 @@ export async function loader({ request, params }: LoaderArgs) {
 
   const scenarioId = fromParams(params, 'scenarioId');
 
-  const scenarioIterationsPromise = scenario.listScenarioIterations({
+  const scenarioIterations = await scenario.listScenarioIterations({
     scenarioId,
   });
 
   return json({
-    scenarioIterations: await scenarioIterationsPromise,
+    scenarioIterations,
   });
 }
 

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view/trigger.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view/trigger.tsx
@@ -55,28 +55,35 @@ export async function loader({ request, params }: LoaderArgs) {
 
   const scenarioId = fromParams(params, 'scenarioId');
 
-  const operatorsPromise = editor.listOperators({
-    scenarioId,
-  });
-
-  const identifiersPromise = editor.listIdentifiers({
-    scenarioId,
-  });
-
-  const dataModelPromise = apiClient.getDataModel();
-  const { custom_lists } = await apiClient.listCustomLists();
-  const organizationPromise = organization.getCurrentOrganization();
-  const { scheduled_executions } = await apiClient.listScheduledExecutions({
-    scenarioId,
-  });
+  const [
+    operators,
+    identifiers,
+    dataModel,
+    customLists,
+    currentOrganization,
+    scheduledExecutions,
+  ] = await Promise.all([
+    editor.listOperators({
+      scenarioId,
+    }),
+    editor.listIdentifiers({
+      scenarioId,
+    }),
+    apiClient.getDataModel(),
+    apiClient.listCustomLists(),
+    organization.getCurrentOrganization(),
+    apiClient.listScheduledExecutions({
+      scenarioId,
+    }),
+  ]);
 
   return json({
-    identifiers: await identifiersPromise,
-    operators: await operatorsPromise,
-    dataModel: adaptDataModelDto((await dataModelPromise).data_model),
-    customLists: custom_lists,
-    organization: await organizationPromise,
-    scheduledExecutions: scheduled_executions,
+    identifiers,
+    operators,
+    dataModel: adaptDataModelDto(dataModel.data_model),
+    customLists: customLists.custom_lists,
+    organization: currentOrganization,
+    scheduledExecutions: scheduledExecutions.scheduled_executions,
   });
 }
 

--- a/packages/app-builder/src/services/auth/auth.server.ts
+++ b/packages/app-builder/src/services/auth/auth.server.ts
@@ -152,7 +152,7 @@ export function makeAuthenticationServerService(
     const user = session.get('user');
     if (
       !marbleToken ||
-      marbleToken.expires_in > new Date().toISOString() ||
+      marbleToken.expires_at < new Date().toISOString() ||
       !user
     ) {
       if (options.failureRedirect) throw redirect(options.failureRedirect);

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -1981,13 +1981,13 @@ components:
       required:
         - access_token
         - token_type
-        - expires_in
+        - expires_at
       properties:
         access_token:
           type: string
         token_type:
           type: string
-        expires_in:
+        expires_at:
           type: string
           format: date-time
     CredentialsDto:

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -16,7 +16,7 @@ export const servers = {
 export type Token = {
     access_token: string;
     token_type: string;
-    expires_in: string;
+    expires_at: string;
 };
 export type CredentialsDto = {
     credentials: {


### PR DESCRIPTION
In this PR, we solve multiple stability issues in the frontend :
1. typo in the `openapi.yaml` file resulting in a bad check for token expiracy
2. fix in th inequality (not catch before due to 1.)
3. handling of // queries with Promise.all to get a "fail fast" behaviour necessary to prevent unhandled promise rejection errors
> Caveat: this PR introduce stability on the current auth service. It doesn't adress the refresh issue

**Improvements:**
1 & 2 will help to logout fast the user when there is an issue with auth status:
- when the cookie is missing (ex: expired cookie so the browser do not send it, cleared cookie by the browser, not auth...)
- when the token is expired

3 will prevent loaders to crash when several // requests failled (ex: multiple 401) and return the first catched error.
ATM, a 401 return a `redirect(/logout)` that trigger the logout correctly
