### PR TITLE
feat(inbox-detail): harmonize ui

### DIFF
--- a/packages/app-builder/public/locales/en/settings.json
+++ b/packages/app-builder/public/locales/en/settings.json
@@ -50,6 +50,7 @@
   "inboxes.inbox_details.role": "Role",
   "inboxes.inbox_details.case_count": "Cases in inbox",
   "inboxes.inbox_details.delete_inbox": "Delete inbox",
+  "inboxes.inbox_details.delete_inbox.tooltip": "You cannot delete an inbox with cases in it",
   "inboxes.inbox_user.update": "Update user role in inbox",
   "inboxes.inbox_user.delete": "Remove user from inbox",
   "inboxes.inbox_user.delete.content": "You are about to delete this user from this inbox, do you want to proceed?",

--- a/packages/app-builder/src/routes/__builder/settings/__settings/inboxes/$inboxId.tsx
+++ b/packages/app-builder/src/routes/__builder/settings/__settings/inboxes/$inboxId.tsx
@@ -1,4 +1,4 @@
-import { Page } from '@app-builder/components';
+import { CollapsiblePaper, Page } from '@app-builder/components';
 import { DeleteInbox } from '@app-builder/routes/ressources/settings/inboxes/delete';
 import { CreateInboxUser } from '@app-builder/routes/ressources/settings/inboxes/inbox-users/create';
 import { DeleteInboxUser } from '@app-builder/routes/ressources/settings/inboxes/inbox-users/delete';
@@ -15,7 +15,7 @@ import { type Namespace } from 'i18next';
 import { type InboxUserDto, type InboxUserRole } from 'marble-api';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Table, useVirtualTable } from 'ui-design-system';
+import { Table, Tooltip, useVirtualTable } from 'ui-design-system';
 
 import { tKeyForInboxUserRole } from '.';
 
@@ -88,52 +88,70 @@ export default function Inbox() {
   return (
     <Page.Container>
       <Page.Content>
-        <div className="bg-grey-00 border-grey-10 flex w-full flex-col gap-4 overflow-hidden rounded-lg border px-8 py-4">
-          <div className="flex flex-row items-center justify-between font-bold capitalize">
-            {t('settings:inboxes.inbox_details.title')}
+        <CollapsiblePaper.Container>
+          <CollapsiblePaper.Title>
+            <span className="flex-1">
+              {t('settings:inboxes.inbox_details.title')}
+            </span>
             <UpdateInbox
               inbox={inbox}
               redirectRoutePath="/settings/inboxes/:inboxId"
             />
-          </div>
-          <div className="text-s grid grid-cols-[200px_2fr]">
-            <span className="font-bold">{t('settings:inboxes.name')}</span>
-            {inbox.name}
-          </div>
+          </CollapsiblePaper.Title>
+          <CollapsiblePaper.Content>
+            <div className="grid grid-cols-[max-content_1fr] grid-rows-2 items-center gap-x-10 gap-y-4">
+              <span className="font-bold">{t('settings:inboxes.name')}</span>
+              {inbox.name}
 
-          <div className="flex flex-row items-center justify-between font-bold capitalize">
-            {t('settings:inboxes.inbox_details.members')}
-            <CreateInboxUser inboxId={inbox.id} />
-          </div>
-          <Table.Container {...getContainerProps()}>
-            <Table.Header headerGroups={table.getHeaderGroups()} />
-            <Table.Body {...getBodyProps()}>
-              {rows.map((row) => {
-                return (
-                  <Table.Row
-                    key={row.id}
-                    tabIndex={0}
-                    className={clsx('hover:bg-grey-02 cursor-pointer')}
-                    row={row}
-                  />
-                );
-              })}
-            </Table.Body>
-          </Table.Container>
-
-          <div className="text-s grid grid-cols-[200px_2fr]">
-            <span className="font-bold">
-              {t('settings:inboxes.inbox_details.case_count')}
-            </span>
-            {caseList.total}
-          </div>
-
-          {caseList.total === 0 ? (
-            <div>
-              <DeleteInbox inbox={inbox} />
+              <span className="font-bold">
+                {t('settings:inboxes.inbox_details.case_count')}
+              </span>
+              {caseList.total}
             </div>
-          ) : null}
-        </div>
+          </CollapsiblePaper.Content>
+        </CollapsiblePaper.Container>
+
+        <CollapsiblePaper.Container>
+          <CollapsiblePaper.Title>
+            <span className="flex-1">
+              {t('settings:inboxes.inbox_details.members')}
+            </span>
+            <CreateInboxUser inboxId={inbox.id} />
+          </CollapsiblePaper.Title>
+          <CollapsiblePaper.Content>
+            <Table.Container {...getContainerProps()}>
+              <Table.Header headerGroups={table.getHeaderGroups()} />
+              <Table.Body {...getBodyProps()}>
+                {rows.map((row) => {
+                  return (
+                    <Table.Row
+                      key={row.id}
+                      tabIndex={0}
+                      className={clsx('hover:bg-grey-02 cursor-pointer')}
+                      row={row}
+                    />
+                  );
+                })}
+              </Table.Body>
+            </Table.Container>
+          </CollapsiblePaper.Content>
+        </CollapsiblePaper.Container>
+
+        {caseList.total === 0 ? (
+          <DeleteInbox inbox={inbox} />
+        ) : (
+          <Tooltip.Default
+            content={
+              <p className="p-2">
+                {t('settings:inboxes.inbox_details.delete_inbox.tooltip')}
+              </p>
+            }
+          >
+            <span className="w-fit">
+              <DeleteInbox inbox={inbox} disabled />
+            </span>
+          </Tooltip.Default>
+        )}
       </Page.Content>
     </Page.Container>
   );

--- a/packages/app-builder/src/routes/ressources/settings/inboxes/delete.tsx
+++ b/packages/app-builder/src/routes/ressources/settings/inboxes/delete.tsx
@@ -31,7 +31,13 @@ export async function action({ request }: ActionArgs) {
   return redirect(getRoute('/settings/inboxes'));
 }
 
-export function DeleteInbox({ inbox }: { inbox: InboxDto }) {
+export function DeleteInbox({
+  inbox,
+  disabled,
+}: {
+  inbox: InboxDto;
+  disabled?: boolean;
+}) {
   const { t } = useTranslation(handle.i18n);
 
   const [open, setOpen] = useState(false);
@@ -46,7 +52,13 @@ export function DeleteInbox({ inbox }: { inbox: InboxDto }) {
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>
       <Modal.Trigger asChild>
-        <Button color="red" variant="primary" name="delete">
+        <Button
+          color="red"
+          variant="primary"
+          name="delete"
+          disabled={disabled}
+          className="w-fit"
+        >
           <Delete
             width="24px"
             height="24px"

--- a/packages/app-builder/src/routes/ressources/settings/inboxes/inbox-users/create.tsx
+++ b/packages/app-builder/src/routes/ressources/settings/inboxes/inbox-users/create.tsx
@@ -84,13 +84,13 @@ export function CreateInboxUser({ inboxId }: { inboxId: string }) {
 
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>
-      <Modal.Trigger asChild>
+      <Modal.Trigger asChild onClick={(e) => e.stopPropagation()}>
         <Button>
           <Plus width={'24px'} height={'24px'} />
           {t('settings:inboxes.inbox_details.add_member')}
         </Button>
       </Modal.Trigger>
-      <Modal.Content>
+      <Modal.Content onClick={(e) => e.stopPropagation()}>
         <CreateInboxUserContent currentInboxId={inboxId} />
       </Modal.Content>
     </Modal.Root>

--- a/packages/app-builder/src/routes/ressources/settings/inboxes/update.tsx
+++ b/packages/app-builder/src/routes/ressources/settings/inboxes/update.tsx
@@ -15,7 +15,7 @@ import { type InboxDto } from 'marble-api';
 import { useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal } from 'ui-design-system';
-import { NewInbox } from 'ui-icons';
+import { Edit, NewInbox } from 'ui-icons';
 import { z } from 'zod';
 
 import { redirectRouteOptions } from './create';
@@ -88,13 +88,13 @@ export function UpdateInbox({
 
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>
-      <Modal.Trigger asChild>
-        <Button className="w-fit whitespace-nowrap" variant="secondary">
-          <NewInbox className="text-l" />
+      <Modal.Trigger asChild onClick={(e) => e.stopPropagation()}>
+        <Button className="w-fit whitespace-nowrap">
+          <Edit width={'24px'} height={'24px'} />
           {t('settings:inboxes.update_inbox')}
         </Button>
       </Modal.Trigger>
-      <Modal.Content>
+      <Modal.Content onClick={(e) => e.stopPropagation()}>
         <UpdateInboxContent
           inbox={inbox}
           redirectRoutePath={redirectRoutePath}


### PR DESCRIPTION
A follow up PR that propose a different UI for inbox/detail (I personnaly must admit the one from Figma was no really practical...)

The design is really close from case/decision detail idea (with the new shared collapsible component used accross admin/setings pages)

Bonus: always display the "Delete" button with tooltip to help the user understand why this is blocked

Before:
<img width="1235" alt="Screenshot 2023-12-21 at 20 04 33" src="https://github.com/checkmarble/marble-frontend/assets/40292402/2b4623f7-a192-434e-8e0c-4ba140105289">

After:
<img width="1232" alt="Screenshot 2023-12-21 at 20 01 46" src="https://github.com/checkmarble/marble-frontend/assets/40292402/f4163970-a78c-40d7-9146-81af634c22c9">
