### PR TITLE
fix(firebase): add logout method to firebase service

### DIFF
--- a/packages/app-builder/src/infra/firebase.ts
+++ b/packages/app-builder/src/infra/firebase.ts
@@ -14,6 +14,7 @@ import {
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signInWithPopup,
+  signOut,
 } from 'firebase/auth';
 
 export type FirebaseClientWrapper = {
@@ -26,6 +27,7 @@ export type FirebaseClientWrapper = {
   createUserWithEmailAndPassword: typeof createUserWithEmailAndPassword;
   sendEmailVerification: typeof sendEmailVerification;
   sendPasswordResetEmail: typeof sendPasswordResetEmail;
+  logout: typeof signOut;
 };
 
 export function initializeFirebaseClient({
@@ -58,5 +60,6 @@ export function initializeFirebaseClient({
     createUserWithEmailAndPassword: createUserWithEmailAndPassword,
     sendEmailVerification: sendEmailVerification,
     sendPasswordResetEmail: sendPasswordResetEmail,
+    logout: signOut,
   };
 }

--- a/packages/app-builder/src/repositories/AuthenticationRepository.ts
+++ b/packages/app-builder/src/repositories/AuthenticationRepository.ts
@@ -40,6 +40,8 @@ export function getAuthenticationClientRepository(
 
   async function googleSignIn(locale: string) {
     const auth = getClientAuth(locale);
+    // Logout before sign in to avoid grant token firebase error
+    await firebaseClient.logout(auth);
     const credential = await firebaseClient.signInWithOAuth(
       auth,
       firebaseClient.googleAuthProvider,
@@ -49,6 +51,8 @@ export function getAuthenticationClientRepository(
 
   async function microsoftSignIn(locale: string) {
     const auth = getClientAuth(locale);
+    // Logout before sign in to avoid grant token firebase error
+    await firebaseClient.logout(auth);
     const credential = await firebaseClient.signInWithOAuth(
       auth,
       firebaseClient.microsoftAuthProvider,
@@ -62,6 +66,8 @@ export function getAuthenticationClientRepository(
     password: string,
   ) {
     const auth = getClientAuth(locale);
+    // Logout before sign in to avoid grant token firebase error
+    await firebaseClient.logout(auth);
     const credential = await firebaseClient.signInWithEmailAndPassword(
       auth,
       email,
@@ -86,6 +92,8 @@ export function getAuthenticationClientRepository(
     password: string,
   ) {
     const auth = getClientAuth(locale);
+    // Logout before sign up to avoid grant token firebase error
+    await firebaseClient.logout(auth);
     const credential = await firebaseClient.createUserWithEmailAndPassword(
       auth,
       email,


### PR DESCRIPTION
This is an attempt to fix the "double login" issue (first one result in an error, second one works).

### Context
From time to time, users experiment a "first login attempt failure". 

It seems to be related to a Firebase error due to a lack of permission on the token. It may be due to the current `logout` process which clear the user session but not the firebase client side data.

In order to ensure a Firebase login won't reuse local data, we enforce a `logout` before each sign in/sign up attempt.