### PR TITLE
Thomas/fix decision nav

### DIFF
--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -2,7 +2,7 @@ import { CaseStatus, decisionsI18n, Outcome } from '@app-builder/components';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
-import { Link, useNavigate } from '@remix-run/react';
+import { Link } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { type DecisionDetail } from 'marble-api';
@@ -14,7 +14,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Checkbox, Table, useVirtualTable } from 'ui-design-system';
+import { Checkbox, rowLink, Table, useVirtualTable } from 'ui-design-system';
 
 import { Score } from './Score';
 
@@ -72,10 +72,20 @@ export function DecisionsList({
 }: DecisionsListProps) {
   const { t } = useTranslation(decisionsI18n);
   const language = useFormatLanguage();
-  const navigate = useNavigate();
 
   const columns = useMemo(() => {
     const columns = [
+      columnHelper.display({
+        ...rowLink.columnProps,
+        cell: ({ row }) => (
+          <Link
+            to={getRoute('/decisions/:decisionId', {
+              decisionId: fromUUID(row.original.id),
+            })}
+            className={rowLink.className}
+          />
+        ),
+      }),
       columnHelper.accessor((row) => row.created_at, {
         id: 'created_at',
         header: t('decisions:created_at'),
@@ -207,15 +217,8 @@ export function DecisionsList({
             <Table.Row
               key={row.id}
               tabIndex={0}
-              className={clsx('hover:bg-grey-02 cursor-pointer')}
+              className={clsx('hover:bg-grey-02 relative cursor-pointer')}
               row={row}
-              onClick={() => {
-                navigate(
-                  getRoute('/decisions/:decisionId', {
-                    decisionId: fromUUID(row.original.id),
-                  }),
-                );
-              }}
             />
           );
         })}

--- a/packages/app-builder/src/components/Page.tsx
+++ b/packages/app-builder/src/components/Page.tsx
@@ -1,6 +1,8 @@
+import { useNavigate } from '@remix-run/react';
 import { cva } from 'class-variance-authority';
 import clsx from 'clsx';
-import { ScrollAreaV2 } from 'ui-design-system';
+import { useTranslation } from 'react-i18next';
+import { ScrollAreaV2, Tooltip } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 function PageContainer({ className, ...props }: React.ComponentProps<'div'>) {
@@ -57,17 +59,26 @@ function PageContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function PageBackButton({ className, ...props }: React.ComponentProps<'div'>) {
+function PageBackButton({
+  className,
+  ...props
+}: React.ComponentProps<'button'>) {
+  const navigate = useNavigate();
+  const { t } = useTranslation(['common']);
   return (
-    <div
-      className={clsx(
-        'border-grey-10 flex items-center justify-center rounded-md border p-2',
-        className,
-      )}
-      {...props}
-    >
-      <Icon icon="arrow-left" className="size-5" />
-    </div>
+    <Tooltip.Default content={t('common:go_back')}>
+      <button
+        className={clsx(
+          'border-grey-10 hover:bg-grey-02 flex items-center justify-center rounded-md border p-2',
+          className,
+        )}
+        onClick={() => navigate(-1)}
+        {...props}
+      >
+        <Icon icon="arrow-left" className="size-5" aria-hidden />
+        <span className="sr-only">{t('common:go_back')}</span>
+      </button>
+    </Tooltip.Default>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId.tsx
@@ -16,11 +16,10 @@ import { EditCaseStatus } from '@app-builder/routes/ressources+/cases+/edit-stat
 import { UploadFile } from '@app-builder/routes/ressources+/cases+/upload-file';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import {
   isRouteErrorResponse,
-  Link,
   useLoaderData,
   useNavigate,
   useRouteError,
@@ -66,13 +65,7 @@ export default function CasePage() {
     <Page.Container>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
-          <Link
-            to={getRoute('/cases/inboxes/:inboxId', {
-              inboxId: fromUUID(caseDetail.inbox_id),
-            })}
-          >
-            <Page.BackButton />
-          </Link>
+          <Page.BackButton />
           {caseDetail.name}
           <CopyToClipboardButton toCopy={caseDetail.id}>
             <span className="text-s font-normal">

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -136,7 +136,7 @@ export default function Cases() {
                 </CaseRightPanel.Trigger>
               </div>
               <CasesFiltersBar />
-              <CasesList cases={cases} className="max-h-[70dvh]" />
+              <CasesList cases={cases} className="max-h-[60dvh]" />
               <PaginationButtons
                 items={cases}
                 onPaginationChange={(paginationParams: PaginationParams) =>

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -21,7 +21,6 @@ import { shortUUIDSchema } from '@app-builder/utils/schema/shortUUIDSchema';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import {
   isRouteErrorResponse,
-  Link,
   useLoaderData,
   useNavigate,
   useRouteError,
@@ -67,14 +66,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 export default function DecisionPage() {
   const { decision } = useLoaderData<typeof loader>();
   const { t } = useTranslation(decisionsI18n);
+
   return (
     <DecisionRightPanel.Root>
       <Page.Container>
         <Page.Header className="justify-between">
           <div className="flex flex-row items-center gap-4">
-            <Link to="./..">
-              <Page.BackButton />
-            </Link>
+            <Page.BackButton />
             {t('decisions:decision')}
             <CopyToClipboardButton toCopy={decision.id}>
               <span className="text-s font-normal">

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -156,7 +156,7 @@ export default function Decisions() {
               </div>
               <DecisionFiltersBar />
               <DecisionsList
-                className="max-h-[70dvh]"
+                className="max-h-[60dvh]"
                 decisions={decisions}
                 selectable
                 selectionProps={selectionProps}

--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -12,7 +12,7 @@ import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { Link, useLoaderData, useRouteError } from '@remix-run/react';
+import { useLoaderData, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
 import {
   createColumnHelper,
@@ -105,9 +105,7 @@ export default function Lists() {
       <Page.Header className="justify-between ">
         <div className="flex w-full flex-row items-center justify-between	gap-4">
           <div className="flex flex-row items-center gap-4">
-            <Link to="./.." className="mr-4">
-              <Page.BackButton />
-            </Link>
+            <Page.BackButton />
             {customList.name}
           </div>
           {canManageList ? (

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
@@ -25,7 +25,7 @@ import {
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, useParam } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { Link, Outlet, useLoaderData } from '@remix-run/react';
+import { Outlet, useLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import invariant from 'tiny-invariant';
@@ -103,9 +103,7 @@ export default function ScenarioEditLayout() {
     <Page.Container>
       <Page.Header className="justify-between gap-4">
         <div className="flex flex-row items-center gap-4">
-          <Link to={getRoute('/scenarios/')}>
-            <Page.BackButton />
-          </Link>
+          <Page.BackButton />
           <UpdateScenario
             defaultValue={{
               name: currentScenario.name,

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -41,7 +41,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import {  useFetcher, useLoaderData } from '@remix-run/react';
+import { useFetcher, useLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import { useEffect } from 'react';
 import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -41,7 +41,7 @@ import {
   json,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
-import { Link, useFetcher, useLoaderData } from '@remix-run/react';
+import {  useFetcher, useLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import { useEffect } from 'react';
 import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
@@ -219,9 +219,7 @@ export default function RuleEdit() {
     <Page.Container>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
-          <Link to="./..">
-            <Page.BackButton />
-          </Link>
+          <Page.BackButton />
           {rule.name ?? fromUUID(ruleId)}
           {editorMode === 'edit' ? (
             <Tag size="big" border="square">

--- a/packages/ui-design-system/src/ScrollArea/ScrollArea.tsx
+++ b/packages/ui-design-system/src/ScrollArea/ScrollArea.tsx
@@ -123,7 +123,7 @@ export const ScrollAreaV2 = forwardRef<ScrollAreaElement, ScrollAreaV2Props>(
         {orientation !== 'vertical' ? (
           <Scrollbar
             orientation="horizontal"
-            className="hover:bg-grey-10 m-px flex h-1 touch-none select-none flex-col rounded-full transition"
+            className="hover:bg-grey-10 z-50 m-px flex h-1 touch-none select-none flex-col rounded-full transition"
           >
             <Thumb className="bg-grey-25 hover:bg-grey-50 relative flex-1 rounded-full transition-colors" />
           </Scrollbar>
@@ -132,7 +132,7 @@ export const ScrollAreaV2 = forwardRef<ScrollAreaElement, ScrollAreaV2Props>(
         {orientation !== 'horizontal' ? (
           <Scrollbar
             orientation="vertical"
-            className="hover:bg-grey-10 m-px flex w-1 touch-none select-none flex-row rounded-full transition"
+            className="hover:bg-grey-10 z-50 m-px flex w-1 touch-none select-none flex-row rounded-full transition"
           >
             <Thumb className="bg-grey-25 hover:bg-grey-50 relative flex-1 rounded-full transition-colors" />
           </Scrollbar>

--- a/packages/ui-design-system/src/Table/Table.tsx
+++ b/packages/ui-design-system/src/Table/Table.tsx
@@ -32,7 +32,7 @@ function TableContainer({
       type="auto"
     >
       <table
-        className="w-full table-fixed border-separate border-spacing-0"
+        className="isolate w-full table-fixed border-separate border-spacing-0"
         {...props}
       />
     </ScrollAreaV2>
@@ -64,25 +64,42 @@ function TableTH<TData extends RowData, TValue>({
   );
 }
 
+const internalRowLink = '__internal-row-link';
+export const rowLink = {
+  columnProps: {
+    id: internalRowLink,
+    header: '',
+  },
+  className:
+    "block size-0 overflow-hidden after:absolute after:inset-0 after:content-['']",
+};
+
 function Header<TData extends RowData>({
   headerGroups,
 }: {
   headerGroups: HeaderGroup<TData>[];
 }) {
   return (
-    <thead className="sticky top-0">
+    <thead className="sticky top-0 z-10">
       {headerGroups.map((headerGroup) => (
         <tr key={headerGroup.id}>
           {headerGroup.headers.map((header, index) => {
+            const context = header.getContext();
+            if (header.id === internalRowLink) {
+              return (
+                <th
+                  colSpan={header.colSpan}
+                  key={header.id}
+                  className="bg-grey-02 border-grey-10 w-0 border-b"
+                ></th>
+              );
+            }
             return (
               <Table.TH header={header} key={header.id}>
                 {header.isPlaceholder ? null : (
                   <div className="text-s text-grey-100 flex flex-row items-center font-semibold">
                     <p className="flex flex-1">
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
+                      {flexRender(header.column.columnDef.header, context)}
                     </p>
                     {{
                       asc: <Icon icon="arrow-2-up" className="size-6" />,
@@ -204,14 +221,25 @@ function Row<TData extends RowData>({
   ...props
 }: Omit<React.ComponentProps<'tr'>, 'children'> & { row: Row<TData> }) {
   return (
-    <tr className={clsx('group h-16', className)} {...props}>
+    <tr className={clsx('group relative h-16', className)} {...props}>
       {row.getVisibleCells().map((cell) => {
+        const context = cell.getContext();
+        if (context.column.id === internalRowLink) {
+          return (
+            <td
+              key={cell.id}
+              className="border-grey-10 border-b group-last:border-b-0"
+            >
+              {flexRender(cell.column.columnDef.cell, context)}
+            </td>
+          );
+        }
         return (
           <td
             key={cell.id}
             className="border-grey-10 text-s w-full border-b px-4 font-normal group-last:border-b-0"
           >
-            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            {flexRender(cell.column.columnDef.cell, context)}
           </td>
         );
       })}


### PR DESCRIPTION
In this PR :
- shorten some table height so pagination is still visible in the page when some filters are selected
- expose a specific "hidden" column for table so we can display an "invisible" link that englobe the row

This implementation (in place of the JS `onClick` handler) allow to keep web `<a />` UX (eg right click specific menu, cmd+click openning...)

Bonus: change `BackButton` implem to move from a `<a />` to a `<button />` calling `navigate.back()`.
In short :
- we gain a "clone" from the back button of the navigator
- we introduce nav side effects (due to back button behaviour)
  - if we do not have history, nothing happen when clicking the button
  - if we come from a separate website, it redirect back to the previous website