### PR TITLE
refactor(healthcheck): simplify healthcheck endpoint

### DIFF
--- a/packages/app-builder/src/routes/healthcheck.ts
+++ b/packages/app-builder/src/routes/healthcheck.ts
@@ -1,20 +1,5 @@
-import { type LoaderFunctionArgs } from '@remix-run/node';
-
-async function isServerLive(request: LoaderFunctionArgs['request']) {
-  const host =
-    request.headers.get('X-Forwarded-Host') ??
-    request.headers.get('host') ??
-    'NO_HOST';
-  const url = new URL('/', `http://${host}`);
-
-  return fetch(url.href, { method: 'HEAD' }).then((r) => {
-    if (!r.ok) return Promise.reject(r);
-  });
-}
-
-export async function loader({ request }: LoaderFunctionArgs) {
+export function loader() {
   try {
-    await Promise.all([isServerLive(request)]);
     return new Response('OK');
   } catch (error: unknown) {
     console.log('healthcheck ❌', { error });


### PR DESCRIPTION
The previous implementation was a copy paste of an existing one which try to fetch itself to verify the server is live and reachable.

This works nicelly locally but not inside containers, so we simplify to a more common `/healthcheck`