### PR TITLE
Thomas/mar 468 inbox users settings

### DIFF
--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
@@ -10,13 +10,17 @@ import { getRoute } from '@app-builder/utils/routes';
 import { fromParams } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
-import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getSortedRowModel,
+} from '@tanstack/react-table';
 import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import { type InboxUserDto, type InboxUserRole } from 'marble-api';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Table, Tooltip, useVirtualTable } from 'ui-design-system';
+import { Table, Tooltip, useTable } from 'ui-design-system';
 
 import { tKeyForInboxUserRole } from './inboxes._index';
 
@@ -78,13 +82,17 @@ export default function Inbox() {
     ];
   }, [orgUsers, t]);
 
-  const { table, getBodyProps, rows, getContainerProps } = useVirtualTable({
+  const { table, getBodyProps, rows, getContainerProps } = useTable({
     data: inbox.users ?? [],
     columns,
     columnResizeMode: 'onChange',
     getCoreRowModel: getCoreRowModel(),
-    enableSorting: false,
+    getSortedRowModel: getSortedRowModel(),
   });
+
+  const nonInboxUsers = orgUsers.filter(
+    (user) => !inbox.users?.some((u) => u.user_id === user.userId),
+  );
 
   return (
     <Page.Container>
@@ -119,7 +127,7 @@ export default function Inbox() {
             <span className="flex-1">
               {t('settings:inboxes.inbox_details.members')}
             </span>
-            <CreateInboxUser inboxId={inbox.id} />
+            <CreateInboxUser inboxId={inbox.id} users={nonInboxUsers} />
           </CollapsiblePaper.Title>
           <CollapsiblePaper.Content>
             <Table.Container {...getContainerProps()} className="max-h-96">

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.create.tsx
@@ -3,9 +3,9 @@ import { FormField } from '@app-builder/components/Form/FormField';
 import { FormLabel } from '@app-builder/components/Form/FormLabel';
 import { FormSelect } from '@app-builder/components/Form/FormSelect';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
+import { type User } from '@app-builder/models';
 import { tKeyForInboxUserRole } from '@app-builder/routes/_builder+/settings+/inboxes._index';
 import { serverServices } from '@app-builder/services/init.server';
-import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { conform, useForm } from '@conform-to/react';
@@ -71,7 +71,13 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 }
 
-export function CreateInboxUser({ inboxId }: { inboxId: string }) {
+export function CreateInboxUser({
+  inboxId,
+  users,
+}: {
+  inboxId: string;
+  users: User[];
+}) {
   const { t } = useTranslation(handle.i18n);
   const [open, setOpen] = useState(false);
 
@@ -91,7 +97,7 @@ export function CreateInboxUser({ inboxId }: { inboxId: string }) {
         </Button>
       </Modal.Trigger>
       <Modal.Content onClick={(e) => e.stopPropagation()}>
-        <CreateInboxUserContent currentInboxId={inboxId} />
+        <CreateInboxUserContent currentInboxId={inboxId} users={users} />
       </Modal.Content>
     </Modal.Root>
   );
@@ -99,8 +105,10 @@ export function CreateInboxUser({ inboxId }: { inboxId: string }) {
 
 export function CreateInboxUserContent({
   currentInboxId,
+  users,
 }: {
   currentInboxId: string;
+  users: User[];
 }) {
   const { t } = useTranslation(handle.i18n);
 
@@ -119,8 +127,7 @@ export function CreateInboxUserContent({
     },
   });
 
-  const { orgUsers } = useOrganizationUsers();
-  const userOptions = orgUsers.map((user) => ({
+  const userOptions = users.map((user) => ({
     id: user.userId,
     name: `${user.firstName} ${user.lastName}`,
   }));


### PR DESCRIPTION
Small improvment for settings/inbox:
- only inject non inbox users to "add new user" modal
- allow filtering on user table
- fix: collapsing the members card could lead to a "table disapearing" due to the table removed from the dom (this is due to `useVirtualTable`)