### PR TITLE
feat: add filter on has case/has no case on decisions page

### DIFF
--- a/packages/app-builder/public/locales/en/common.json
+++ b/packages/app-builder/public/locales/en/common.json
@@ -1,4 +1,6 @@
 {
+  "true": "True",
+  "false": "False",
   "auth.logout": "Log out",
   "search": "Search",
   "error_one": "{{count}} error",

--- a/packages/app-builder/public/locales/en/decisions.json
+++ b/packages/app-builder/public/locales/en/decisions.json
@@ -4,7 +4,7 @@
   "detail.scenario_name_runs_on": "<ScenarioName>{{scenarioName}}</ScenarioName> (runs on <TriggerObjectType>{{triggerObjectType}}</TriggerObjectType>)",
   "detail.error": "An error as occured. Make sure the provided decision id is valid.",
   "trigger_object.type": "Trigger object",
-  "presence_of_case": "Presence of a case",
+  "filters.has_case": "Presence of a case",
   "filters.date_range.title": "creation date is:",
   "score": "Score",
   "outcome": "Outcome",

--- a/packages/app-builder/public/locales/en/decisions.json
+++ b/packages/app-builder/public/locales/en/decisions.json
@@ -4,6 +4,7 @@
   "detail.scenario_name_runs_on": "<ScenarioName>{{scenarioName}}</ScenarioName> (runs on <TriggerObjectType>{{triggerObjectType}}</TriggerObjectType>)",
   "detail.error": "An error as occured. Make sure the provided decision id is valid.",
   "trigger_object.type": "Trigger object",
+  "presence_of_case": "Presence of a case",
   "filters.date_range.title": "creation date is:",
   "score": "Score",
   "outcome": "Outcome",

--- a/packages/app-builder/public/locales/en/scenarios.json
+++ b/packages/app-builder/public/locales/en/scenarios.json
@@ -45,8 +45,6 @@
   "operator.does_not_contain": "does not contain",
   "operator.contains_any_of": "contains any of",
   "operator.contains_none_of": "does not contain any of",
-  "false": "false",
-  "true": "true",
   "rules.function.title": "function",
   "deployment_modal.activate.button": "Activate",
   "deployment_modal.activate.title": "Activate version",

--- a/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
@@ -18,6 +18,7 @@ import * as z from 'zod';
 import { type DecisionFilterName, decisionFilterNames } from './filters';
 
 export const decisionFiltersSchema = z.object({
+  hasCase: z.array(z.string()).optional(),
   outcome: z.array(z.enum(['approve', 'review', 'decline'])).optional(),
   triggerObject: z.array(z.string()).optional(),
   dateRange: dateRangeSchema.optional(),
@@ -39,11 +40,14 @@ const DecisionFiltersContext = createSimpleContext<DecisionFiltersContextValue>(
 
 export type DecisionFiltersForm = {
   outcome: Exclude<Outcome, 'null' | 'unknown'>[];
+
+  hasCase: string[];
   triggerObject: string[];
   dateRange: DateRangeFilterForm;
   scenarioId: string[];
 };
 const emptyDecisionFilters: DecisionFiltersForm = {
+  hasCase: [],
   outcome: [],
   triggerObject: [],
   dateRange: null,
@@ -130,6 +134,15 @@ export function useOutcomeFilter() {
   const selectedOutcomes = field.value;
   const setSelectedOutcomes = field.onChange;
   return { selectedOutcomes, setSelectedOutcomes };
+}
+
+export function useHasCaseFilter() {
+  const { field } = useController<DecisionFiltersForm, 'hasCase'>({
+    name: 'hasCase',
+  });
+  const selectedHasCase = field.value;
+  const setSelectedHasCase = field.onChange;
+  return { selectedHasCase, setSelectedHasCase };
 }
 
 export function useDateRangeFilter() {

--- a/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
@@ -18,7 +18,10 @@ import * as z from 'zod';
 import { type DecisionFilterName, decisionFilterNames } from './filters';
 
 export const decisionFiltersSchema = z.object({
-  hasCase: z.array(z.string()).optional(),
+  hasCase: z
+    .enum(['true', 'false'])
+    .transform((val) => val === 'true')
+    .optional(),
   outcome: z.array(z.enum(['approve', 'review', 'decline'])).optional(),
   triggerObject: z.array(z.string()).optional(),
   dateRange: dateRangeSchema.optional(),
@@ -40,14 +43,13 @@ const DecisionFiltersContext = createSimpleContext<DecisionFiltersContextValue>(
 
 export type DecisionFiltersForm = {
   outcome: Exclude<Outcome, 'null' | 'unknown'>[];
-
-  hasCase: string[];
+  hasCase: boolean | null;
   triggerObject: string[];
   dateRange: DateRangeFilterForm;
   scenarioId: string[];
 };
 const emptyDecisionFilters: DecisionFiltersForm = {
-  hasCase: [],
+  hasCase: null,
   outcome: [],
   triggerObject: [],
   dateRange: null,
@@ -98,6 +100,7 @@ export function DecisionFiltersProvider({
     const formValues = formMethods.getValues();
     _submitDecisionFilters({
       ...formValues,
+      hasCase: formValues.hasCase ?? undefined,
       dateRange: formValues.dateRange ?? undefined,
     });
   });

--- a/packages/app-builder/src/components/Decisions/Filters/FilterDetail/FilterDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/FilterDetail/FilterDetail.tsx
@@ -2,6 +2,7 @@ import { assertNever } from 'typescript-utils';
 
 import { type DecisionFilterName } from '../filters';
 import { DecisionsDateRangeFilter } from './DecisionsDateRangeFilter';
+import { HasCaseFilter } from './HasCaseFilter';
 import { OutcomeFilter } from './OutcomeFilter';
 import { ScenarioFilter } from './ScenarioFilter';
 import { TriggerObjectFilter } from './TriggerObjectFilter';
@@ -20,6 +21,8 @@ export function FilterDetail({
       return <OutcomeFilter />;
     case 'triggerObject':
       return <TriggerObjectFilter />;
+    case 'hasCase':
+      return <HasCaseFilter />;
     default:
       assertNever('[DecisionFilter] unknown filter:', filterName);
   }

--- a/packages/app-builder/src/components/Decisions/Filters/FilterDetail/HasCaseFilter.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/FilterDetail/HasCaseFilter.tsx
@@ -1,0 +1,57 @@
+import { Highlight } from '@app-builder/components/Highlight';
+import { matchSorter } from 'match-sorter';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input, SelectWithCombobox } from 'ui-design-system';
+
+import { decisionsI18n } from '../../decisions-i18n';
+import { useHasCaseFilter } from '../DecisionFiltersContext';
+
+function useHasCaseOptions() {
+  const { t } = useTranslation(decisionsI18n);
+
+  return [
+    { value: 'true', label: t('common:true') },
+    { value: 'false', label: t('common:false') },
+  ];
+}
+
+export function HasCaseFilter() {
+  const [value, setSearchValue] = useState('');
+  const { selectedHasCase, setSelectedHasCase } = useHasCaseFilter();
+  const searchValue = useDeferredValue(value);
+
+  const options = useHasCaseOptions();
+  console.log(options);
+  const matches = useMemo(
+    () => matchSorter(options, searchValue, { keys: ['label'] }),
+    [searchValue, options],
+  );
+  console.log(searchValue);
+  console.log(matches);
+
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <SelectWithCombobox.Root
+        open
+        onSearchValueChange={setSearchValue}
+        selectedValue={selectedHasCase}
+        onSelectedValueChange={setSelectedHasCase}
+      >
+        <SelectWithCombobox.Combobox render={<Input />} autoSelect autoFocus />
+        <SelectWithCombobox.ComboboxList className="max-h-40">
+          {matches.map((hasCase) => {
+            return (
+              <SelectWithCombobox.ComboboxItem
+                key={hasCase.value}
+                value={hasCase.value}
+              >
+                <Highlight text={hasCase.label} query={searchValue} />
+              </SelectWithCombobox.ComboboxItem>
+            );
+          })}
+        </SelectWithCombobox.ComboboxList>
+      </SelectWithCombobox.Root>
+    </div>
+  );
+}

--- a/packages/app-builder/src/components/Decisions/Filters/FilterDetail/HasCaseFilter.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/FilterDetail/HasCaseFilter.tsx
@@ -1,57 +1,45 @@
-import { Highlight } from '@app-builder/components/Highlight';
-import { matchSorter } from 'match-sorter';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Input, SelectWithCombobox } from 'ui-design-system';
+import { Switch } from 'ui-design-system';
 
 import { decisionsI18n } from '../../decisions-i18n';
 import { useHasCaseFilter } from '../DecisionFiltersContext';
 
-function useHasCaseOptions() {
-  const { t } = useTranslation(decisionsI18n);
+/**
+ * The HasCase filter can be null (not selected) or a boolean (selected).
+ * To simplify, since the UI should be displayed when the user want to filter on it, we use a switch (only two states).
+ * Thus, we need to have a default value for the HasCase filter in case no value is selected.
+ * We assume users want to see decisions without cases by default.
+ */
+const defaultHasCase = false;
+function useDefaultHasCase() {
+  const { selectedHasCase, setSelectedHasCase } = useHasCaseFilter();
+  useEffect(() => {
+    if (selectedHasCase === null) {
+      setSelectedHasCase(defaultHasCase);
+    }
+  }, [selectedHasCase, setSelectedHasCase]);
 
-  return [
-    { value: 'true', label: t('common:true') },
-    { value: 'false', label: t('common:false') },
-  ];
+  return {
+    selectedHasCase: selectedHasCase ?? defaultHasCase,
+    setSelectedHasCase,
+  };
 }
 
 export function HasCaseFilter() {
-  const [value, setSearchValue] = useState('');
-  const { selectedHasCase, setSelectedHasCase } = useHasCaseFilter();
-  const searchValue = useDeferredValue(value);
-
-  const options = useHasCaseOptions();
-  console.log(options);
-  const matches = useMemo(
-    () => matchSorter(options, searchValue, { keys: ['label'] }),
-    [searchValue, options],
-  );
-  console.log(searchValue);
-  console.log(matches);
+  const { t } = useTranslation(decisionsI18n);
+  const { selectedHasCase, setSelectedHasCase } = useDefaultHasCase();
 
   return (
-    <div className="flex flex-col gap-2 p-2">
-      <SelectWithCombobox.Root
-        open
-        onSearchValueChange={setSearchValue}
-        selectedValue={selectedHasCase}
-        onSelectedValueChange={setSelectedHasCase}
-      >
-        <SelectWithCombobox.Combobox render={<Input />} autoSelect autoFocus />
-        <SelectWithCombobox.ComboboxList className="max-h-40">
-          {matches.map((hasCase) => {
-            return (
-              <SelectWithCombobox.ComboboxItem
-                key={hasCase.value}
-                value={hasCase.value}
-              >
-                <Highlight text={hasCase.label} query={searchValue} />
-              </SelectWithCombobox.ComboboxItem>
-            );
-          })}
-        </SelectWithCombobox.ComboboxList>
-      </SelectWithCombobox.Root>
+    <div className="flex flex-row justify-between gap-2 p-2">
+      <label htmlFor="hasCase" className="">
+        {t('decisions:filters.has_case')}
+      </label>
+      <Switch
+        id="hasCase"
+        checked={selectedHasCase}
+        onCheckedChange={setSelectedHasCase}
+      />
     </div>
   );
 }

--- a/packages/app-builder/src/components/Decisions/Filters/filters.ts
+++ b/packages/app-builder/src/components/Decisions/Filters/filters.ts
@@ -6,6 +6,7 @@ export const decisionFilterNames = [
   'scenarioId',
   'outcome',
   'triggerObject',
+  'hasCase',
 ] as const;
 
 export type DecisionFilterName = (typeof decisionFilterNames)[number];
@@ -20,6 +21,8 @@ export function getFilterIcon(filterName: DecisionFilterName): IconName {
       return 'category';
     case 'triggerObject':
       return 'alt-route';
+    case 'hasCase':
+      return 'case-manager';
     default:
       assertNever('[DecisionFilter] unknown filter:', filterName);
   }
@@ -35,6 +38,8 @@ export function getFilterTKey(filterName: DecisionFilterName) {
       return 'decisions:outcome';
     case 'triggerObject':
       return 'decisions:trigger_object.type';
+    case 'hasCase':
+      return 'decisions:presence_of_case';
     default:
       assertNever('[DecisionFilter] unknown filter:', filterName);
   }

--- a/packages/app-builder/src/components/Decisions/Filters/filters.ts
+++ b/packages/app-builder/src/components/Decisions/Filters/filters.ts
@@ -39,7 +39,7 @@ export function getFilterTKey(filterName: DecisionFilterName) {
     case 'triggerObject':
       return 'decisions:trigger_object.type';
     case 'hasCase':
-      return 'decisions:presence_of_case';
+      return 'decisions:filters.has_case';
     default:
       assertNever('[DecisionFilter] unknown filter:', filterName);
   }

--- a/packages/app-builder/src/components/Decisions/decisions-i18n.ts
+++ b/packages/app-builder/src/components/Decisions/decisions-i18n.ts
@@ -2,4 +2,8 @@ import { type Namespace } from 'i18next';
 
 import { filtersI18n } from '../Filters/filters-i18n';
 
-export const decisionsI18n = ['decisions', ...filtersI18n] satisfies Namespace;
+export const decisionsI18n = [
+  'decisions',
+  'common',
+  ...filtersI18n,
+] satisfies Namespace;

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditorSearchResults.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditorSearchResults.tsx
@@ -1,3 +1,4 @@
+import { scenarioI18n } from '@app-builder/components';
 import { type LabelledAst } from '@app-builder/models';
 import { coerceToConstantsLabelledAst } from '@app-builder/services/editor';
 import { matchSorter } from 'match-sorter';
@@ -17,10 +18,10 @@ export function OperandEditorSearchResults({
   searchText,
   onSelect,
 }: OperandEditorSearchResultsProps) {
-  const { t } = useTranslation('scenarios');
+  const { t } = useTranslation(scenarioI18n);
 
   const constantOptions = coerceToConstantsLabelledAst(searchText, {
-    booleans: { true: [t('true')], false: [t('false')] },
+    booleans: { true: [t('common:true')], false: [t('common:false')] },
   });
 
   const availableOptions = matchSorter(options, searchText, {
@@ -44,7 +45,7 @@ export function OperandEditorSearchResults({
         <GroupHeader.Container>
           <GroupHeader.Title>
             <Label className="text-grey-100 text-m font-semibold">
-              {t('edit_operand.result', {
+              {t('scenarios:edit_operand.result', {
                 count: availableOptions.length,
               })}
             </Label>

--- a/packages/app-builder/src/components/Scenario/scenario-i18n.ts
+++ b/packages/app-builder/src/components/Scenario/scenario-i18n.ts
@@ -1,3 +1,3 @@
 import { type Namespace } from 'i18next';
 
-export const scenarioI18n = ['scenarios'] satisfies Namespace;
+export const scenarioI18n = ['common', 'scenarios'] satisfies Namespace;

--- a/packages/app-builder/src/repositories/DecisionRepository.ts
+++ b/packages/app-builder/src/repositories/DecisionRepository.ts
@@ -22,14 +22,35 @@ export type DecisionFilters = {
         fromNow: string;
       };
   scenarioId?: string[];
+  hasCase?: string[];
+};
+
+export type DecisionFiltersDto = {
+  outcome?: Outcome[];
+  triggerObject?: string[];
+  dateRange?:
+    | {
+        type: 'static';
+        startDate?: string;
+        endDate?: string;
+      }
+    | {
+        type: 'dynamic';
+        fromNow: string;
+      };
+  scenarioId?: string[];
+  hasCase?: boolean[];
 };
 
 export type DecisionFiltersWithPagination =
   FiltersWithPagination<DecisionFilters>;
 
+export type DecisionFiltersDtoWithPagination =
+  FiltersWithPagination<DecisionFiltersDto>;
+
 export interface DecisionRepository {
   listDecisions(
-    args: DecisionFiltersWithPagination,
+    args: DecisionFiltersDtoWithPagination,
   ): Promise<PaginatedResponse<Decision>>;
 }
 

--- a/packages/app-builder/src/repositories/DecisionRepository.ts
+++ b/packages/app-builder/src/repositories/DecisionRepository.ts
@@ -22,35 +22,15 @@ export type DecisionFilters = {
         fromNow: string;
       };
   scenarioId?: string[];
-  hasCase?: string[];
-};
-
-export type DecisionFiltersDto = {
-  outcome?: Outcome[];
-  triggerObject?: string[];
-  dateRange?:
-    | {
-        type: 'static';
-        startDate?: string;
-        endDate?: string;
-      }
-    | {
-        type: 'dynamic';
-        fromNow: string;
-      };
-  scenarioId?: string[];
-  hasCase?: boolean[];
+  hasCase?: boolean;
 };
 
 export type DecisionFiltersWithPagination =
   FiltersWithPagination<DecisionFilters>;
 
-export type DecisionFiltersDtoWithPagination =
-  FiltersWithPagination<DecisionFiltersDto>;
-
 export interface DecisionRepository {
   listDecisions(
-    args: DecisionFiltersDtoWithPagination,
+    args: DecisionFiltersWithPagination,
   ): Promise<PaginatedResponse<Decision>>;
 }
 

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -58,30 +58,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return redirect(getRoute('/decisions/'));
   }
 
-  const parseBool = (value: string) => {
-    if (value === 'true') return true;
-    return false;
-  };
-  const filters = parsedFilterQuery.data;
-  const hasCase = filters.hasCase
-    ? filters.hasCase
-        .filter((x) => ['true', 'false'].includes(x))
-        .map(parseBool)
-    : undefined;
-
-  console.log({
-    ...{
-      ...filters,
-      hasCase,
-    },
-    ...parsedPaginationQuery.data,
-  });
   const [decisionsData, scenarios] = await Promise.all([
     decision.listDecisions({
-      ...{
-        ...filters,
-        hasCase,
-      },
+      ...parsedFilterQuery.data,
       ...parsedPaginationQuery.data,
     }),
     scenario.listScenarios(),
@@ -128,7 +107,7 @@ export default function Decisions() {
                     }
                 : {},
               scenarioId: decisionFilters.scenarioId ?? [],
-              hasCase: decisionFilters.hasCase ?? [],
+              hasCase: decisionFilters?.hasCase ?? null,
               offsetId: pagination?.offsetId || null,
               next: pagination?.next || null,
               previous: pagination?.previous || null,

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -58,9 +58,30 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return redirect(getRoute('/decisions/'));
   }
 
+  const parseBool = (value: string) => {
+    if (value === 'true') return true;
+    return false;
+  };
+  const filters = parsedFilterQuery.data;
+  const hasCase = filters.hasCase
+    ? filters.hasCase
+        .filter((x) => ['true', 'false'].includes(x))
+        .map(parseBool)
+    : undefined;
+
+  console.log({
+    ...{
+      ...filters,
+      hasCase,
+    },
+    ...parsedPaginationQuery.data,
+  });
   const [decisionsData, scenarios] = await Promise.all([
     decision.listDecisions({
-      ...parsedFilterQuery.data,
+      ...{
+        ...filters,
+        hasCase,
+      },
       ...parsedPaginationQuery.data,
     }),
     scenario.listScenarios(),
@@ -107,6 +128,7 @@ export default function Decisions() {
                     }
                 : {},
               scenarioId: decisionFilters.scenarioId ?? [],
+              hasCase: decisionFilters.hasCase ?? [],
               offsetId: pagination?.offsetId || null,
               next: pagination?.next || null,
               previous: pagination?.previous || null,

--- a/packages/app-builder/src/services/editor/coerceToConstantsLabelledAst.ts
+++ b/packages/app-builder/src/services/editor/coerceToConstantsLabelledAst.ts
@@ -91,17 +91,21 @@ function coerceToConstantArray(search: string): LabelledAst[] {
 function getBooleanCoercionLogic(
   options: CoerceToConstantsLabelledAstOptions['booleans'],
 ) {
+  const sanitizedOptions = {
+    true: options.true.map((value) => value.trim().toLocaleLowerCase()),
+    false: options.false.map((value) => value.trim().toLocaleLowerCase()),
+  };
   return {
     isCoerceableToBoolean: (search: string) => {
       const sanitizedSearch = search.trim().toLocaleLowerCase();
       return (
-        options.true.includes(sanitizedSearch) ||
-        options.false.includes(sanitizedSearch)
+        sanitizedOptions.true.includes(sanitizedSearch) ||
+        sanitizedOptions.false.includes(sanitizedSearch)
       );
     },
     coerceToBoolean: (search: string) => {
       const sanitizedSearch = search.trim().toLocaleLowerCase();
-      return options.true.includes(sanitizedSearch);
+      return sanitizedOptions.true.includes(sanitizedSearch);
     },
   };
 }

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -139,9 +139,7 @@ paths:
           in: query
           required: false
           schema:
-            type: array
-            items:
-              type: boolean
+            type: boolean
         - $ref: '#/components/parameters/offsetId'
         - $ref: '#/components/parameters/previous'
         - $ref: '#/components/parameters/next'

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -134,6 +134,14 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: has_case
+          description: 'Optional filter: the decision is attached to a case'
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: boolean
         - $ref: '#/components/parameters/offsetId'
         - $ref: '#/components/parameters/previous'
         - $ref: '#/components/parameters/next'

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -526,12 +526,13 @@ export function getCredentials(opts?: Oazapfts.RequestOpts) {
 /**
  * List decisions
  */
-export function listDecisions({ outcome, scenarioId, triggerObject, startDate, endDate, offsetId, previous, next, limit, order, sorting }: {
+export function listDecisions({ outcome, scenarioId, triggerObject, startDate, endDate, hasCase, offsetId, previous, next, limit, order, sorting }: {
     outcome?: Outcome[];
     scenarioId?: string[];
     triggerObject?: string[];
     startDate?: string;
     endDate?: string;
+    hasCase?: boolean[];
     offsetId?: string;
     previous?: boolean;
     next?: boolean;
@@ -556,6 +557,7 @@ export function listDecisions({ outcome, scenarioId, triggerObject, startDate, e
         "triggerObject[]": triggerObject,
         startDate,
         endDate,
+        has_case: hasCase,
         offsetId,
         previous,
         next,

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -532,7 +532,7 @@ export function listDecisions({ outcome, scenarioId, triggerObject, startDate, e
     triggerObject?: string[];
     startDate?: string;
     endDate?: string;
-    hasCase?: boolean[];
+    hasCase?: boolean;
     offsetId?: string;
     previous?: boolean;
     next?: boolean;


### PR DESCRIPTION
As discussed, I implemented this by allowing to filter by the different cases "is attached to a case" and "is not attached to a case".

Maybe not totally ideal compared to just allowing one of those two options (assuming only one of them really makes sense from a product perspective) where we could have worked more easily with a toggle in the filter, but let's keep it like this for now.

<img width="422" alt="Capture d’écran 2024-01-29 à 11 11 17" src="https://github.com/checkmarble/marble-frontend/assets/128643171/def33bf7-3895-40f9-ba54-15f6e203ec7b">
<img width="439" alt="Capture d’écran 2024-01-29 à 11 11 22" src="https://github.com/checkmarble/marble-frontend/assets/128643171/83a20e8d-8ab4-462a-bf4b-81cb87733320">
<img width="1254" alt="Capture d’écran 2024-01-29 à 11 11 29" src="https://github.com/checkmarble/marble-frontend/assets/128643171/e3cd7f71-ad87-4eaa-be71-c264df4abac4">


The back-end API is a change compared to the current implementation, cf https://github.com/checkmarble/marble-backend/pull/462