### PR TITLE
feat: Add Now function to Operand & TimeAdd

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/Operand.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/Operand.tsx
@@ -7,6 +7,7 @@ import {
   isDatabaseAccess,
   isPayload,
   isTimeAdd,
+  isTimeNow,
   isUndefinedAstNode,
 } from '@app-builder/models';
 import {
@@ -29,6 +30,7 @@ export function isEditableOperand(node: AstNode): boolean {
     isPayload(node) ||
     isAggregation(node) ||
     isTimeAdd(node) ||
+    isTimeNow(node) ||
     isUndefinedAstNode(node)
   );
 }

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
@@ -13,6 +13,7 @@ import {
   type TableModel,
 } from '@app-builder/models';
 import { newTimeAddLabelledAst } from '@app-builder/models/LabelledAst/TimeAdd';
+import { newTimeNowLabelledAst } from '@app-builder/models/LabelledAst/TimeNow';
 import { allAggregators } from '@app-builder/services/editor';
 import {
   adaptAstNodeFromEditorViewModel,
@@ -151,6 +152,7 @@ const OperandEditorContent = forwardRef<
     const functions = [
       ...allAggregators.map(newAggregatorLabelledAst),
       newTimeAddLabelledAst(),
+      newTimeNowLabelledAst(),
     ];
 
     const enumOptionValues = getEnumOptionsFromNeighbour({

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/TimestampField.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/TimestampField.tsx
@@ -2,11 +2,13 @@ import {
   type EvaluationError,
   isDatabaseAccess,
   isPayload,
+  isTimeNow,
   type LabelledAst,
   newDatabaseAccessorsLabelledAst,
   newPayloadAccessorsLabelledAst,
   NewUndefinedAstNode,
 } from '@app-builder/models';
+import { newTimeNowLabelledAst } from '@app-builder/models/LabelledAst/TimeNow';
 import {
   adaptAstNodeFromEditorViewModel,
   adaptEditorNodeViewModel,
@@ -49,7 +51,7 @@ export const TimestampField = ({
       ...databaseAccessors,
     ].filter((labelledAst) => labelledAst.dataType == 'Timestamp');
 
-    return timestampFieldOptions;
+    return [newTimeNowLabelledAst(), ...timestampFieldOptions];
   }, [
     builder.input.dataModel,
     builder.input.identifiers.databaseAccessors,
@@ -81,6 +83,8 @@ export const TimestampField = ({
       node,
     });
   }
+
+  if (node && isTimeNow(node)) initialValue = newTimeNowLabelledAst();
 
   return (
     <TimestampFieldCombobox

--- a/packages/app-builder/src/models/LabelledAst/LabelledAst.ts
+++ b/packages/app-builder/src/models/LabelledAst/LabelledAst.ts
@@ -8,6 +8,7 @@ import {
   isDatabaseAccess,
   isPayload,
   isTimeAdd,
+  isTimeNow,
   isUndefinedAstNode,
 } from '../ast-node';
 import { type DataType, type EnumValue, type TableModel } from '../data-model';
@@ -22,6 +23,7 @@ import { newDatabaseAccessorsLabelledAst } from './DatabaseAccessors';
 import { getAstNodeDisplayName } from './getAstNodeDisplayName';
 import { newPayloadAccessorsLabelledAst } from './PayloadAccessor';
 import { newTimeAddLabelledAst } from './TimeAdd';
+import { newTimeNowLabelledAst } from './TimeNow';
 import { newUndefinedLabelledAst } from './Undefined';
 
 //TODO(combobox): find a better naming
@@ -92,6 +94,10 @@ export function adaptLabelledAst(
 
   if (isTimeAdd(node)) {
     return newTimeAddLabelledAst(node);
+  }
+
+  if (isTimeNow(node)) {
+    return newTimeNowLabelledAst(node);
   }
 
   if (isUndefinedAstNode(node)) {

--- a/packages/app-builder/src/models/LabelledAst/TimeAdd.ts
+++ b/packages/app-builder/src/models/LabelledAst/TimeAdd.ts
@@ -3,11 +3,14 @@ import {
   getPayloadAccessorsDisplayName,
   isDatabaseAccess,
   isPayload,
+  isTimeNow,
   type LabelledAst,
   NewTimeAddAstNode,
   type TimeAddAstNode,
 } from '@app-builder/models';
 import { Temporal } from 'temporal-polyfill';
+
+import { TimeNowName } from './TimeNow';
 
 export function newTimeAddLabelledAst(
   node: TimeAddAstNode = NewTimeAddAstNode()
@@ -35,6 +38,10 @@ const getTimeAddName = (node: TimeAddAstNode): string => {
     timestamp = getPayloadAccessorsDisplayName(
       node.namedChildren['timestampField']
     );
+  }
+
+  if (isTimeNow(node.namedChildren['timestampField'])) {
+    timestamp = TimeNowName;
   }
 
   if (sign === '' || isoDuration === '' || timestamp === '') {

--- a/packages/app-builder/src/models/LabelledAst/TimeNow.ts
+++ b/packages/app-builder/src/models/LabelledAst/TimeNow.ts
@@ -1,0 +1,16 @@
+import { NewTimeNowAstNode, type TimeNowAstNode } from '../ast-node';
+import { type LabelledAst } from './LabelledAst';
+
+export function newTimeNowLabelledAst(
+  node: TimeNowAstNode = NewTimeNowAstNode()
+): LabelledAst {
+  return {
+    name: TimeNowName,
+    description: 'The time when the scenario is run',
+    operandType: 'Function',
+    dataType: 'unknown',
+    astNode: node,
+  };
+}
+
+export const TimeNowName = 'Now';

--- a/packages/app-builder/src/models/ast-node.ts
+++ b/packages/app-builder/src/models/ast-node.ts
@@ -198,6 +198,7 @@ export interface TimeAddAstNode {
 export type TimestampFieldAstNode =
   | DatabaseAccessAstNode
   | PayloadAstNode
+  | TimeNowAstNode
   | UndefinedAstNode;
 
 export function NewTimeAddAstNode(
@@ -221,7 +222,28 @@ export function NewTimeAddAstNode(
   };
 }
 
-export const functionNodeNames = [aggregationAstNodeName, timeAddAstNodeName];
+const timeNowAstNodeName = 'TimeNow';
+export interface TimeNowAstNode {
+  name: typeof timeNowAstNodeName;
+  constant?: undefined;
+  children: [];
+  namedChildren: Record<string, never>;
+}
+
+export function NewTimeNowAstNode(): TimeNowAstNode {
+  return {
+    name: timeNowAstNodeName,
+    constant: undefined,
+    children: [],
+    namedChildren: {},
+  };
+}
+
+export const functionNodeNames = [
+  aggregationAstNodeName,
+  timeAddAstNodeName,
+  timeNowAstNodeName,
+];
 
 export function isDatabaseAccess(node: AstNode): node is DatabaseAccessAstNode {
   return node.name === databaseAccessAstNodeName;
@@ -243,6 +265,10 @@ export function isCustomListAccess(
 
 export function isTimeAdd(node: AstNode): node is TimeAddAstNode {
   return node.name === timeAddAstNodeName;
+}
+
+export function isTimeNow(node: AstNode): node is TimeNowAstNode {
+  return node.name === timeNowAstNodeName;
 }
 
 export interface OrAndGroupAstNode {


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-392/add-the-now-operator)

The backend was already providing the TimeNow() function, we just had to display it.
 
<img width="597" alt="Capture d’écran 2023-11-29 à 16 01 59" src="https://github.com/checkmarble/marble-frontend/assets/17145012/d510ac80-1f68-4602-a977-7051a81bdcb5">

<img width="521" alt="Capture d’écran 2023-11-29 à 16 13 22" src="https://github.com/checkmarble/marble-frontend/assets/17145012/6bc51184-9bae-41fa-929e-06e2b5f16ea0">

