### PR TITLE
feat(scenario): open most relevant iteration by default

### DIFF
--- a/packages/app-builder/src/repositories/ScenarioRepository.ts
+++ b/packages/app-builder/src/repositories/ScenarioRepository.ts
@@ -23,6 +23,7 @@ import { type Scenario } from 'marble-api';
 
 export interface ScenarioRepository {
   listScenarios(): Promise<Scenario[]>;
+  getScenario(args: { scenarioId: string }): Promise<Scenario>;
   createScenario(args: {
     name: string;
     description: string;
@@ -73,6 +74,10 @@ export function getScenarioRepository() {
     listScenarios: async () => {
       const scenarios = await marbleApiClient.listScenarios();
       return scenarios;
+    },
+    getScenario: async ({ scenarioId }) => {
+      const scenario = await marbleApiClient.getScenario(scenarioId);
+      return scenario;
     },
     createScenario: async (args) => {
       const scenario = await marbleApiClient.createScenario(args);

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_layout.tsx
@@ -17,15 +17,15 @@ export const handle = {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { authService } = serverServices;
-  const { apiClient } = await authService.isAuthenticated(request, {
+  const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
 
   const scenarioId = fromParams(params, 'scenarioId');
 
-  const scenario = await apiClient.getScenario(scenarioId);
+  const currentScenario = await scenario.getScenario({ scenarioId });
 
-  return json(scenario);
+  return json(currentScenario);
 }
 
 export const useCurrentScenario = () =>


### PR DESCRIPTION
In this PR :
- add missing repository `getScenario` function
- openning a scenario will open by default: 
  - the live version (if any)
  - or the most recent scenario version (draft of last published version)

It seems better like this. The previous logic was based on an old internal convention for publication