### PR TITLE
feat(toast): add icons to toast messages

### DIFF
--- a/packages/app-builder/src/components/MarbleToaster.tsx
+++ b/packages/app-builder/src/components/MarbleToaster.tsx
@@ -49,6 +49,17 @@ export function MarbleToaster({
     <Toaster
       position="top-center"
       containerClassName={headerHeight({ type: 'mt' })}
+      toastOptions={{
+        loading: {
+          icon: LoaderIcon,
+        },
+        success: {
+          icon: SuccessIcon,
+        },
+        error: {
+          icon: ErrorIcon,
+        },
+      }}
     >
       {(currentToast) => (
         <ToastBar toast={currentToast}>
@@ -86,3 +97,24 @@ function getMessage(message: string) {
     </div>
   );
 }
+
+const LoaderIcon = (
+  <div
+    aria-hidden
+    className="border-grey-02 border-r-grey-50 box-border h-4 w-4 animate-spin rounded-full border-2 border-solid"
+  />
+);
+
+const ErrorIcon = (
+  <div
+    aria-hidden
+    className="animate-circleAnimation after:animate-firstLineAnimation after:bg-grey-00 before:animate-secondLineAnimation before:bg-grey-00 relative h-5 w-5 rotate-45 rounded-full bg-red-100 delay-100 before:absolute before:bottom-[9px] before:left-1 before:h-[2px] before:w-3 before:rounded-lg before:delay-150 after:absolute after:bottom-[9px] after:left-1 after:h-[2px] after:w-3 after:rounded-lg after:delay-150"
+  />
+);
+
+const SuccessIcon = (
+  <div
+    aria-hidden
+    className="animate-circleAnimation after:animate-checkmarkAnimation after:border-grey-00 relative h-5 w-5 rotate-45 rounded-full bg-green-100 delay-100 after:absolute after:bottom-[6px] after:left-[6px] after:box-border after:h-[10px] after:w-[6px] after:border-b-2 after:border-r-2 after:border-solid after:delay-200"
+  />
+);

--- a/packages/app-builder/src/root.tsx
+++ b/packages/app-builder/src/root.tsx
@@ -20,6 +20,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AuthenticityTokenProvider,
+  ClientOnly,
   createAuthenticityToken,
   ExternalScripts,
 } from 'remix-utils';
@@ -177,7 +178,9 @@ function App() {
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
-        <MarbleToaster toastMessage={toastMessage} />
+        <ClientOnly>
+          {() => <MarbleToaster toastMessage={toastMessage} />}
+        </ClientOnly>
       </body>
     </html>
   );

--- a/packages/tailwind-preset/tailwind.config.js
+++ b/packages/tailwind-preset/tailwind.config.js
@@ -29,6 +29,52 @@ module.exports = {
             opacity: 0,
           },
         },
+        circleAnimation: {
+          from: {
+            transform: 'scale(0) rotate(45deg)',
+            opacity: 0,
+          },
+          to: {
+            transform: 'scale(1) rotate(45deg)',
+            opacity: 1,
+          },
+        },
+        firstLineAnimation: {
+          from: {
+            transform: 'scale(0)',
+            opacity: 0,
+          },
+          to: {
+            transform: 'scale(1)',
+            opacity: 1,
+          },
+        },
+        secondLineAnimation: {
+          from: {
+            transform: 'scale(0) rotate(90deg)',
+            opacity: 0,
+          },
+          to: {
+            transform: 'scale(1) rotate(90deg)',
+            opacity: 1,
+          },
+        },
+        checkmarkAnimation: {
+          '0%': {
+            height: 0,
+            width: 0,
+            opacity: 0,
+          },
+          '40%': {
+            height: 0,
+            width: '6px',
+            opacity: 1,
+          },
+          '100%': {
+            opacity: 1,
+            height: '10px',
+          },
+        },
         overlayShow: {
           from: {
             opacity: 0,
@@ -79,6 +125,11 @@ module.exports = {
       animation: {
         'ping-slow': 'ping-slow 5s ease infinite',
         slideUpAndFade: 'slideUpAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)',
+        circleAnimation:
+          'circleAnimation 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+        firstLineAnimation: 'firstLineAnimation 300ms ease-out forwards',
+        secondLineAnimation: 'secondLineAnimation 300ms ease-out forwards',
+        checkmarkAnimation: 'checkmarkAnimation  300ms ease-out forwards',
         overlayShow: 'overlayShow 200ms cubic-bezier(0.16, 1, 0.3, 1)',
         slideRightAndFadeIn:
           'slideRightAndFadeIn 200ms cubic-bezier(0.16, 1, 0.3, 1)',


### PR DESCRIPTION
In this PR: some delight ✨ 

In short, copy paste of lib icons, using tailwind for styling so it do not behave weirdly.

In long, this seems to be a problem with the CSS in JS library used internally in the lib. A more robust, long term solution would be to move for the headless lib exposed by `react-hot-toast` but it means re-coding `Toaster` and `ToastBar`.

**Bonnus:** gif with toast animation in slow mode (25% on the browser)

![output](https://github.com/checkmarble/marble-frontend/assets/40292402/a45152d3-fcf3-4054-909e-770d656addb3)
