### PR TITLE
feat(nav): add expanded/collapsed button to nav bar

### DIFF
--- a/packages/app-builder/public/locales/en/navigation.json
+++ b/packages/app-builder/public/locales/en/navigation.json
@@ -9,6 +9,8 @@
   "scenario.rules": "Rules",
   "scenario.decision": "Decision",
   "data": "Your Data",
+  "expanded": "Expanded",
+  "collapsed": "Collapsed",
   "api": "Marble API",
   "scheduledExecutions": "Scheduled Executions",
   "caseManager": "Case Manager",

--- a/packages/app-builder/src/components/Navigation.tsx
+++ b/packages/app-builder/src/components/Navigation.tsx
@@ -2,18 +2,19 @@ import { NavLink } from '@remix-run/react';
 import { cva } from 'class-variance-authority';
 import clsx from 'clsx';
 import { type Namespace, type ParseKeys } from 'i18next';
+import type React from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const navigationI18n = ['navigation'] satisfies Namespace;
 
-export type SidebarLinkProps = {
+export interface SidebarLinkProps {
   Icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
   labelTKey: ParseKeys<['navigation']>;
   to: string;
-};
+}
 
 export const sidebarLink = cva(
-  'text-s flex flex-row items-center gap-2 rounded-sm p-2 font-medium',
+  'text-s flex flex-row items-center gap-2 rounded-sm p-2 font-medium w-full',
   {
     variants: {
       isActive: {
@@ -27,40 +28,52 @@ export const sidebarLink = cva(
   },
 );
 
-function SidebarLink({ Icon, labelTKey, to }: SidebarLinkProps) {
+export function SidebarLink({ Icon, labelTKey, to }: SidebarLinkProps) {
   const { t } = useTranslation(navigationI18n);
 
   return (
     <NavLink className={({ isActive }) => sidebarLink({ isActive })} to={to}>
-      <Icon height="24px" width="24px" />
-      {t(labelTKey)}
+      <Icon height="24px" width="24px" className="shrink-0" />
+      <span className="line-clamp-1 text-left opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
+        {t(labelTKey)}
+      </span>
     </NavLink>
   );
 }
 
-function SidebarNav({
-  children,
-  ...navProps
-}: React.HTMLAttributes<HTMLElement>) {
+export interface SidebarButtonProps
+  extends Omit<React.ComponentPropsWithoutRef<'button'>, 'children'> {
+  Icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  labelTKey: ParseKeys<['navigation']>;
+}
+
+export function SidebarButton({
+  Icon,
+  labelTKey,
+  className,
+  ...props
+}: SidebarButtonProps) {
+  const { t } = useTranslation(navigationI18n);
+
   return (
-    <nav {...navProps}>
-      <ul className="flex flex-col gap-2">{children}</ul>
-    </nav>
+    <li>
+      <button className={sidebarLink({ className })} {...props}>
+        <Icon height="24px" width="24px" className="shrink-0" />
+        <span className="line-clamp-1 text-left opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
+          {t(labelTKey)}
+        </span>
+      </button>
+    </li>
   );
 }
 
-export const Sidebar = {
-  Nav: SidebarNav,
-  Link: SidebarLink,
-};
-
-export type ScenariosLinkProps = {
+export interface ScenariosLinkProps {
   Icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
   labelTKey: ParseKeys<['navigation']>;
   to: string;
-};
+}
 
-function ScenariosLink({ Icon, labelTKey, to }: SidebarLinkProps) {
+export function ScenariosLink({ Icon, labelTKey, to }: SidebarLinkProps) {
   const { t } = useTranslation(navigationI18n);
 
   return (
@@ -80,22 +93,3 @@ function ScenariosLink({ Icon, labelTKey, to }: SidebarLinkProps) {
     </NavLink>
   );
 }
-
-function ScenariosNav({
-  children,
-  ...navProps
-}: React.HTMLAttributes<HTMLElement>) {
-  return (
-    <nav {...navProps}>
-      <ul className="flex flex-row gap-2">{children}</ul>
-    </nav>
-  );
-}
-
-export const Scenarios = {
-  Nav: ScenariosNav,
-  Link: ScenariosLink,
-};
-
-export const Decisions = Scenarios;
-export type DecisionsLinkProps = ScenariosLinkProps;

--- a/packages/app-builder/src/routes/__builder.tsx
+++ b/packages/app-builder/src/routes/__builder.tsx
@@ -1,8 +1,8 @@
 import {
   navigationI18n,
   PermissionsProvider,
-  Sidebar,
-  type SidebarLinkProps,
+  SidebarButton,
+  SidebarLink,
 } from '@app-builder/components';
 import { isAdmin } from '@app-builder/models';
 import { ChatlioWidget } from '@app-builder/services/chatlio/ChatlioWidget';
@@ -20,10 +20,12 @@ import { json, type LoaderArgs } from '@remix-run/node';
 import { Form, Outlet, useLoaderData } from '@remix-run/react';
 import clsx from 'clsx';
 import { type Namespace } from 'i18next';
+import { type SVGProps, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Avatar, Button, ScrollArea } from 'ui-design-system';
 import {
   Arrow2Down,
+  ArrowRight,
   CaseManager,
   Decision,
   Harddrive,
@@ -39,36 +41,6 @@ import {
 import { getRoute } from '../utils/routes';
 import { useRefreshToken } from './ressources/auth/refresh';
 import { LanguagePicker } from './ressources/user/language';
-
-const LINKS: SidebarLinkProps[] = [
-  // { labelTKey: 'navigation:home', to: 'home', Icon: Home },
-  {
-    labelTKey: 'navigation:scenarios',
-    to: getRoute('/scenarios'),
-    Icon: Scenarios,
-  },
-  { labelTKey: 'navigation:lists', to: getRoute('/lists'), Icon: Lists },
-  {
-    labelTKey: 'navigation:decisions',
-    to: getRoute('/decisions'),
-    Icon: Decision,
-  },
-  {
-    labelTKey: 'navigation:scheduledExecutions',
-    to: getRoute('/scheduled-executions'),
-    Icon: ScheduledExecution,
-  },
-  {
-    labelTKey: 'navigation:caseManager',
-    to: getRoute('/cases'),
-    Icon: CaseManager,
-  },
-];
-
-const BOTTOM_LINKS: SidebarLinkProps[] = [
-  { labelTKey: 'navigation:data', to: getRoute('/data'), Icon: Harddrive },
-  { labelTKey: 'navigation:api', to: getRoute('/api'), Icon: World },
-];
 
 export async function loader({ request }: LoaderArgs) {
   const { authService } = serverServices;
@@ -100,30 +72,39 @@ export default function Builder() {
   // This is only added here to prevent "auto login" on /login pages... (/logout do not trigger logout from Firebase)
   useRefreshToken();
 
+  const [expanded, setExpanded] = useState(true);
+
   return (
     <PermissionsProvider userPermissions={user.permissions}>
       <OrganizationUsersContextProvider orgUsers={orgUsers}>
         <OrganizationTagsContextProvider orgTags={orgTags}>
           <div className="flex h-full flex-1 flex-row overflow-hidden">
             <header
-              className={clsx(
-                'bg-grey-00 border-r-grey-10 flex max-h-screen w-full shrink-0 flex-col border-r',
-                'max-w-min md:max-w-[235px]',
-              )}
+              aria-expanded={expanded}
+              className="bg-grey-00 border-r-grey-10 group/nav flex max-h-screen w-14 shrink-0 flex-col border-r transition-all aria-expanded:w-[235px]"
             >
-              <div className="px-2 pb-9 pt-3">
+              <div className="h-24 px-2 pt-3">
                 <Popover.Root>
                   <Popover.Trigger asChild>
-                    <button className="hover:bg-grey-05 active:bg-grey-10 group flex w-full flex-row items-center justify-between gap-2 rounded-md p-2">
-                      <LogoStandard
-                        className="max-h-12"
-                        width="100%"
-                        height="100%"
-                        preserveAspectRatio="xMinYMid meet"
-                        aria-labelledby="marble"
-                      />
+                    <button className="hover:bg-grey-05 active:bg-grey-10 group flex w-full flex-row items-center justify-between gap-2 overflow-hidden rounded-md p-2">
+                      <div className="inline-flex">
+                        <LogoStandard
+                          width={undefined}
+                          height={undefined}
+                          aria-labelledby="marble"
+                          viewBox="0 0 80 80"
+                          className="w-6 shrink-0 transition-all group-aria-expanded/nav:w-12"
+                        />
+                        <LogoStandard
+                          width={undefined}
+                          height={undefined}
+                          aria-labelledby="marble"
+                          viewBox="80 0 277 80"
+                          className="w-32 opacity-0 transition-opacity group-aria-expanded/nav:opacity-100"
+                        />
+                      </div>
                       <Arrow2Down
-                        className="group-radix-state-open:rotate-180"
+                        className="group-radix-state-open:rotate-180 opacity-0 transition-opacity group-aria-expanded/nav:opacity-100"
                         height="24px"
                         width="24px"
                       />
@@ -179,35 +160,93 @@ export default function Builder() {
               </div>
               <ScrollArea.Root className="flex flex-1 flex-col" type="auto">
                 <ScrollArea.Viewport>
-                  <Sidebar.Nav className="p-2">
-                    {LINKS.map((linkProps) => (
-                      <li key={linkProps.labelTKey}>
-                        <Sidebar.Link {...linkProps} />
+                  <nav className="p-2">
+                    <ul className="flex flex-col gap-2">
+                      <li>
+                        <SidebarLink
+                          labelTKey="navigation:scenarios"
+                          to={getRoute('/scenarios')}
+                          Icon={Scenarios}
+                        />
                       </li>
-                    ))}
-                  </Sidebar.Nav>
+                      <li>
+                        <SidebarLink
+                          labelTKey="navigation:lists"
+                          to={getRoute('/lists')}
+                          Icon={Lists}
+                        />
+                      </li>
+                      <li>
+                        <SidebarLink
+                          labelTKey="navigation:decisions"
+                          to={getRoute('/decisions')}
+                          Icon={Decision}
+                        />
+                      </li>
+                      <li>
+                        <SidebarLink
+                          labelTKey="navigation:scheduledExecutions"
+                          to={getRoute('/scheduled-executions')}
+                          Icon={ScheduledExecution}
+                        />
+                      </li>
+                      <li>
+                        <SidebarLink
+                          labelTKey="navigation:caseManager"
+                          to={getRoute('/cases')}
+                          Icon={CaseManager}
+                        />
+                      </li>
+                    </ul>
+                  </nav>
                 </ScrollArea.Viewport>
                 <ScrollArea.Scrollbar>
                   <ScrollArea.Thumb />
                 </ScrollArea.Scrollbar>
               </ScrollArea.Root>
-              <Sidebar.Nav className="p-2 pb-4">
-                {BOTTOM_LINKS.map((linkProps) => (
-                  <li key={linkProps.labelTKey}>
-                    <Sidebar.Link {...linkProps} />
-                  </li>
-                ))}
-                {isAdmin(user) ? (
-                  <li key="navigation:settings">
-                    <Sidebar.Link
-                      labelTKey="navigation:settings"
-                      to={getRoute('/settings')}
-                      Icon={Settings}
+              <nav className="p-2 pb-4">
+                <ul className="flex flex-col gap-2">
+                  <li>
+                    <SidebarLink
+                      labelTKey="navigation:data"
+                      to={getRoute('/data')}
+                      Icon={Harddrive}
                     />
                   </li>
-                ) : null}
-                <ChatlioWidget user={user} organization={organization} />
-              </Sidebar.Nav>
+                  <li>
+                    <SidebarLink
+                      labelTKey="navigation:api"
+                      to={getRoute('/api')}
+                      Icon={World}
+                    />
+                  </li>
+                  {isAdmin(user) ? (
+                    <li key="navigation:settings">
+                      <SidebarLink
+                        labelTKey="navigation:settings"
+                        to={getRoute('/settings')}
+                        Icon={Settings}
+                      />
+                    </li>
+                  ) : null}
+                  <li>
+                    <ChatlioWidget user={user} organization={organization} />
+                  </li>
+                  <li>
+                    <SidebarButton
+                      onClick={() => {
+                        setExpanded((expanded) => !expanded);
+                      }}
+                      labelTKey={
+                        expanded
+                          ? 'navigation:collapsed'
+                          : 'navigation:expanded'
+                      }
+                      Icon={ExpandedIcon}
+                    />
+                  </li>
+                </ul>
+              </nav>
             </header>
 
             <Outlet />
@@ -215,5 +254,17 @@ export default function Builder() {
         </OrganizationTagsContextProvider>
       </OrganizationUsersContextProvider>
     </PermissionsProvider>
+  );
+}
+
+function ExpandedIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <ArrowRight
+      className={clsx(
+        'transition-transform group-aria-expanded/nav:rotate-180',
+        className,
+      )}
+      {...props}
+    />
   );
 }

--- a/packages/app-builder/src/routes/__builder/cases/inboxes.tsx
+++ b/packages/app-builder/src/routes/__builder/cases/inboxes.tsx
@@ -38,7 +38,7 @@ export default function Cases() {
         {t('navigation:caseManager')}
       </Page.Header>
       <div className="flex h-full flex-row">
-        <div className="border-r-grey-25 flex h-full w-full max-w-[300px] flex-col border-r p-4">
+        <div className="border-r-grey-10 flex h-full w-full max-w-[300px] flex-col border-r p-4">
           <div className="flex flex-row items-center gap-2 pb-4">
             <Inbox />
             <p className="font-bold">{t('cases:case.inboxes')}</p>

--- a/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view.tsx
+++ b/packages/app-builder/src/routes/__builder/scenarios/$scenarioId/i/$iterationId/__edit-view.tsx
@@ -1,7 +1,7 @@
 import {
   navigationI18n,
   ScenarioPage,
-  Scenarios,
+  ScenariosLink,
   usePermissionsContext,
 } from '@app-builder/components';
 import { withCornerPing } from '@app-builder/components/Ping';
@@ -119,53 +119,55 @@ export default function ScenarioEditLayout() {
         </div>
       </ScenarioPage.Header>
       <ScenarioPage.Content>
-        <Scenarios.Nav>
-          <li>
-            <Scenarios.Link
-              aria-invalid={hasTriggerErrors(scenarioValidation)}
-              labelTKey="navigation:scenario.trigger"
-              to="./trigger"
-              Icon={
-                hasTriggerErrors(scenarioValidation)
-                  ? withCornerPing({
-                      children: <Trigger />,
-                      variant: 'top-right',
-                    })
-                  : Trigger
-              }
-            />
-          </li>
-          <li>
-            <Scenarios.Link
-              aria-invalid={hasRulesErrors(scenarioValidation)}
-              labelTKey="navigation:scenario.rules"
-              to="./rules"
-              Icon={
-                hasRulesErrors(scenarioValidation)
-                  ? withCornerPing({
-                      children: <Rules />,
-                      variant: 'top-right',
-                    })
-                  : Rules
-              }
-            />
-          </li>
-          <li>
-            <Scenarios.Link
-              aria-invalid={hasDecisionErrors(scenarioValidation)}
-              labelTKey="navigation:scenario.decision"
-              to="./decision"
-              Icon={
-                hasDecisionErrors(scenarioValidation)
-                  ? withCornerPing({
-                      children: <Decision />,
-                      variant: 'top-right',
-                    })
-                  : Decision
-              }
-            />
-          </li>
-        </Scenarios.Nav>
+        <nav>
+          <ul className="flex flex-row gap-2">
+            <li>
+              <ScenariosLink
+                aria-invalid={hasTriggerErrors(scenarioValidation)}
+                labelTKey="navigation:scenario.trigger"
+                to="./trigger"
+                Icon={
+                  hasTriggerErrors(scenarioValidation)
+                    ? withCornerPing({
+                        children: <Trigger />,
+                        variant: 'top-right',
+                      })
+                    : Trigger
+                }
+              />
+            </li>
+            <li>
+              <ScenariosLink
+                aria-invalid={hasRulesErrors(scenarioValidation)}
+                labelTKey="navigation:scenario.rules"
+                to="./rules"
+                Icon={
+                  hasRulesErrors(scenarioValidation)
+                    ? withCornerPing({
+                        children: <Rules />,
+                        variant: 'top-right',
+                      })
+                    : Rules
+                }
+              />
+            </li>
+            <li>
+              <ScenariosLink
+                aria-invalid={hasDecisionErrors(scenarioValidation)}
+                labelTKey="navigation:scenario.decision"
+                to="./decision"
+                Icon={
+                  hasDecisionErrors(scenarioValidation)
+                    ? withCornerPing({
+                        children: <Decision />,
+                        variant: 'top-right',
+                      })
+                    : Decision
+                }
+              />
+            </li>
+          </ul>
+        </nav>
         <Outlet />
       </ScenarioPage.Content>
     </ScenarioPage.Container>

--- a/packages/app-builder/src/routes/__builder/settings/__settings.tsx
+++ b/packages/app-builder/src/routes/__builder/settings/__settings.tsx
@@ -30,7 +30,7 @@ export default function Settings() {
         {t('navigation:settings')}
       </Page.Header>
       <div className="flex h-full flex-row">
-        <div className="border-r-grey-25 flex h-full w-full max-w-[300px] flex-col border-r p-4">
+        <div className="border-r-grey-10 flex h-full w-full max-w-[300px] flex-col border-r p-4">
           <div className="flex flex-row items-center gap-2 pb-4">
             <Inbox height="20px" width="20px" />
             <p className="font-bold">{t('settings:users')}</p>

--- a/packages/app-builder/src/services/chatlio/ChatlioWidget.tsx
+++ b/packages/app-builder/src/services/chatlio/ChatlioWidget.tsx
@@ -1,7 +1,6 @@
-import { sidebarLink } from '@app-builder/components';
+import { SidebarButton } from '@app-builder/components';
 import { type CurrentUser } from '@app-builder/models';
 import { type Organization } from '@app-builder/models/organization';
-import { useTranslation } from 'react-i18next';
 import { Helpcenter } from 'ui-icons';
 
 import { getFullName } from '../user';
@@ -13,11 +12,11 @@ export function ChatlioWidget({
   user: CurrentUser;
   organization: Organization;
 }) {
-  const { t } = useTranslation(['navigation']);
   return (
     <>
-      <button
-        className={sidebarLink()}
+      <SidebarButton
+        labelTKey="navigation:helpCenter"
+        Icon={Helpcenter}
         onClick={() => {
           window._chatlio?.configure?.({
             collapsedMode: 'hidden',
@@ -33,14 +32,13 @@ export function ChatlioWidget({
           window._chatlio?.showOrHide?.();
         }}
         data-chatlio-widget-button
-      >
-        <Helpcenter height="24px" width="24px" />
-        {t('navigation:helpCenter')}
-      </button>
-      <chatlio-widget
-        widgetid="4aef4109-4ac2-4499-590d-511078df07fd"
-        data-start-hidden
-      ></chatlio-widget>
+      />
+      <div className="absolute">
+        <chatlio-widget
+          widgetid="4aef4109-4ac2-4499-590d-511078df07fd"
+          data-start-hidden
+        ></chatlio-widget>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
In this PR :
- clean up nav items
  - explicit JSX (no more map for nav items)
  - remove useless abstraction
- implement collapsible nav bar

![output](https://github.com/checkmarble/marble-frontend/assets/40292402/891569a8-b00c-4cfd-988f-17e7160c0a79)
