### PR TITLE
refactor(table): horizontal scrollable tables

### DIFF
--- a/packages/app-builder/public/locales/en/scheduledExecution.json
+++ b/packages/app-builder/public/locales/en/scheduledExecution.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "Scenario name",
   "scenario_trigger_object_type": "Trigger Object",
-  "number_of_created_decisions": "Number of decisions",
+  "number_of_created_decisions": "Decisions",
   "status": "Status",
   "created_at": "Created at",
   "started_at": "Started at",

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -84,18 +84,18 @@ export function DecisionsList({
         {
           id: 'created_at',
           header: t('decisions:created_at'),
-          size: 50,
+          size: 100,
         },
       ),
       columnHelper.accessor((row) => row.scenario.name, {
         id: 'scenario_name',
         header: t('decisions:scenario.name'),
-        size: 100,
+        size: 200,
       }),
       columnHelper.accessor((row) => row.trigger_object_type, {
         id: 'trigger_object_type',
         header: t('decisions:trigger_object.type'),
-        size: 100,
+        size: 200,
         cell: ({ getValue }) => (
           <span className="capitalize">{getValue()}</span>
         ),
@@ -103,7 +103,7 @@ export function DecisionsList({
       columnHelper.accessor((row) => row.case?.name ?? '-', {
         id: 'case',
         header: t('decisions:case'),
-        size: 100,
+        size: 200,
         cell: ({ getValue, row }) =>
           row.original.case ? (
             <div className="flex w-fit flex-row items-center justify-center gap-1">
@@ -127,13 +127,13 @@ export function DecisionsList({
       columnHelper.accessor((row) => row.score, {
         id: 'score',
         header: t('decisions:score'),
-        size: 50,
+        size: 100,
         cell: ({ getValue }) => <Score score={getValue()} />,
       }),
       columnHelper.accessor((row) => row.outcome, {
         id: 'outcome',
         header: t('decisions:outcome'),
-        size: 50,
+        size: 100,
         cell: ({ getValue }) => (
           <Outcome border="square" size="big" outcome={getValue()} />
         ),
@@ -165,7 +165,8 @@ export function DecisionsList({
               }}
             />
           ),
-          size: 30,
+          size: 58,
+          enableResizing: false,
         }),
       );
     }

--- a/packages/app-builder/src/components/Scenario/Iteration/VersionSelect.tsx
+++ b/packages/app-builder/src/components/Scenario/Iteration/VersionSelect.tsx
@@ -25,7 +25,7 @@ export function VersionSelect({
     <Select.Default
       value={currentIteration.id}
       border="rounded"
-      className="min-w-[126px]"
+      className="min-w-[126px] shrink-0"
       onValueChange={(selectedId) => {
         const elem = scenarioIterations.find(({ id }) => id === selectedId);
         if (!elem?.id) return;

--- a/packages/app-builder/src/components/ScheduledExecutions/ScheduledExecutionDetails.tsx
+++ b/packages/app-builder/src/components/ScheduledExecutions/ScheduledExecutionDetails.tsx
@@ -53,9 +53,11 @@ function ScheduledExecutionDetailsInternal({
       name="download"
       disabled={downloadingDecisions}
     >
-      {downloadingDecisions
-        ? t('scheduledExecution:downloading_decisions')
-        : t('scheduledExecution:download_decisions')}
+      <span className="line-clamp-1 shrink-0">
+        {downloadingDecisions
+          ? t('scheduledExecution:downloading_decisions')
+          : t('scheduledExecution:download_decisions')}
+      </span>
     </Button>
   );
 }

--- a/packages/app-builder/src/components/ScheduledExecutions/ScheduledExecutionsList.tsx
+++ b/packages/app-builder/src/components/ScheduledExecutions/ScheduledExecutionsList.tsx
@@ -40,7 +40,7 @@ export function ScheduledExecutionsList({
         accessorFn: (s) =>
           s.status == 'success' ? s.number_of_created_decisions : '0',
         header: t('scheduledExecution:number_of_created_decisions'),
-        size: 200,
+        size: 100,
       },
       {
         id: 'status',
@@ -104,12 +104,12 @@ export function ScheduledExecutionsList({
 
 const getStatusIcon = (status: string) => {
   if (status === 'success') {
-    return <Icon icon="tick" className="size-6 text-green-100" />;
+    return <Icon icon="tick" className="size-6 shrink-0 text-green-100" />;
   }
   if (status === 'failure') {
-    return <Icon icon="cross" className="size-6 text-red-100" />;
+    return <Icon icon="cross" className="size-6 shrink-0 text-red-100" />;
   }
-  return <Icon icon="restart-alt" className="text-grey-50 size-6" />;
+  return <Icon icon="restart-alt" className="text-grey-50 size-6 shrink-0" />;
 };
 
 const getStatusTKey = (status: string): ParseKeys<['scheduledExecution']> => {

--- a/packages/app-builder/src/routes/_builder+/data.tsx
+++ b/packages/app-builder/src/routes/_builder+/data.tsx
@@ -135,7 +135,7 @@ function TableDetails({
       {
         id: 'required',
         accessorKey: 'required',
-        size: 80,
+        size: 100,
         header: t('data:field_required'),
         cell: ({ cell }) => {
           return cell.row.original.nullable
@@ -198,26 +198,26 @@ function TableDetails({
         id: 'foreignKey',
         accessorKey: 'foreignKey',
         header: t('data:foreign_key'),
-        size: 50,
+        size: 150,
         enableSorting: true,
       },
       {
         id: 'parentTable',
         accessorKey: 'parentTable',
-        size: 50,
+        size: 150,
         header: t('data:parent_table'),
       },
       {
         id: 'parentFieldName',
         accessorKey: 'parentFieldName',
         header: t('data:parent_field_name'),
-        size: 50,
+        size: 150,
       },
       {
         id: 'exampleUsage',
         accessorKey: 'exampleUsage',
         header: t('data:example_usage'),
-        size: 100,
+        size: 300,
       },
     ],
     [t],

--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -60,7 +60,7 @@ export default function Lists() {
       columnHelper.accessor((row) => row.value, {
         id: 'value',
         header: t('lists:value', { count: listValues.length }),
-        size: 600,
+        size: 500,
         sortingFn: 'text',
         enableSorting: true,
         cell: ({ getValue }) => {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
@@ -80,12 +80,14 @@ export default function ScenarioEditLayout() {
 
   return (
     <Page.Container>
-      <Page.Header className="justify-between">
+      <Page.Header className="justify-between gap-4">
         <div className="flex flex-row items-center gap-4">
           <Link to={getRoute('/scenarios/')}>
             <Page.BackButton />
           </Link>
-          {currentScenario.name}
+          <span className="line-clamp-2 text-ellipsis">
+            {currentScenario.name}
+          </span>
           <VersionSelect
             scenarioIterations={sortedScenarioIterations}
             currentIteration={currentIteration}

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
@@ -47,9 +47,9 @@ export default function Inbox() {
   const columns = useMemo(() => {
     return [
       columnHelper.accessor((row) => row.user_id, {
-        id: 'name:',
+        id: 'name',
         header: t('settings:inboxes.name'),
-        size: 100,
+        size: 200,
         cell: ({ getValue }) => {
           const user = orgUsers.find((u) => u.userId === getValue());
           if (!user) return;
@@ -57,15 +57,15 @@ export default function Inbox() {
         },
       }),
       columnHelper.accessor((row) => row.role, {
-        id: 'role:',
+        id: 'role',
         header: t('settings:inboxes.inbox_details.role'),
-        size: 100,
+        size: 200,
         cell: ({ getValue }) =>
           t(tKeyForInboxUserRole(getValue<InboxUserRole>())),
       }),
       columnHelper.display({
         id: 'actions',
-        size: 50,
+        size: 100,
         cell: ({ cell }) => {
           return (
             <div className="text-grey-00 group-hover:text-grey-100 flex gap-2">

--- a/packages/app-builder/src/routes/_builder+/settings+/tags.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/tags.tsx
@@ -39,12 +39,12 @@ export default function Tags() {
       columnHelper.accessor((row) => row.name, {
         id: 'name',
         header: t('settings:tags.name'),
-        size: 100,
+        size: 200,
       }),
       columnHelper.accessor((row) => row.color, {
         id: 'color',
         header: t('settings:tags.color'),
-        size: 50,
+        size: 100,
         cell: ({ getValue }) => (
           <div
             className="size-4 rounded-full"
@@ -55,11 +55,11 @@ export default function Tags() {
       columnHelper.accessor((row) => row.cases_count, {
         id: 'cases',
         header: t('settings:tags.cases'),
-        size: 100,
+        size: 200,
       }),
       columnHelper.display({
         id: 'actions',
-        size: 50,
+        size: 100,
         cell: ({ cell }) => {
           return (
             <div className="text-grey-00 group-hover:text-grey-100 flex gap-2">

--- a/packages/app-builder/src/routes/_builder+/settings+/users.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/users.tsx
@@ -54,12 +54,12 @@ export default function Users() {
       columnHelper.accessor((row) => `${row.firstName} ${row.lastName}`, {
         id: 'name',
         header: t('settings:users.name'),
-        size: 100,
+        size: 150,
       }),
       columnHelper.accessor((row) => row.email, {
         id: 'email',
         header: t('settings:users.email'),
-        size: 100,
+        size: 150,
         cell: ({ getValue }) => (
           <div className="overflow-hidden text-ellipsis">{getValue()}</div>
         ),
@@ -67,7 +67,7 @@ export default function Users() {
       columnHelper.accessor((row) => row.role, {
         id: 'role',
         header: t('settings:users.role'),
-        size: 100,
+        size: 150,
         cell: ({ getValue }) => t(tKeyForUserRole(getValue())),
       }),
       columnHelper.accessor((row) => row.userId, {

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/create_draft.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/create_draft.tsx
@@ -107,7 +107,9 @@ const NewDraftButton = ({
       <HiddenInputs iterationId={iterationId} />
       <Button type="submit">
         <Icon icon="plus" className="size-6" />
-        {t('scenarios:create_iteration.title')}
+        <span className="line-clamp-1 hidden shrink-0 lg:block">
+          {t('scenarios:create_iteration.title')}
+        </span>
       </Button>
     </fetcher.Form>
   );
@@ -131,7 +133,9 @@ const ExistingDraftModal = ({
       <Modal.Trigger asChild>
         <Button>
           <Icon icon="plus" className="size-6" />
-          {t('scenarios:create_iteration.title')}
+          <span className="line-clamp-1 hidden shrink-0 lg:block">
+            {t('scenarios:create_iteration.title')}
+          </span>
         </Button>
       </Modal.Trigger>
       <Modal.Content>

--- a/packages/app-builder/src/routes/ressources+/scenarios+/deployment.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/deployment.tsx
@@ -277,7 +277,9 @@ const DeploymentModal = ({
       <Modal.Trigger asChild>
         <Button {...buttonConfig.props}>
           <Icon icon={buttonConfig.icon.trigger} className="size-6" />
-          {t(buttonConfig.label)}
+          <span className="line-clamp-1 hidden shrink-0 lg:block">
+            {t(buttonConfig.label)}
+          </span>
         </Button>
       </Modal.Trigger>
       <Modal.Content className="bg-grey-00">
@@ -305,7 +307,9 @@ const DisabledDeploymentButton = ({
     >
       <Button {...buttonConfig.props} disabled>
         <Icon icon={buttonConfig.icon.trigger} className="size-6" />
-        {t(buttonConfig.label)}
+        <span className="line-clamp-1 hidden shrink-0 lg:block">
+          {t(buttonConfig.label)}
+        </span>
       </Button>
     </Tooltip.Default>
   );

--- a/packages/ui-design-system/src/Table/Table.tsx
+++ b/packages/ui-design-system/src/Table/Table.tsx
@@ -28,6 +28,8 @@ function TableContainer({
         'border-grey-10 border-spacing-0 rounded-lg border',
         className,
       )}
+      orientation="both"
+      type="auto"
     >
       <table
         className="w-full table-fixed border-separate border-spacing-0"


### PR DESCRIPTION
Small UI refactor to enable horizontal scrollability on tables :
- add a horizontal scroll indicator (always displayed when scrollable)
- start to scroll horizontally when the config pixel size is reached

Bonus: revamp some configs to set enlarge sizes (previously, the table was so shrinked, certain tables where unreadable)

Concretelly, here is an example :

**Before** actions on the right are unreachable (no scrolling)
<img width="614" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/2be7cd19-fa5c-4fba-a02a-9a3b12c6d31b">


**After** actions are accessible by scrollin, table is less shrinked
<img width="665" alt="Screenshot 2024-01-31 at 18 22 59" src="https://github.com/checkmarble/marble-frontend/assets/40292402/30e59a04-24fd-484b-bb2d-5d8df8529bbf">
