### PR TITLE
feat(chatlio): add chatlio script

### DIFF
--- a/packages/app-builder/package.json
+++ b/packages/app-builder/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@remix-run/dev": "^1.19.3",
     "@remix-run/eslint-config": "^1.19.3",
+    "@segment/analytics-next": "^1.60.0",
     "@sentry/cli": "^2.21.2",
     "@types/autosuggest-highlight": "^3.2.0",
     "@types/qs": "^6.9.8",
@@ -45,7 +46,7 @@
     "@remix-run/node": "^1.19.3",
     "@remix-run/react": "^1.19.3",
     "@remix-run/serve": "^1.19.3",
-    "@segment/analytics-next": "^1.60.0",
+    "@segment/snippet": "^5.0.1",
     "@sentry/remix": "^7.74.0",
     "@tanstack/react-table": "^8.10.6",
     "autosuggest-highlight": "^3.3.4",

--- a/packages/app-builder/src/root.tsx
+++ b/packages/app-builder/src/root.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 import {
   AuthenticityTokenProvider,
   createAuthenticityToken,
+  ExternalScripts,
 } from 'remix-utils';
 import { Tooltip } from 'ui-design-system';
 import { LogoStandard } from 'ui-icons';
@@ -29,6 +30,8 @@ import { ErrorComponent } from './components/ErrorComponent';
 import { getToastMessage, MarbleToaster } from './components/MarbleToaster';
 import { serverServices } from './services/init.server';
 import { useSegmentPageTracking } from './services/segment';
+import { getSegmentScript } from './services/segment/segment.server';
+import { SegmentScript } from './services/segment/SegmentScript';
 import tailwindStyles from './tailwind.css';
 import { getClientEnvVars } from './utils/environment.server';
 
@@ -75,6 +78,7 @@ export const loader = async ({ request }: LoaderArgs) => {
       locale,
       csrf,
       toastMessage,
+      segmentScript: getSegmentScript(),
     },
     {
       headers: [
@@ -140,7 +144,8 @@ export function ErrorBoundary() {
 }
 
 function App() {
-  const { locale, ENV, toastMessage, csrf } = useLoaderData<typeof loader>();
+  const { locale, ENV, toastMessage, csrf, segmentScript } =
+    useLoaderData<typeof loader>();
 
   const { i18n } = useTranslation(handle.i18n);
 
@@ -155,6 +160,8 @@ function App() {
       <head>
         <Meta />
         <Links />
+        <SegmentScript script={segmentScript} />
+        <ExternalScripts />
       </head>
       <body className="selection:text-grey-00 h-screen w-full overflow-hidden antialiased selection:bg-purple-100">
         <AuthenticityTokenProvider token={csrf}>

--- a/packages/app-builder/src/routes/__builder.tsx
+++ b/packages/app-builder/src/routes/__builder.tsx
@@ -4,6 +4,8 @@ import {
   Sidebar,
   type SidebarLinkProps,
 } from '@app-builder/components';
+import { ChatlioWidget } from '@app-builder/services/chatlio/ChatlioWidget';
+import { chatlioScript } from '@app-builder/services/chatlio/script';
 import { serverServices } from '@app-builder/services/init.server';
 import { OrganizationUsersContextProvider } from '@app-builder/services/organization/organization-users';
 import {
@@ -77,6 +79,7 @@ export async function loader({ request }: LoaderArgs) {
 
 export const handle = {
   i18n: ['common', ...navigationI18n] satisfies Namespace,
+  scripts: () => [chatlioScript],
 };
 
 export default function Builder() {
@@ -90,6 +93,8 @@ export default function Builder() {
 
   return (
     <PermissionsProvider userPermissions={user.permissions}>
+      <ChatlioWidget />
+
       <OrganizationUsersContextProvider orgUsers={orgUsers}>
         <div className="flex h-full flex-1 flex-row overflow-hidden">
           <header

--- a/packages/app-builder/src/services/chatlio/ChatlioWidget.tsx
+++ b/packages/app-builder/src/services/chatlio/ChatlioWidget.tsx
@@ -1,0 +1,5 @@
+export function ChatlioWidget() {
+  return (
+    <chatlio-widget widgetid="4aef4109-4ac2-4499-590d-511078df07fd"></chatlio-widget>
+  );
+}

--- a/packages/app-builder/src/services/chatlio/chatlio.d.ts
+++ b/packages/app-builder/src/services/chatlio/chatlio.d.ts
@@ -1,0 +1,10 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    ['chatlio-widget']: ChatlioWidget;
+  }
+
+  // More info here: https://chatlio.com/docs/api-v1/
+  interface ChatlioWidget {
+    widgetid: string;
+  }
+}

--- a/packages/app-builder/src/services/chatlio/script.ts
+++ b/packages/app-builder/src/services/chatlio/script.ts
@@ -1,0 +1,6 @@
+export const chatlioScript = {
+  type: 'text/javascript',
+  async: true,
+  src: 'https://js.chatlio.com/widget.js',
+  suppressHydrationWarning: true,
+};

--- a/packages/app-builder/src/services/segment/SegmentScript.tsx
+++ b/packages/app-builder/src/services/segment/SegmentScript.tsx
@@ -1,0 +1,10 @@
+export function SegmentScript({ script }: { script: string }) {
+  return (
+    <script
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{
+        __html: script,
+      }}
+    />
+  );
+}

--- a/packages/app-builder/src/services/segment/index.tsx
+++ b/packages/app-builder/src/services/segment/index.tsx
@@ -4,15 +4,14 @@ import { useEffect } from 'react';
 import { useHydrated } from 'remix-utils';
 
 import getPageViewNameAndProps from './getPageviewNameAndProps';
-import { analytics } from './segment.client';
 
 export function useSegmentIdentification(user: CurrentUser) {
   const isHydrated = useHydrated();
   useEffect(() => {
     if (isHydrated) {
-      void analytics.identify(user.actorIdentity.userId);
+      void window.analytics.identify(user.actorIdentity.userId);
       if (user.actorIdentity.userId) {
-        void analytics.track('Logged In');
+        void window.analytics.track('Logged In');
       }
     }
   }, [user.actorIdentity.userId, user.organizationId, isHydrated]);
@@ -28,7 +27,7 @@ export function useSegmentPageTracking() {
       const tracking = getPageViewNameAndProps(thisPage);
       if (!tracking) return;
       const { name, properties } = tracking;
-      void analytics.page(name, properties);
+      void window.analytics.page(name, properties);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location, thisPage.id, isHydrated]);
@@ -37,5 +36,5 @@ export function useSegmentPageTracking() {
 }
 
 export const segment = {
-  reset: () => analytics.reset(),
+  reset: () => window.analytics.reset(),
 };

--- a/packages/app-builder/src/services/segment/segment.client.tsx
+++ b/packages/app-builder/src/services/segment/segment.client.tsx
@@ -1,6 +1,0 @@
-import { getClientEnv } from '@app-builder/utils/environment.client';
-import { AnalyticsBrowser } from '@segment/analytics-next';
-
-export const analytics = AnalyticsBrowser.load({
-  writeKey: getClientEnv('SEGMENT_WRITE_KEY'),
-});

--- a/packages/app-builder/src/services/segment/segment.d.ts
+++ b/packages/app-builder/src/services/segment/segment.d.ts
@@ -1,0 +1,7 @@
+import { type AnalyticsSnippet } from '@segment/analytics-next';
+
+declare global {
+  interface Window {
+    analytics: AnalyticsSnippet;
+  }
+}

--- a/packages/app-builder/src/services/segment/segment.server.ts
+++ b/packages/app-builder/src/services/segment/segment.server.ts
@@ -1,0 +1,15 @@
+import { getServerEnv } from '@app-builder/utils/environment.server';
+import { min } from '@segment/snippet';
+
+export function getSegmentScript() {
+  return min({
+    apiKey: getServerEnv('SEGMENT_WRITE_KEY'),
+
+    // TODO(GDPR): uncomment to lazy load segment after GDPR consent
+    // Ressource to implement in house cookie consent banner: https://github.com/remix-run/examples/tree/main/gdpr-cookie-consent
+    // load: false,
+
+    // page tracking is done manually
+    page: false,
+  });
+}

--- a/packages/app-builder/src/utils/environment.client.ts
+++ b/packages/app-builder/src/utils/environment.client.ts
@@ -14,7 +14,6 @@ export type ClientEnvVars = {
   MARBLE_APP_DOMAIN: string;
   SENTRY_DSN: string;
   SENTRY_ENVIRONMENT: string;
-  SEGMENT_WRITE_KEY: string;
 };
 
 export function getClientEnv<K extends keyof ClientEnvVars>(

--- a/packages/app-builder/src/utils/environment.server.ts
+++ b/packages/app-builder/src/utils/environment.server.ts
@@ -91,6 +91,5 @@ export function getClientEnvVars(): ClientEnvVars {
     MARBLE_APP_DOMAIN: getServerEnv('MARBLE_APP_DOMAIN'),
     SENTRY_DSN: getServerEnv('SENTRY_DSN'),
     SENTRY_ENVIRONMENT: getServerEnv('SENTRY_ENVIRONMENT'),
-    SEGMENT_WRITE_KEY: getServerEnv('SEGMENT_WRITE_KEY'),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,9 @@ importers:
       '@remix-run/serve':
         specifier: ^1.19.3
         version: 1.19.3
-      '@segment/analytics-next':
-        specifier: ^1.60.0
-        version: 1.60.0
+      '@segment/snippet':
+        specifier: ^5.0.1
+        version: 5.0.1
       '@sentry/remix':
         specifier: ^7.74.0
         version: 7.74.0(@remix-run/node@1.19.3)(@remix-run/react@1.19.3)(react@18.2.0)
@@ -246,6 +246,9 @@ importers:
       '@remix-run/eslint-config':
         specifier: ^1.19.3
         version: 1.19.3(eslint@8.44.0)(react@18.2.0)(typescript@5.1.6)
+      '@segment/analytics-next':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@sentry/cli':
         specifier: ^2.21.2
         version: 2.21.2
@@ -3589,14 +3592,14 @@ packages:
   /@lukeed/csprng@1.1.0:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
-    dev: false
+    dev: true
 
   /@lukeed/uuid@2.0.1:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
     dependencies:
       '@lukeed/csprng': 1.1.0
-    dev: false
+    dev: true
 
   /@mdx-js/react@2.3.0(react@18.2.0):
     resolution: {integrity: sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==}
@@ -3615,6 +3618,22 @@ packages:
       pump: 3.0.0
       tar-fs: 2.1.1
     dev: true
+
+  /@ndhoule/each@2.0.1:
+    resolution: {integrity: sha512-wHuJw6x+rF6Q9Skgra++KccjBozCr9ymtna0FhxmV/8xT/hZ2ExGYR8SV8prg8x4AH/7mzDYErNGIVHuzHeybw==}
+    dependencies:
+      '@ndhoule/keys': 2.0.0
+    dev: false
+
+  /@ndhoule/keys@2.0.0:
+    resolution: {integrity: sha512-vtCqKBC1Av6dsBA8xpAO+cgk051nfaI+PnmTZep2Px0vYrDvpUmLxv7z40COlWH5yCpu3gzNhepk+02yiQiZNw==}
+    dev: false
+
+  /@ndhoule/map@2.0.1:
+    resolution: {integrity: sha512-WOEf2An9mL4DVY6NHgaRmFC82pZGrmzW4I0hpPPdczDP4Gp5+Q1Nny77x3w0qzENA8+cbgd9+Lx2ClSTLvkB0g==}
+    dependencies:
+      '@ndhoule/each': 2.0.1
+    dev: false
 
   /@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1:
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -4973,7 +4992,7 @@ packages:
       '@lukeed/uuid': 2.0.1
       dset: 3.1.3
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@segment/analytics-next@1.60.0:
     resolution: {integrity: sha512-ujYs5kbDBsRqX7KrkrLZ8hizXKZfng2vrUEUoStGekUkAwDYYV9ZaKm7WEXZbIzzBh9R/C0l7ihK3DGN7PA2UQ==}
@@ -4992,13 +5011,13 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@segment/analytics.js-video-plugins@0.2.1:
     resolution: {integrity: sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==}
     dependencies:
       unfetch: 3.1.2
-    dev: false
+    dev: true
 
   /@segment/facade@3.4.10:
     resolution: {integrity: sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==}
@@ -5007,16 +5026,22 @@ packages:
       inherits: 2.0.4
       new-date: 1.0.3
       obj-case: 0.2.1
-    dev: false
+    dev: true
 
   /@segment/isodate-traverse@1.1.1:
     resolution: {integrity: sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==}
     dependencies:
       '@segment/isodate': 1.0.3
-    dev: false
+    dev: true
 
   /@segment/isodate@1.0.3:
     resolution: {integrity: sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==}
+    dev: true
+
+  /@segment/snippet@5.0.1:
+    resolution: {integrity: sha512-BbDEVW0Lq7RiP9y3xilnmRYFozhLPeqO7MnOpMUzIYAloYlIXry5mbsgi+qxk4c8XmAGrmMt0w1V0iy6B4FpIg==}
+    dependencies:
+      '@ndhoule/map': 2.0.1
     dev: false
 
   /@segment/tsub@2.0.0:
@@ -5029,7 +5054,7 @@ packages:
       tiny-hashes: 1.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@sentry-internal/tracing@7.74.0:
     resolution: {integrity: sha512-JK6IRGgdtZjswGfaGIHNWIThffhOHzVIIaGmglui+VFIzOsOqePjoxaDV0MEvzafxXZD7eWqGE5RGuZ0n6HFVg==}
@@ -5189,7 +5214,7 @@ packages:
       '@stdlib/assert-has-float32array-support': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/array-float64@0.0.6:
     resolution: {integrity: sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==}
@@ -5197,7 +5222,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-has-float64array-support': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/array-uint16@0.0.6:
     resolution: {integrity: sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==}
@@ -5205,7 +5230,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-has-uint16array-support': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/array-uint32@0.0.6:
     resolution: {integrity: sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==}
@@ -5213,7 +5238,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-has-uint32array-support': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/array-uint8@0.0.7:
     resolution: {integrity: sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==}
@@ -5221,7 +5246,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-has-uint8array-support': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-float32array-support@0.0.8:
     resolution: {integrity: sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==}
@@ -5235,7 +5260,7 @@ packages:
       '@stdlib/fs-read-file': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-float64array-support@0.0.8:
     resolution: {integrity: sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==}
@@ -5246,7 +5271,7 @@ packages:
       '@stdlib/assert-is-float64array': 0.0.8
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-node-buffer-support@0.0.8:
     resolution: {integrity: sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==}
@@ -5257,13 +5282,13 @@ packages:
       '@stdlib/assert-is-buffer': 0.0.8
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-own-property@0.0.7:
     resolution: {integrity: sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-symbol-support@0.0.8:
     resolution: {integrity: sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==}
@@ -5273,7 +5298,7 @@ packages:
     dependencies:
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-tostringtag-support@0.0.9:
     resolution: {integrity: sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==}
@@ -5284,7 +5309,7 @@ packages:
       '@stdlib/assert-has-symbol-support': 0.0.8
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-uint16array-support@0.0.8:
     resolution: {integrity: sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==}
@@ -5296,7 +5321,7 @@ packages:
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/constants-uint16-max': 0.0.7
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-uint32array-support@0.0.8:
     resolution: {integrity: sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==}
@@ -5308,7 +5333,7 @@ packages:
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/constants-uint32-max': 0.0.7
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-has-uint8array-support@0.0.8:
     resolution: {integrity: sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==}
@@ -5320,7 +5345,7 @@ packages:
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/constants-uint8-max': 0.0.7
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-array@0.0.7:
     resolution: {integrity: sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==}
@@ -5328,7 +5353,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-big-endian@0.0.7:
     resolution: {integrity: sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==}
@@ -5340,7 +5365,7 @@ packages:
       '@stdlib/array-uint8': 0.0.7
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-boolean@0.0.8:
     resolution: {integrity: sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==}
@@ -5350,7 +5375,7 @@ packages:
       '@stdlib/assert-has-tostringtag-support': 0.0.9
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-buffer@0.0.8:
     resolution: {integrity: sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==}
@@ -5358,7 +5383,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-is-object-like': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-float32array@0.0.8:
     resolution: {integrity: sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==}
@@ -5366,7 +5391,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-float64array@0.0.8:
     resolution: {integrity: sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==}
@@ -5374,7 +5399,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-function@0.0.8:
     resolution: {integrity: sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==}
@@ -5382,7 +5407,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-type-of': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-little-endian@0.0.7:
     resolution: {integrity: sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==}
@@ -5394,7 +5419,7 @@ packages:
       '@stdlib/array-uint8': 0.0.7
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-number@0.0.7:
     resolution: {integrity: sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==}
@@ -5405,7 +5430,7 @@ packages:
       '@stdlib/number-ctor': 0.0.7
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-object-like@0.0.8:
     resolution: {integrity: sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==}
@@ -5414,7 +5439,7 @@ packages:
     dependencies:
       '@stdlib/assert-tools-array-function': 0.0.7
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-object@0.0.8:
     resolution: {integrity: sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==}
@@ -5422,7 +5447,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-is-array': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-plain-object@0.0.7:
     resolution: {integrity: sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==}
@@ -5434,7 +5459,7 @@ packages:
       '@stdlib/assert-is-object': 0.0.8
       '@stdlib/utils-get-prototype-of': 0.0.7
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-regexp-string@0.0.9:
     resolution: {integrity: sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==}
@@ -5449,7 +5474,7 @@ packages:
       '@stdlib/regexp-eol': 0.0.7
       '@stdlib/regexp-regexp': 0.0.8
       '@stdlib/streams-node-stdin': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-regexp@0.0.7:
     resolution: {integrity: sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==}
@@ -5458,7 +5483,7 @@ packages:
     dependencies:
       '@stdlib/assert-has-tostringtag-support': 0.0.9
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-string@0.0.8:
     resolution: {integrity: sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==}
@@ -5468,7 +5493,7 @@ packages:
       '@stdlib/assert-has-tostringtag-support': 0.0.9
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-uint16array@0.0.8:
     resolution: {integrity: sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==}
@@ -5476,7 +5501,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-uint32array@0.0.8:
     resolution: {integrity: sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==}
@@ -5484,7 +5509,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-is-uint8array@0.0.8:
     resolution: {integrity: sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==}
@@ -5492,7 +5517,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/assert-tools-array-function@0.0.7:
     resolution: {integrity: sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==}
@@ -5500,7 +5525,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-is-array': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/buffer-ctor@0.0.7:
     resolution: {integrity: sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==}
@@ -5508,7 +5533,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-has-node-buffer-support': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/buffer-from-string@0.0.8:
     resolution: {integrity: sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==}
@@ -5519,7 +5544,7 @@ packages:
       '@stdlib/assert-is-string': 0.0.8
       '@stdlib/buffer-ctor': 0.0.7
       '@stdlib/string-format': 0.0.3
-    dev: false
+    dev: true
 
   /@stdlib/cli-ctor@0.0.3:
     resolution: {integrity: sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==}
@@ -5529,7 +5554,7 @@ packages:
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
       '@stdlib/utils-noop': 0.0.14
       minimist: 1.2.8
-    dev: false
+    dev: true
 
   /@stdlib/complex-float32@0.0.7:
     resolution: {integrity: sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==}
@@ -5543,7 +5568,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/complex-float64@0.0.8:
     resolution: {integrity: sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==}
@@ -5557,7 +5582,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/complex-reim@0.0.6:
     resolution: {integrity: sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==}
@@ -5570,7 +5595,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/complex-reimf@0.0.1:
     resolution: {integrity: sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==}
@@ -5583,7 +5608,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-exponent-bias@0.0.8:
     resolution: {integrity: sha512-IzBJQw9hYgWCki7VoC/zJxEA76Nmf8hmY+VkOWnJ8IyfgTXClgY8tfDGS1cc4l/hCOEllxGp9FRvVdn24A5tKQ==}
@@ -5593,7 +5618,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-high-word-abs-mask@0.0.1:
     resolution: {integrity: sha512-1vy8SUyMHFBwqUUVaZFA7r4/E3cMMRKSwsaa/EZ15w7Kmc01W/ZmaaTLevRcIdACcNgK+8i8813c8H7LScXNcQ==}
@@ -5603,7 +5628,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-high-word-exponent-mask@0.0.8:
     resolution: {integrity: sha512-z28/EQERc0VG7N36bqdvtrRWjFc8600PKkwvl/nqx6TpKAzMXNw55BS1xT4C28Sa9Z7uBWeUj3UbIFedbkoyMw==}
@@ -5613,7 +5638,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-high-word-sign-mask@0.0.1:
     resolution: {integrity: sha512-hmTr5caK1lh1m0eyaQqt2Vt3y+eEdAx57ndbADEbXhxC9qSGd0b4bLSzt/Xp4MYBYdQkHAE/BlkgUiRThswhCg==}
@@ -5623,7 +5648,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-max-base2-exponent-subnormal@0.0.8:
     resolution: {integrity: sha512-YGBZykSiXFebznnJfWFDwhho2Q9xhUWOL+X0lZJ4ItfTTo40W6VHAyNYz98tT/gJECFype0seNzzo1nUxCE7jQ==}
@@ -5633,7 +5658,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-max-base2-exponent@0.0.8:
     resolution: {integrity: sha512-xBAOtso1eiy27GnTut2difuSdpsGxI8dJhXupw0UukGgvy/3CSsyNm+a1Suz/dhqK4tPOTe5QboIdNMw5IgXKQ==}
@@ -5643,7 +5668,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-min-base2-exponent-subnormal@0.0.8:
     resolution: {integrity: sha512-bt81nBus/91aEqGRQBenEFCyWNsf8uaxn4LN1NjgkvY92S1yVxXFlC65fJHsj9FTqvyZ+uj690/gdMKUDV3NjQ==}
@@ -5653,7 +5678,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-ninf@0.0.8:
     resolution: {integrity: sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==}
@@ -5664,7 +5689,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-pinf@0.0.8:
     resolution: {integrity: sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==}
@@ -5674,7 +5699,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-float64-smallest-normal@0.0.8:
     resolution: {integrity: sha512-Qwxpn5NA3RXf+mQcffCWRcsHSPTUQkalsz0+JDpblDszuz2XROcXkOdDr5LKgTAUPIXsjOgZzTsuRONENhsSEg==}
@@ -5684,25 +5709,25 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/constants-uint16-max@0.0.7:
     resolution: {integrity: sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/constants-uint32-max@0.0.7:
     resolution: {integrity: sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/constants-uint8-max@0.0.7:
     resolution: {integrity: sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/fs-exists@0.0.8:
     resolution: {integrity: sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==}
@@ -5714,7 +5739,7 @@ packages:
       '@stdlib/fs-read-file': 0.0.8
       '@stdlib/process-cwd': 0.0.8
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/fs-read-file@0.0.8:
     resolution: {integrity: sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==}
@@ -5724,7 +5749,7 @@ packages:
     dependencies:
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/fs-resolve-parent-path@0.0.8:
     resolution: {integrity: sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==}
@@ -5741,7 +5766,7 @@ packages:
       '@stdlib/fs-read-file': 0.0.8
       '@stdlib/process-cwd': 0.0.8
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/math-base-assert-is-infinite@0.0.9:
     resolution: {integrity: sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==}
@@ -5753,7 +5778,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/math-base-assert-is-nan@0.0.8:
     resolution: {integrity: sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==}
@@ -5763,7 +5788,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/math-base-napi-binary@0.0.8:
     resolution: {integrity: sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==}
@@ -5777,7 +5802,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/math-base-napi-unary@0.0.9:
     resolution: {integrity: sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==}
@@ -5791,7 +5816,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/math-base-special-abs@0.0.6:
     resolution: {integrity: sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==}
@@ -5803,7 +5828,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/math-base-special-copysign@0.0.7:
     resolution: {integrity: sha512-7Br7oeuVJSBKG8BiSk/AIRFTBd2sbvHdV3HaqRj8tTZHX8BQomZ3Vj4Qsiz3kPyO4d6PpBLBTYlGTkSDlGOZJA==}
@@ -5819,7 +5844,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/math-base-special-ldexp@0.0.5:
     resolution: {integrity: sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==}
@@ -5841,13 +5866,13 @@ packages:
       '@stdlib/number-float64-base-to-words': 0.0.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/number-ctor@0.0.7:
     resolution: {integrity: sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/number-float64-base-exponent@0.0.6:
     resolution: {integrity: sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==}
@@ -5859,7 +5884,7 @@ packages:
       '@stdlib/number-float64-base-get-high-word': 0.0.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/number-float64-base-from-words@0.0.6:
     resolution: {integrity: sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==}
@@ -5873,7 +5898,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/number-float64-base-get-high-word@0.0.6:
     resolution: {integrity: sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==}
@@ -5887,7 +5912,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/number-float64-base-normalize@0.0.9:
     resolution: {integrity: sha512-+rm7RQJEj8zHkqYFE2a6DgNQSB5oKE/IydHAajgZl40YB91BoYRYf/ozs5/tTwfy2Fc04+tIpSfFtzDr4ZY19Q==}
@@ -5903,7 +5928,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/number-float64-base-to-float32@0.0.7:
     resolution: {integrity: sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==}
@@ -5913,7 +5938,7 @@ packages:
       '@stdlib/array-float32': 0.0.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/number-float64-base-to-words@0.0.7:
     resolution: {integrity: sha512-7wsYuq+2MGp9rAkTnQ985rah7EJI9TfgHrYSSd4UIu4qIjoYmWIKEhIDgu7/69PfGrls18C3PxKg1pD/v7DQTg==}
@@ -5930,7 +5955,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/os-byte-order@0.0.7:
     resolution: {integrity: sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==}
@@ -5945,7 +5970,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/os-float-word-order@0.0.7:
     resolution: {integrity: sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==}
@@ -5959,7 +5984,7 @@ packages:
       '@stdlib/utils-library-manifest': 0.0.8
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/process-cwd@0.0.8:
     resolution: {integrity: sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==}
@@ -5969,7 +5994,7 @@ packages:
     dependencies:
       '@stdlib/cli-ctor': 0.0.3
       '@stdlib/fs-read-file': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/process-read-stdin@0.0.7:
     resolution: {integrity: sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==}
@@ -5982,7 +6007,7 @@ packages:
       '@stdlib/buffer-from-string': 0.0.8
       '@stdlib/streams-node-stdin': 0.0.7
       '@stdlib/utils-next-tick': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/regexp-eol@0.0.7:
     resolution: {integrity: sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==}
@@ -5994,7 +6019,7 @@ packages:
       '@stdlib/assert-is-plain-object': 0.0.7
       '@stdlib/assert-is-string': 0.0.8
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/regexp-extended-length-path@0.0.7:
     resolution: {integrity: sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==}
@@ -6002,7 +6027,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/regexp-function-name@0.0.7:
     resolution: {integrity: sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==}
@@ -6010,7 +6035,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/regexp-regexp@0.0.8:
     resolution: {integrity: sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==}
@@ -6018,25 +6043,25 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/utils-define-nonenumerable-read-only-property': 0.0.7
-    dev: false
+    dev: true
 
   /@stdlib/streams-node-stdin@0.0.7:
     resolution: {integrity: sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/string-base-format-interpolate@0.0.4:
     resolution: {integrity: sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/string-base-format-tokenize@0.0.4:
     resolution: {integrity: sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/string-format@0.0.3:
     resolution: {integrity: sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==}
@@ -6045,7 +6070,7 @@ packages:
     dependencies:
       '@stdlib/string-base-format-interpolate': 0.0.4
       '@stdlib/string-base-format-tokenize': 0.0.4
-    dev: false
+    dev: true
 
   /@stdlib/string-lowercase@0.0.9:
     resolution: {integrity: sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==}
@@ -6059,7 +6084,7 @@ packages:
       '@stdlib/process-read-stdin': 0.0.7
       '@stdlib/streams-node-stdin': 0.0.7
       '@stdlib/string-format': 0.0.3
-    dev: false
+    dev: true
 
   /@stdlib/string-replace@0.0.11:
     resolution: {integrity: sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==}
@@ -6079,13 +6104,13 @@ packages:
       '@stdlib/string-format': 0.0.3
       '@stdlib/utils-escape-regexp-string': 0.0.9
       '@stdlib/utils-regexp-from-string': 0.0.9
-    dev: false
+    dev: true
 
   /@stdlib/types@0.0.14:
     resolution: {integrity: sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/utils-constructor-name@0.0.8:
     resolution: {integrity: sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==}
@@ -6095,7 +6120,7 @@ packages:
       '@stdlib/assert-is-buffer': 0.0.8
       '@stdlib/regexp-function-name': 0.0.7
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/utils-convert-path@0.0.8:
     resolution: {integrity: sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==}
@@ -6112,7 +6137,7 @@ packages:
       '@stdlib/streams-node-stdin': 0.0.7
       '@stdlib/string-lowercase': 0.0.9
       '@stdlib/string-replace': 0.0.11
-    dev: false
+    dev: true
 
   /@stdlib/utils-define-nonenumerable-read-only-property@0.0.7:
     resolution: {integrity: sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==}
@@ -6121,7 +6146,7 @@ packages:
     dependencies:
       '@stdlib/types': 0.0.14
       '@stdlib/utils-define-property': 0.0.9
-    dev: false
+    dev: true
 
   /@stdlib/utils-define-property@0.0.9:
     resolution: {integrity: sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==}
@@ -6129,7 +6154,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/types': 0.0.14
-    dev: false
+    dev: true
 
   /@stdlib/utils-escape-regexp-string@0.0.9:
     resolution: {integrity: sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==}
@@ -6138,7 +6163,7 @@ packages:
     dependencies:
       '@stdlib/assert-is-string': 0.0.8
       '@stdlib/string-format': 0.0.3
-    dev: false
+    dev: true
 
   /@stdlib/utils-get-prototype-of@0.0.7:
     resolution: {integrity: sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==}
@@ -6147,7 +6172,7 @@ packages:
     dependencies:
       '@stdlib/assert-is-function': 0.0.8
       '@stdlib/utils-native-class': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/utils-global@0.0.7:
     resolution: {integrity: sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==}
@@ -6155,7 +6180,7 @@ packages:
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
     dependencies:
       '@stdlib/assert-is-boolean': 0.0.8
-    dev: false
+    dev: true
 
   /@stdlib/utils-library-manifest@0.0.8:
     resolution: {integrity: sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==}
@@ -6170,7 +6195,7 @@ packages:
       resolve: 1.22.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@stdlib/utils-native-class@0.0.8:
     resolution: {integrity: sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==}
@@ -6179,19 +6204,19 @@ packages:
     dependencies:
       '@stdlib/assert-has-own-property': 0.0.7
       '@stdlib/assert-has-tostringtag-support': 0.0.9
-    dev: false
+    dev: true
 
   /@stdlib/utils-next-tick@0.0.8:
     resolution: {integrity: sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/utils-noop@0.0.14:
     resolution: {integrity: sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-    dev: false
+    dev: true
 
   /@stdlib/utils-regexp-from-string@0.0.9:
     resolution: {integrity: sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==}
@@ -6201,7 +6226,7 @@ packages:
       '@stdlib/assert-is-string': 0.0.8
       '@stdlib/regexp-regexp': 0.0.8
       '@stdlib/string-format': 0.0.3
-    dev: false
+    dev: true
 
   /@stdlib/utils-type-of@0.0.8:
     resolution: {integrity: sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==}
@@ -6210,7 +6235,7 @@ packages:
     dependencies:
       '@stdlib/utils-constructor-name': 0.0.8
       '@stdlib/utils-global': 0.0.7
-    dev: false
+    dev: true
 
   /@storybook/addon-actions@7.4.6(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-SsqZr3js5NinKPnC8AeNI7Ij+Q6fIl9tRdRmSulEgjksjOg7E5S1/Wsn5Bb2CCgj7MaX6VxGyC7s3XskQtDiIQ==}
@@ -10097,6 +10122,7 @@ packages:
 
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: true
 
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -10195,7 +10221,7 @@ packages:
   /dset@3.1.3:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
     engines: {node: '>=4'}
-    dev: false
+    dev: true
 
   /duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
@@ -12801,7 +12827,7 @@ packages:
   /js-cookie@3.0.1:
     resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
     engines: {node: '>=12'}
-    dev: false
+    dev: true
 
   /js-file-download@0.4.12:
     resolution: {integrity: sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==}
@@ -14091,7 +14117,7 @@ packages:
     resolution: {integrity: sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==}
     dependencies:
       '@segment/isodate': 1.0.3
-    dev: false
+    dev: true
 
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -14291,7 +14317,7 @@ packages:
 
   /obj-case@0.2.1:
     resolution: {integrity: sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==}
-    dev: false
+    dev: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -16509,7 +16535,7 @@ packages:
 
   /spark-md5@3.0.2:
     resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
-    dev: false
+    dev: true
 
   /spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
@@ -17116,7 +17142,7 @@ packages:
 
   /tiny-hashes@1.0.1:
     resolution: {integrity: sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==}
-    dev: false
+    dev: true
 
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
@@ -17470,11 +17496,11 @@ packages:
 
   /unfetch@3.1.2:
     resolution: {integrity: sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==}
-    dev: false
+    dev: true
 
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
-    dev: false
+    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
Easy to integrate, painfull to make it work with Segment ^^'

Key learnings :
- for any 3rd party script to load in `<head>`: use `handle.script` from `remix-utils`
- when a 3rd party integration raise hydration warnings, use `suppressHydrationWarning` prop

Ressources :
- https://github.com/sergiodxa/remix-utils?tab=readme-ov-file#external-scripts
- https://github.com/facebook/react/issues/24430
- https://react.dev/reference/react-dom/hydrate#suppressing-unavoidable-hydration-mismatch-errors

NB: we may loose Chatlio Segment integration by moving Segment workspace to EU region