### PR TITLE
fix: do not display launch button on past iteration

### DIFF
--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view/trigger.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view/trigger.tsx
@@ -203,7 +203,7 @@ export default function Trigger() {
     );
   };
 
-  const isLive = scenarioIteration.version !== null;
+  const isLive = scenarioIteration.id == scenario.liveVersionId;
   const pendingExecutions = scheduledExecutions.filter((execution) =>
     ['pending', 'processing'].includes(execution.status)
   );


### PR DESCRIPTION
## Context

"Launch Now" was displayed for all iterations that weren't draft, which includes past, offline version.
Now it makes sure it's displayed only on the live version 