### PR TITLE
feat(Decisions): better add to case abstraction

### DIFF
--- a/packages/app-builder/public/locales/en/common.json
+++ b/packages/app-builder/public/locales/en/common.json
@@ -14,7 +14,7 @@
   "errors.data.duplicate_table_name": "A table with this name already exist",
   "errors.data.duplicate_link_name": "A link with this name already exist",
   "errors.draft.invalid": "This draft can't be published because it contains errors.",
-  "errors.add_to_case.invalid": "The decision already belongs to a case",
+  "errors.add_to_case.invalid": "A decision already belongs to a case",
   "cancel": "Cancel",
   "save": "Save",
   "delete": "Delete",

--- a/packages/app-builder/src/components/Decisions/DecisionRightPanel.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionRightPanel.tsx
@@ -4,7 +4,6 @@ import {
 } from '@app-builder/components/RightPanel';
 import { AddToCase } from '@app-builder/routes/ressources/cases/add-to-case';
 import { createSimpleContext } from '@app-builder/utils/create-context';
-import { type DialogTriggerProps } from '@radix-ui/react-dialog';
 import { useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollArea } from 'ui-design-system';
@@ -115,30 +114,7 @@ function DecisionRightPanelContent() {
   );
 }
 
-function DecisionRightPanelTrigger({
-  onClick,
-  decisionIds,
-  ...otherProps
-}: {
-  decisionIds: Data['decisionIds'] | (() => Data['decisionIds']);
-} & DialogTriggerProps) {
-  const { onTriggerClick } = useDecisionRightPanelContext();
-
-  return (
-    <RightPanel.Trigger
-      onClick={(e) => {
-        onTriggerClick({
-          decisionIds:
-            typeof decisionIds === 'function' ? decisionIds() : decisionIds,
-        });
-        onClick?.(e);
-      }}
-      {...otherProps}
-    />
-  );
-}
-
 export const DecisionRightPanel = {
   Root: DecisionRightPanelRoot,
-  Trigger: DecisionRightPanelTrigger,
+  Trigger: RightPanel.Trigger,
 };

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -6,7 +6,13 @@ import { Link, useNavigate } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { type DecisionDetail } from 'marble-api';
-import { useImperativeHandle, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Checkbox, Table, useVirtualTable } from 'ui-design-system';
 
@@ -37,15 +43,19 @@ type WithoutSelectable = {
 
 export function useSelectedDecisionIds() {
   const [rowSelection, setRowSelection] = useState({});
-  const getSelectedDecisionIdsRef = useRef<() => string[]>(() => []);
+  const getSelectedDecisionsRef = useRef<() => DecisionDetail[]>(() => []);
+  const getSelectedDecisions = useCallback(
+    () => getSelectedDecisionsRef.current(),
+    [],
+  );
 
   return {
     hasSelection: Object.keys(rowSelection).length > 0,
-    getSelectedDecisionIds: getSelectedDecisionIdsRef.current,
+    getSelectedDecisions,
     selectionProps: {
       rowSelection,
       setRowSelection,
-      getSelectedDecisionIdsRef,
+      getSelectedDecisionsRef,
     },
   };
 }
@@ -168,9 +178,8 @@ export function DecisionsList({
   });
 
   useImperativeHandle(
-    selectionProps?.getSelectedDecisionIdsRef,
-    () => () =>
-      table.getSelectedRowModel().flatRows.map((row) => row.original.id),
+    selectionProps?.getSelectedDecisionsRef,
+    () => () => table.getSelectedRowModel().flatRows.map((row) => row.original),
   );
 
   return (

--- a/packages/app-builder/src/routes/__builder/decisions/$decisionId.tsx
+++ b/packages/app-builder/src/routes/__builder/decisions/$decisionId.tsx
@@ -7,6 +7,7 @@ import {
   OutcomePanel,
   Page,
   RulesDetail,
+  useDecisionRightPanelContext,
 } from '@app-builder/components';
 import { ScorePanel } from '@app-builder/components/Decisions/Score';
 import { TriggerObjectDetail } from '@app-builder/components/Decisions/TriggerObjectDetail';
@@ -69,14 +70,7 @@ export default function DecisionPage() {
               </span>
             </CopyToClipboardButton>
           </div>
-          {!decision.case ? (
-            <DecisionRightPanel.Trigger asChild decisionIds={[decision.id]}>
-              <Button>
-                <Plus />
-                {t('decisions:add_to_case')}
-              </Button>
-            </DecisionRightPanel.Trigger>
-          ) : null}
+          {!decision.case ? <AddToCase decisionIds={[decision.id]} /> : null}
         </Page.Header>
         <Page.Content>
           <div className="grid grid-cols-[2fr_1fr] gap-4 lg:gap-8">
@@ -93,6 +87,24 @@ export default function DecisionPage() {
         </Page.Content>
       </Page.Container>
     </DecisionRightPanel.Root>
+  );
+}
+
+function AddToCase({ decisionIds }: { decisionIds: string[] }) {
+  const { t } = useTranslation(decisionsI18n);
+  const { onTriggerClick } = useDecisionRightPanelContext();
+  return (
+    <DecisionRightPanel.Trigger
+      asChild
+      onClick={() => {
+        onTriggerClick({ decisionIds });
+      }}
+    >
+      <Button>
+        <Plus />
+        {t('decisions:add_to_case')}
+      </Button>
+    </DecisionRightPanel.Trigger>
   );
 }
 


### PR DESCRIPTION
Small rework of the AddToCase abstraction button so we can handle a toast error to prevent adding already linked decision.

>NB: not really usefull ATM, but I wanted to test this with the react-table selection handling (using a `useImperativeHandle` under the hood, I must admit this is a hook I rarelly use so it was a good occasion 😛)

![output](https://github.com/checkmarble/marble-frontend/assets/40292402/a2a16c02-7afa-4f6b-9672-47693b935f2c)

