### PR TITLE
refactor(validation): use a single endpoint for validation

### DIFF
--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/trigger.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/trigger.tsx
@@ -15,7 +15,7 @@ import {
   NewEmptyTriggerAstNode,
 } from '@app-builder/models';
 import { useCurrentScenario } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/_layout';
-import { useTriggerOrRuleValidationFetcher } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule';
+import { useTriggerValidationFetcher } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule';
 import {
   useCurrentScenarioIteration,
   useEditorMode,
@@ -172,11 +172,10 @@ export default function Trigger() {
 
   const [schedule, setSchedule] = useState(scenarioIteration.schedule ?? '');
 
-  const { validate, validation: localValidation } =
-    useTriggerOrRuleValidationFetcher(
-      scenarioIteration.scenarioId,
-      scenarioIteration.id,
-    );
+  const { validate, validation: localValidation } = useTriggerValidationFetcher(
+    scenarioIteration.scenarioId,
+    scenarioIteration.id,
+  );
 
   const scenario = useCurrentScenario();
   const getScenarioErrorMessage = useGetScenarioErrorMessage();

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -18,7 +18,7 @@ import { adaptDataModelDto } from '@app-builder/models/data-model';
 import { useCurrentScenario } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/_layout';
 import { DeleteRule } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/delete';
 import { DuplicateRule } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/duplicate';
-import { useTriggerOrRuleValidationFetcher } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule';
+import { useRuleValidationFetcher } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule';
 import {
   useCurrentScenarioIterationRule,
   useEditorMode,
@@ -163,8 +163,11 @@ export default function RuleEdit() {
   const ruleId = useParam('ruleId');
 
   const fetcher = useFetcher<typeof action>();
-  const { validate, validation: localValidation } =
-    useTriggerOrRuleValidationFetcher(scenarioId, iterationId, ruleId);
+  const { validate, validation: localValidation } = useRuleValidationFetcher(
+    scenarioId,
+    iterationId,
+    ruleId,
+  );
 
   const scenario = useCurrentScenario();
   const rule = useCurrentScenarioIterationRule();

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -1337,44 +1337,11 @@ paths:
         '404':
           $ref: '#/components/responses/404'
   /scenario-iterations/{scenarioIterationId}/validate:
-    get:
-      tags:
-        - Scenario Iterations
-      summary: Validate a scenario iteration by id
-      operationId: validateScenarioIteration
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: scenarioIterationId
-          description: ID of the scenario iteration
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: The scenario validation of the iteration
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - scenario_validation
-                properties:
-                  scenario_validation:
-                    $ref: '#/components/schemas/ScenarioValidationDto'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
     post:
       tags:
         - Scenario Iterations
-      summary: Validate a scenario iteration using the rule or trigger passed in body
-      operationId: validateScenarioIterationWithGivenTriggerOrRule
+      summary: Validate a scenario iteration by id. A rule or trigger can be override in the body
+      operationId: validateScenarioIteration
       security:
         - bearerAuth: []
       parameters:
@@ -1401,10 +1368,9 @@ paths:
                   type: string
                   nullable: true
                   format: uuid
-        required: true
       responses:
         '200':
-          description: The scenario validation of the iteration using the rule or tigger passed in the body
+          description: The scenario validation of the sent iteration
           content:
             application/json:
               schema:

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -1350,31 +1350,9 @@ export function scheduleScenarioExecution(scenarioIterationId: string, opts?: Oa
     }));
 }
 /**
- * Validate a scenario iteration by id
+ * Validate a scenario iteration by id. A rule or trigger can be override in the body
  */
-export function validateScenarioIteration(scenarioIterationId: string, opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: {
-            scenario_validation: ScenarioValidationDto;
-        };
-    } | {
-        status: 401;
-        data: string;
-    } | {
-        status: 403;
-        data: string;
-    } | {
-        status: 404;
-        data: string;
-    }>(`/scenario-iterations/${encodeURIComponent(scenarioIterationId)}/validate`, {
-        ...opts
-    }));
-}
-/**
- * Validate a scenario iteration using the rule or trigger passed in body
- */
-export function validateScenarioIterationWithGivenTriggerOrRule(scenarioIterationId: string, body: {
+export function validateScenarioIteration(scenarioIterationId: string, body?: {
     trigger_or_rule: NodeDto;
     rule_id: string | null;
 }, opts?: Oazapfts.RequestOpts) {


### PR DESCRIPTION
In this PR :
- remove the GET validation endpoint from the API
- refactor validation related repository + `validate-with-given-trigger-or-rule`: the main idea is to expose higher level resources to the frontend
   - get trigger specific validation
   - get rule specific validation

In the future, we may want to only validate a portion of the ast or equivalent, this interface makes it easier to change (and understand what's really going on)