### PR TITLE
refactor(EvaluationErrors): improve error messages UI

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/EditFilters.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/EditFilters.tsx
@@ -10,6 +10,10 @@ import {
   adaptEditorNodeViewModel,
   type AstBuilder,
 } from '@app-builder/services/editor/ast-editor';
+import {
+  adaptEvaluationErrorViewModels,
+  useGetNodeEvaluationErrorMessage,
+} from '@app-builder/services/validation';
 import clsx from 'clsx';
 import { Fragment } from 'react/jsx-runtime';
 import { useTranslation } from 'react-i18next';
@@ -84,6 +88,8 @@ export const EditFilters = ({
     onChange(value.filter((_, index) => index !== filterIndex));
   };
 
+  const getNodeEvaluationErrorMessage = useGetNodeEvaluationErrorMessage();
+
   return (
     <div>
       <div className="grid grid-cols-[8px_16px_max-content_1fr_max-content]">
@@ -147,10 +153,10 @@ export const EditFilters = ({
                   />
                 </div>
                 <EvaluationErrors
-                  evaluationErrors={[
+                  errors={adaptEvaluationErrorViewModels([
                     ...filter.errors.filter,
                     ...filter.errors.value,
-                  ]}
+                  ]).map(getNodeEvaluationErrorMessage)}
                 />
               </div>
               <div className="col-start-5 flex h-10 flex-col items-center justify-center">

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/Modal.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/Modal.tsx
@@ -17,6 +17,10 @@ import {
   type EditorNodeViewModel,
 } from '@app-builder/services/editor/ast-editor';
 import { CopyPasteASTContextProvider } from '@app-builder/services/editor/copy-paste-ast';
+import {
+  adaptEvaluationErrorViewModels,
+  useGetNodeEvaluationErrorMessage,
+} from '@app-builder/services/validation';
 import { createSimpleContext } from '@app-builder/utils/create-context';
 import { type Namespace } from 'i18next';
 import {
@@ -257,6 +261,8 @@ const AggregationEditModalContent = ({
     onSave(adaptAggregationAstNode(aggregation));
   };
 
+  const getNodeEvaluationErrorMessage = useGetNodeEvaluationErrorMessage();
+
   return (
     <>
       <ModalV2.Title>
@@ -295,7 +301,11 @@ const AggregationEditModalContent = ({
                 aggregation.errors.label.length > 0 ? 'red-100' : 'grey-10'
               }
             />
-            <EvaluationErrors evaluationErrors={aggregation.errors.label} />
+            <EvaluationErrors
+              errors={adaptEvaluationErrorViewModels(
+                aggregation.errors.label,
+              ).map(getNodeEvaluationErrorMessage)}
+            />
           </div>
           <div className="flex flex-col gap-2">
             {t('scenarios:edit_aggregation.function_title')}
@@ -317,7 +327,9 @@ const AggregationEditModalContent = ({
                   operators={aggregatorOperators}
                 />
                 <EvaluationErrors
-                  evaluationErrors={aggregation.errors.aggregator}
+                  errors={adaptEvaluationErrorViewModels(
+                    aggregation.errors.aggregator,
+                  ).map(getNodeEvaluationErrorMessage)}
                 />
               </div>
               <div className="flex flex-col gap-2">
@@ -338,7 +350,9 @@ const AggregationEditModalContent = ({
                   errors={aggregation.errors.aggregatedField}
                 />
                 <EvaluationErrors
-                  evaluationErrors={aggregation.errors.aggregatedField}
+                  errors={adaptEvaluationErrorViewModels(
+                    aggregation.errors.aggregatedField,
+                  ).map(getNodeEvaluationErrorMessage)}
                 />
               </div>
             </div>

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/Modal.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TimeAddEdit/Modal.tsx
@@ -21,6 +21,10 @@ import {
   type EditorNodeViewModel,
 } from '@app-builder/services/editor/ast-editor';
 import { CopyPasteASTContextProvider } from '@app-builder/services/editor/copy-paste-ast';
+import {
+  adaptEvaluationErrorViewModels,
+  useGetNodeEvaluationErrorMessage,
+} from '@app-builder/services/validation';
 import { createSimpleContext } from '@app-builder/utils/create-context';
 import { type PropsWithChildren, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -174,11 +178,13 @@ const TimeAddEditModalContent = ({
   onSave: (astNode: AstNode) => void;
 }) => {
   const { t } = useTranslation(['scenarios', 'common']);
+  const getNodeEvaluationErrorMessage = useGetNodeEvaluationErrorMessage();
   const [value, setValue] = useState<TimeAddViewModal>(() => initialValue);
 
   const handleSave = () => {
     onSave(adaptTimeAddAstNode(value));
   };
+
   return (
     <>
       <Modal.Title>{t('scenarios:edit_date.title')}</Modal.Title>
@@ -242,11 +248,11 @@ const TimeAddEditModalContent = ({
             />
           </div>
           <EvaluationErrors
-            evaluationErrors={[
+            errors={adaptEvaluationErrorViewModels([
               ...value.errors.timestampField,
               ...value.errors.sign,
               ...value.errors.duration,
-            ]}
+            ]).map(getNodeEvaluationErrorMessage)}
           />
         </div>
         <div className="flex flex-1 flex-row gap-2">

--- a/packages/app-builder/src/components/Scenario/ScenarioValidationError.tsx
+++ b/packages/app-builder/src/components/Scenario/ScenarioValidationError.tsx
@@ -1,47 +1,25 @@
-import { type EvaluationError } from '@app-builder/models';
-import {
-  adaptEvaluationErrorViewModels,
-  useGetNodeEvaluationErrorMessage,
-} from '@app-builder/services/validation';
 import clsx from 'clsx';
-import type React from 'react';
-
-export function ScenarioValidationError({
-  className,
-  children,
-}: {
-  className?: string;
-  children?: React.ReactNode;
-}) {
-  return (
-    <div
-      className={clsx(
-        'bg-red-05 text-s flex h-8 items-center justify-center rounded px-2 py-1 font-medium text-red-100',
-        className,
-      )}
-    >
-      {children}
-    </div>
-  );
-}
 
 export function EvaluationErrors({
-  evaluationErrors,
+  errors,
   className,
 }: {
-  evaluationErrors: EvaluationError[];
+  errors: string[];
   className?: string;
 }) {
-  const getNodeEvaluationErrorMessage = useGetNodeEvaluationErrorMessage();
-  if (evaluationErrors.length === 0) return null;
-
-  const errors = adaptEvaluationErrorViewModels(evaluationErrors).map((error) =>
-    getNodeEvaluationErrorMessage(error),
-  );
+  if (errors.length === 0) return null;
   return (
     <div className={clsx('flex flex-row flex-wrap gap-2', className)}>
       {errors.map((error) => (
-        <ScenarioValidationError key={error}>{error}</ScenarioValidationError>
+        <span
+          key={error}
+          className={clsx(
+            'bg-red-05 text-s flex h-8 items-center justify-center rounded px-2 py-1 font-medium text-red-100',
+            className,
+          )}
+        >
+          {error}
+        </span>
       ))}
     </div>
   );

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
@@ -1,5 +1,5 @@
 import { Ping } from '@app-builder/components/Ping';
-import { ScenarioValidationError } from '@app-builder/components/Scenario/ScenarioValidationError';
+import { EvaluationErrors } from '@app-builder/components/Scenario/ScenarioValidationError';
 import { CreateRule } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/create';
 import { useEditorMode } from '@app-builder/services/editor';
 import { serverServices } from '@app-builder/services/init.server';
@@ -131,20 +131,21 @@ export default function Rules() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-row items-center justify-between gap-2">
-        <div className="flex flex-row flex-wrap gap-1">
-          {scenarioValidation.rules.errors.map((error) => (
-            <ScenarioValidationError key={error}>
-              {getScenarioErrorMessage(error)}
-            </ScenarioValidationError>
-          ))}
+      {editorMode === 'edit' ? (
+        <div className="flex flex-row-reverse items-center justify-between gap-2">
+          <CreateRule scenarioId={scenarioId} iterationId={iterationId} />
+          <EvaluationErrors
+            errors={scenarioValidation.rules.errors.map(
+              getScenarioErrorMessage,
+            )}
+          />
         </div>
-        <span>
-          {editorMode === 'edit' ? (
-            <CreateRule scenarioId={scenarioId} iterationId={iterationId} />
-          ) : null}
-        </span>
-      </div>
+      ) : (
+        <EvaluationErrors
+          errors={scenarioValidation.rules.errors.map(getScenarioErrorMessage)}
+        />
+      )}
+
       <Table.Container {...getContainerProps()} className="bg-grey-00 max-h-96">
         <Table.Header headerGroups={table.getHeaderGroups()} />
         <Table.Body {...getBodyProps()}>

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/trigger.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/trigger.tsx
@@ -6,7 +6,7 @@ import {
 } from '@app-builder/components';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { AstBuilder } from '@app-builder/components/Scenario/AstBuilder';
-import { ScenarioValidationError } from '@app-builder/components/Scenario/ScenarioValidationError';
+import { EvaluationErrors } from '@app-builder/components/Scenario/ScenarioValidationError';
 import { ScheduleOption } from '@app-builder/components/Scenario/Trigger';
 import {
   adaptDataModelDto,
@@ -249,24 +249,24 @@ export default function Trigger() {
 
       <AstBuilder builder={astEditor} viewOnly={editorMode === 'view'} />
 
-      <div className="flex flex-row items-end justify-between gap-2">
-        <div className="flex min-h-[40px] flex-row flex-wrap gap-1">
-          {scenarioValidation.trigger.errors
-            .filter((error) => error != 'TRIGGER_CONDITION_REQUIRED')
-            .map((error) => (
-              <ScenarioValidationError key={error}>
-                {getScenarioErrorMessage(error)}
-              </ScenarioValidationError>
-            ))}
+      {editorMode === 'edit' ? (
+        <div className="flex flex-row-reverse items-center justify-between gap-2">
+          <Button type="submit" onClick={handleSave}>
+            {t('common:save')}
+          </Button>
+          <EvaluationErrors
+            errors={scenarioValidation.trigger.errors
+              .filter((error) => error != 'TRIGGER_CONDITION_REQUIRED')
+              .map(getScenarioErrorMessage)}
+          />
         </div>
-        <span>
-          {editorMode === 'edit' ? (
-            <Button type="submit" onClick={handleSave}>
-              {t('common:save')}
-            </Button>
-          ) : null}
-        </span>
-      </div>
+      ) : (
+        <EvaluationErrors
+          errors={scenarioValidation.trigger.errors
+            .filter((error) => error != 'TRIGGER_CONDITION_REQUIRED')
+            .map(getScenarioErrorMessage)}
+        />
+      )}
     </Paper.Container>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -8,7 +8,7 @@ import {
 } from '@app-builder/components/Form';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { AstBuilder } from '@app-builder/components/Scenario/AstBuilder';
-import { ScenarioValidationError } from '@app-builder/components/Scenario/ScenarioValidationError';
+import { EvaluationErrors } from '@app-builder/components/Scenario/ScenarioValidationError';
 import {
   type AstNode,
   NewEmptyRuleAstNode,
@@ -400,17 +400,11 @@ function RuleEditContent({
       <Paper.Container scrollable={false} className="bg-grey-00 max-w-3xl">
         <AstBuilder builder={builder} />
 
-        {ruleValidation.errors ? (
-          <div className="flex flex-row flex-wrap gap-1">
-            {ruleValidation.errors
-              .filter((error) => error != 'RULE_FORMULA_REQUIRED')
-              .map((error) => (
-                <ScenarioValidationError key={error}>
-                  {getScenarioErrorMessage(error)}
-                </ScenarioValidationError>
-              ))}
-          </div>
-        ) : null}
+        <EvaluationErrors
+          errors={ruleValidation.errors
+            .filter((error) => error != 'RULE_FORMULA_REQUIRED')
+            .map(getScenarioErrorMessage)}
+        />
       </Paper.Container>
 
       <DeleteRule


### PR DESCRIPTION
Improve `EvaluationErrors` handling: there was a lot of specific rendering for that, especially inside aggregation modal
- expose a better abstraction
  - handle errors as an array to give consistency accross screens to display errors
  - the first refactor I did was too specific
- fix a lot of layering issues (especially between `view` and `edit` mode): this is UI only