### PR TITLE
Thomas/add decision scenario iteration

### DIFF
--- a/packages/app-builder/public/locales/en/decisions.json
+++ b/packages/app-builder/public/locales/en/decisions.json
@@ -33,5 +33,6 @@
   "rules.status.triggered": "triggered",
   "rules.status.error": "error",
   "rules.status.unknown": "unknown",
-  "rules.description": "Description"
+  "rules.description": "Description",
+  "rules.error.not_found": "The associated rule info could not be found. Please try again or contact your admin."
 }

--- a/packages/app-builder/public/locales/en/decisions.json
+++ b/packages/app-builder/public/locales/en/decisions.json
@@ -1,5 +1,6 @@
 {
   "scenario.name": "Scenario",
+  "scenario.version": "Version",
   "search.placeholder": "Search by id",
   "detail.scenario_name_runs_on": "<ScenarioName>{{scenarioName}}</ScenarioName> (runs on <TriggerObjectType>{{triggerObjectType}}</TriggerObjectType>)",
   "detail.error": "An error as occured. Make sure the provided decision id is valid.",

--- a/packages/app-builder/src/components/Decisions/DecisionDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionDetail.tsx
@@ -19,11 +19,12 @@ export function DecisionDetail({ decision }: { decision: DecisionDetail }) {
         {t('decisions:decision_detail.title')}
       </Collapsible.Title>
       <Collapsible.Content>
-        <div className="grid grid-cols-[max-content_1fr] grid-rows-4 items-center gap-x-10 gap-y-2">
+        <div className="grid grid-cols-[max-content_1fr] grid-rows-5 items-center gap-x-10 gap-y-2">
           <DetailLabel>{t('decisions:created_at')}</DetailLabel>
           <time dateTime={createdAt}>
             {formatDateTime(createdAt, { language })}
           </time>
+
           <DetailLabel>{t('decisions:scenario.name')}</DetailLabel>
           <Link
             to={getRoute('/scenarios/:scenarioId', {
@@ -33,8 +34,21 @@ export function DecisionDetail({ decision }: { decision: DecisionDetail }) {
           >
             {scenario.name}
           </Link>
+
+          <DetailLabel>{t('decisions:scenario.version')}</DetailLabel>
+          <Link
+            to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
+              scenarioId: fromUUID(scenario.id),
+              iterationId: fromUUID(scenario.scenarioIterationId),
+            })}
+            className="hover:text-purple-120 focus:text-purple-120 font-semibold capitalize text-purple-100 hover:underline focus:underline"
+          >
+            {`V${scenario.version}`}
+          </Link>
+
           <DetailLabel>{t('decisions:object_type')}</DetailLabel>
           <div className="capitalize">{triggerObjectType}</div>
+
           <DetailLabel>{t('decisions:case')}</DetailLabel>
           {caseDetail ? (
             <div className="flex w-fit flex-row items-center justify-center gap-1">

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -29,7 +29,7 @@ type Column =
   | 'score'
   | 'outcome';
 
-interface DecisionVM {
+interface DecisionViewModel {
   id: string;
   createdAt: string;
   scenario: {
@@ -50,7 +50,7 @@ interface DecisionVM {
 
 type DecisionsListProps = {
   className?: string;
-  decisions: DecisionVM[];
+  decisions: DecisionViewModel[];
   columnVisibility?: Partial<Record<Column, boolean>>;
 } & (WithSelectable | WithoutSelectable);
 
@@ -66,7 +66,7 @@ type WithoutSelectable = {
 
 export function useSelectedDecisionIds() {
   const [rowSelection, setRowSelection] = useState({});
-  const getSelectedDecisionsRef = useRef<() => DecisionVM[]>(() => []);
+  const getSelectedDecisionsRef = useRef<() => DecisionViewModel[]>(() => []);
   const getSelectedDecisions = useCallback(
     () => getSelectedDecisionsRef.current(),
     [],
@@ -83,7 +83,7 @@ export function useSelectedDecisionIds() {
   };
 }
 
-const columnHelper = createColumnHelper<DecisionVM>();
+const columnHelper = createColumnHelper<DecisionViewModel>();
 
 export function DecisionsList({
   className,

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -93,6 +93,34 @@ export function DecisionsList({
         id: 'scenario_name',
         header: t('decisions:scenario.name'),
         size: 200,
+        cell: ({ getValue, row }) => (
+          <Link
+            to={getRoute('/scenarios/:scenarioId', {
+              scenarioId: fromUUID(row.original.scenario.id),
+            })}
+            onClick={(e) => e.stopPropagation()}
+            className="hover:text-purple-120 focus:text-purple-120 font-semibold capitalize text-purple-100 hover:underline focus:underline"
+          >
+            {getValue()}
+          </Link>
+        ),
+      }),
+      columnHelper.accessor((row) => row.scenario.version, {
+        id: 'scenario_version',
+        header: 'Vi',
+        size: 20,
+        cell: ({ getValue, row }) => (
+          <Link
+            to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
+              scenarioId: fromUUID(row.original.scenario.id),
+              iterationId: fromUUID(row.original.scenario.scenarioIterationId),
+            })}
+            onClick={(e) => e.stopPropagation()}
+            className="hover:text-purple-120 focus:text-purple-120 font-semibold capitalize text-purple-100 hover:underline focus:underline"
+          >
+            {`V${getValue()}`}
+          </Link>
+        ),
       }),
       columnHelper.accessor((row) => row.triggerObjectType, {
         id: 'trigger_object_type',

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -1,5 +1,4 @@
 import { CaseStatus, decisionsI18n, Outcome } from '@app-builder/components';
-import { type DecisionDetail } from '@app-builder/models/decision';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -7,6 +7,10 @@ import { Link, useNavigate } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
 import {
+  type CaseStatus as TCaseStatus,
+  type Outcome as TOutcome,
+} from 'marble-api';
+import {
   useCallback,
   useImperativeHandle,
   useMemo,
@@ -26,9 +30,28 @@ type Column =
   | 'score'
   | 'outcome';
 
+interface DecisionVM {
+  id: string;
+  createdAt: string;
+  scenario: {
+    id: string;
+    name: string;
+    version: number;
+    scenarioIterationId: string;
+  };
+  triggerObjectType: string;
+  case?: {
+    id: string;
+    name: string;
+    status: TCaseStatus;
+  };
+  score: number;
+  outcome: TOutcome;
+}
+
 type DecisionsListProps = {
   className?: string;
-  decisions: DecisionDetail[];
+  decisions: DecisionVM[];
   columnVisibility?: Partial<Record<Column, boolean>>;
 } & (WithSelectable | WithoutSelectable);
 
@@ -44,7 +67,7 @@ type WithoutSelectable = {
 
 export function useSelectedDecisionIds() {
   const [rowSelection, setRowSelection] = useState({});
-  const getSelectedDecisionsRef = useRef<() => DecisionDetail[]>(() => []);
+  const getSelectedDecisionsRef = useRef<() => DecisionVM[]>(() => []);
   const getSelectedDecisions = useCallback(
     () => getSelectedDecisionsRef.current(),
     [],
@@ -61,7 +84,7 @@ export function useSelectedDecisionIds() {
   };
 }
 
-const columnHelper = createColumnHelper<DecisionDetail>();
+const columnHelper = createColumnHelper<DecisionVM>();
 
 export function DecisionsList({
   className,

--- a/packages/app-builder/src/components/Decisions/RulesDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/RulesDetail.tsx
@@ -86,16 +86,16 @@ export function RulesDetail({
                           Score: <span className="font-semibold" />,
                         }}
                         values={{
-                          score: formatNumber(rule.scoreModifier, {
+                          score: formatNumber(rule.ruleDetail.scoreModifier, {
                             language,
                             signDisplay: 'always',
                           }),
                         }}
                       />
                     </div>
-                    {rule.formula ? (
+                    {rule.ruleDetail.formula ? (
                       <RuleFormula
-                        formula={rule.formula}
+                        formula={rule.ruleDetail.formula}
                         databaseAccessors={databaseAccessors}
                         payloadAccessors={payloadAccessors}
                         astOperators={astOperators}

--- a/packages/app-builder/src/models/cases.ts
+++ b/packages/app-builder/src/models/cases.ts
@@ -6,12 +6,12 @@ import {
   type CaseTagsUpdatedEventDto,
   type CommentAddedEvent,
   type DecisionAddedEvent,
+  type Error,
   type FileAddedEvent,
   type InboxChangedEvent,
   type NameUpdatedEvent,
+  type Outcome,
 } from 'marble-api';
-
-import { adaptDecision, type Decision } from './decision';
 
 interface CaseTagsUpdatedEvent
   extends Omit<CaseTagsUpdatedEventDto, 'new_value'> {
@@ -60,7 +60,22 @@ export function adaptCaseEventDto(caseEventDto: CaseEventDto): CaseEvent {
 
 export interface CaseDetail
   extends Omit<CaseDetailDto, 'events' | 'decisions'> {
-  decisions: Decision[];
+  decisions: {
+    id: string;
+    createdAt: string;
+    triggerObject: Record<string, unknown>;
+    triggerObjectType: string;
+    outcome: Outcome;
+    scenario: {
+      id: string;
+      name: string;
+      description: string;
+      scenarioIterationId: string;
+      version: number;
+    };
+    score: number;
+    error?: Error;
+  }[];
   events: CaseEvent[];
 }
 
@@ -71,7 +86,21 @@ export function adaptCaseDetailDto({
 }: CaseDetailDto): CaseDetail {
   return {
     ...rest,
-    decisions: decisions.map(adaptDecision),
+    decisions: decisions.map((decisionDto) => ({
+      id: decisionDto.id,
+      createdAt: decisionDto.created_at,
+      triggerObject: decisionDto.trigger_object,
+      triggerObjectType: decisionDto.trigger_object_type,
+      outcome: decisionDto.outcome,
+      scenario: {
+        id: decisionDto.scenario.id,
+        name: decisionDto.scenario.name,
+        description: decisionDto.scenario.description,
+        scenarioIterationId: decisionDto.scenario.scenario_iteration_id,
+        version: decisionDto.scenario.version,
+      },
+      score: decisionDto.score,
+    })),
     events: events.map(adaptCaseEventDto),
   };
 }

--- a/packages/app-builder/src/models/decision.ts
+++ b/packages/app-builder/src/models/decision.ts
@@ -20,6 +20,7 @@ interface DecisionWithoutRule {
     id: string;
     name: string;
     description: string;
+    scenarioIterationId: string;
     version: number;
   };
   score: number;
@@ -39,7 +40,10 @@ export interface Decision extends DecisionWithoutRule {
 }
 
 export interface RuleExecutionWithFormula extends RuleExecution {
-  formula?: AstNode | null;
+  ruleDetail: {
+    scoreModifier: number;
+    formula?: AstNode | null;
+  };
 }
 
 export interface DecisionDetail extends DecisionWithoutRule {
@@ -60,6 +64,7 @@ function adaptDecisionWithoutRule(
       id: dto.scenario.id,
       name: dto.scenario.name,
       description: dto.scenario.description,
+      scenarioIterationId: dto.scenario.scenario_iteration_id,
       version: dto.scenario.version,
     },
     score: dto.score,
@@ -91,9 +96,12 @@ export function adaptDecisionDetail(dto: DecisionDetailDto): DecisionDetail {
     case: dto.case,
     rules: dto.rules.map((rule) => ({
       ...adaptRuleExecutionDto(rule),
-      formula: rule.formula_ast_expression
-        ? adaptAstNode(rule.formula_ast_expression)
-        : null,
+      ruleDetail: {
+        scoreModifier: rule.rule_detail.score_modifier,
+        formula: rule.rule_detail.formula_ast_expression
+          ? adaptAstNode(rule.rule_detail.formula_ast_expression)
+          : null,
+      },
     })),
   };
 }

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -11,14 +11,14 @@ import {
 } from '@app-builder/components';
 import { ScorePanel } from '@app-builder/components/Decisions/Score';
 import { TriggerObjectDetail } from '@app-builder/components/Decisions/TriggerObjectDetail';
-import { adaptDataModelDto, isNotFoundHttpError } from '@app-builder/models';
+import { isNotFoundHttpError } from '@app-builder/models';
 import { serverServices } from '@app-builder/services/init.server';
 import { handleParseParamError } from '@app-builder/utils/http/handle-errors';
 import { notFound } from '@app-builder/utils/http/http-responses';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { shortUUIDSchema } from '@app-builder/utils/schema/shortUUIDSchema';
-import { json, type LoaderFunctionArgs } from '@remix-run/node';
+import { defer, type LoaderFunctionArgs } from '@remix-run/node';
 import {
   isRouteErrorResponse,
   Link,
@@ -39,7 +39,7 @@ export const handle = {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { authService } = serverServices;
-  const { decision, editor, apiClient, scenario } =
+  const { decision, editor, apiClient, scenario, dataModelRepository } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),
     });
@@ -55,29 +55,38 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     const currentDecision = await decision.getDecisionById(decisionId);
 
-    const scenarioIterationPromise = scenario.getScenarioIteration({
-      iterationId: currentDecision.scenario.scenarioIterationId,
-    });
+    const astRuleData = Promise.all([
+      scenario.getScenarioIteration({
+        iterationId: currentDecision.scenario.scenarioIterationId,
+      }),
+      editor.listOperators({
+        scenarioId: currentDecision.scenario.id,
+      }),
+      editor.listAccessors({
+        scenarioId: currentDecision.scenario.id,
+      }),
+      dataModelRepository.getDataModel(),
+      apiClient.listCustomLists(),
+    ]).then(
+      ([
+        scenarioIteration,
+        astOperators,
+        accessors,
+        dataModel,
+        { custom_lists },
+      ]) => ({
+        rules: scenarioIteration.rules,
+        databaseAccessors: accessors.databaseAccessors,
+        payloadAccessors: accessors.payloadAccessors,
+        astOperators,
+        dataModel,
+        customLists: custom_lists,
+      }),
+    );
 
-    const operatorsPromise = editor.listOperators({
-      scenarioId: currentDecision.scenario.id,
-    });
-
-    const accessorsPromise = editor.listAccessors({
-      scenarioId: currentDecision.scenario.id,
-    });
-
-    const dataModelPromise = apiClient.getDataModel();
-    const { custom_lists } = await apiClient.listCustomLists();
-
-    return json({
+    return defer({
       decision: currentDecision,
-      rules: (await scenarioIterationPromise).rules,
-      databaseAccessors: (await accessorsPromise).databaseAccessors,
-      payloadAccessors: (await accessorsPromise).payloadAccessors,
-      astOperators: await operatorsPromise,
-      dataModel: adaptDataModelDto((await dataModelPromise).data_model),
-      customLists: custom_lists,
+      astRuleData,
     });
   } catch (error) {
     if (isNotFoundHttpError(error)) {
@@ -89,15 +98,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export default function DecisionPage() {
-  const {
-    decision,
-    rules,
-    databaseAccessors,
-    payloadAccessors,
-    astOperators,
-    dataModel,
-    customLists,
-  } = useLoaderData<typeof loader>();
+  const { decision, astRuleData } = useLoaderData<typeof loader>();
   const { t } = useTranslation(decisionsI18n);
   return (
     <DecisionRightPanel.Root>
@@ -122,13 +123,8 @@ export default function DecisionPage() {
               <DecisionDetail decision={decision} />
               <RulesDetail
                 ruleExecutions={decision.rules}
-                rules={rules}
                 triggerObjectType={decision.triggerObjectType}
-                databaseAccessors={databaseAccessors}
-                payloadAccessors={payloadAccessors}
-                astOperators={astOperators}
-                dataModel={dataModel}
-                customLists={customLists}
+                astRuleData={astRuleData}
               />
             </div>
             <div className="flex flex-col gap-4 lg:gap-6">

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -181,7 +181,7 @@ function AddToCase({
   getSelectedDecisions,
 }: {
   hasSelection: boolean;
-  getSelectedDecisions: () => DecisionDetail[];
+  getSelectedDecisions: () => { id: string; case?: object }[];
 }) {
   const { t } = useTranslation(handle.i18n);
   const { onTriggerClick } = useDecisionRightPanelContext();

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -15,7 +15,6 @@ import {
 } from '@app-builder/components';
 import { decisionFilterNames } from '@app-builder/components/Decisions/Filters/filters';
 import { FiltersButton } from '@app-builder/components/Filters';
-import { type DecisionDetail } from '@app-builder/models/decision';
 import { type PaginationParams } from '@app-builder/models/pagination';
 import { type DecisionFiltersWithPagination } from '@app-builder/repositories/DecisionRepository';
 import { serverServices } from '@app-builder/services/init.server';

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -3272,15 +3272,24 @@ components:
           type: boolean
         error:
           $ref: '#/components/schemas/Error'
-    RuleExecutionWithAstDto:
+    RuleExecutionWithDetailDto:
       allOf:
         - $ref: '#/components/schemas/RuleExecutionDto'
         - type: object
+          required:
+            - rule_detail
           properties:
-            formula_ast_expression:
-              nullable: true
-              oneOf:
-                - $ref: '#/components/schemas/NodeDto'
+            rule_detail:
+              type: object
+              required:
+                - score_modifier
+              properties:
+                score_modifier:
+                  type: integer
+                formula_ast_expression:
+                  nullable: true
+                  oneOf:
+                    - $ref: '#/components/schemas/NodeDto'
     DecisionWithoutRuleDto:
       type: object
       required:
@@ -3310,6 +3319,7 @@ components:
             - id
             - name
             - description
+            - scenario_iteration_id
             - version
           properties:
             id:
@@ -3319,6 +3329,9 @@ components:
               type: string
             description:
               type: string
+            scenario_iteration_id:
+              type: string
+              format: uuid
             version:
               type: integer
         score:
@@ -3348,7 +3361,7 @@ components:
             rules:
               type: array
               items:
-                $ref: '#/components/schemas/RuleExecutionWithAstDto'
+                $ref: '#/components/schemas/RuleExecutionWithDetailDto'
     CaseStatus:
       type: string
       enum: ['open', 'investigating', 'discarded', 'resolved']

--- a/packages/marble-api/scripts/openapi.yaml
+++ b/packages/marble-api/scripts/openapi.yaml
@@ -165,7 +165,7 @@ paths:
                       items:
                         type: array
                         items:
-                          $ref: '#/components/schemas/DecisionDetailDto'
+                          $ref: '#/components/schemas/DecisionDto'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -190,7 +190,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DecisionDto'
+                $ref: '#/components/schemas/DecisionDetailDto'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -3261,6 +3261,7 @@ components:
         - description
         - score_modifier
         - result
+        - rule_id
       properties:
         name:
           type: string
@@ -3272,25 +3273,10 @@ components:
           type: boolean
         error:
           $ref: '#/components/schemas/Error'
-    RuleExecutionWithDetailDto:
-      allOf:
-        - $ref: '#/components/schemas/RuleExecutionDto'
-        - type: object
-          required:
-            - rule_detail
-          properties:
-            rule_detail:
-              type: object
-              required:
-                - score_modifier
-              properties:
-                score_modifier:
-                  type: integer
-                formula_ast_expression:
-                  nullable: true
-                  oneOf:
-                    - $ref: '#/components/schemas/NodeDto'
-    DecisionWithoutRuleDto:
+        rule_id:
+          type: string
+          format: uuid
+    DecisionDto:
       type: object
       required:
         - id
@@ -3336,11 +3322,13 @@ components:
               type: integer
         score:
           type: integer
+        case:
+          $ref: '#/components/schemas/Case'
         error:
           $ref: '#/components/schemas/Error'
-    DecisionDto:
+    DecisionDetailDto:
       allOf:
-        - $ref: '#/components/schemas/DecisionWithoutRuleDto'
+        - $ref: '#/components/schemas/DecisionDto'
         - type: object
           required:
             - rules
@@ -3349,19 +3337,6 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/RuleExecutionDto'
-    DecisionDetailDto:
-      allOf:
-        - $ref: '#/components/schemas/DecisionWithoutRuleDto'
-        - type: object
-          required:
-            - rules
-          properties:
-            case:
-              $ref: '#/components/schemas/Case'
-            rules:
-              type: array
-              items:
-                $ref: '#/components/schemas/RuleExecutionWithDetailDto'
     CaseStatus:
       type: string
       enum: ['open', 'investigating', 'discarded', 'resolved']
@@ -3412,7 +3387,53 @@ components:
             decisions:
               type: array
               items:
-                $ref: '#/components/schemas/DecisionDto'
+                type: object
+                required:
+                  - id
+                  - created_at
+                  - trigger_object
+                  - trigger_object_type
+                  - outcome
+                  - scenario
+                  - score
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  created_at:
+                    type: string
+                    format: date-time
+                  trigger_object:
+                    additionalProperties: true
+                  trigger_object_type:
+                    type: string
+                  outcome:
+                    $ref: '#/components/schemas/Outcome'
+                  scenario:
+                    type: object
+                    required:
+                      - id
+                      - name
+                      - description
+                      - scenario_iteration_id
+                      - version
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                      description:
+                        type: string
+                      scenario_iteration_id:
+                        type: string
+                        format: uuid
+                      version:
+                        type: integer
+                  score:
+                    type: integer
+                  error:
+                    $ref: '#/components/schemas/Error'
             events:
               type: array
               items:

--- a/packages/marble-api/src/fixtures/decisions.ts
+++ b/packages/marble-api/src/fixtures/decisions.ts
@@ -1,12 +1,12 @@
 import { faker } from '@faker-js/faker/locale/en';
 
 import {
-  type DecisionDto,
+  type DecisionDetailDto,
   type getDecision,
   type listDecisions,
 } from '../generated/marble-api';
 
-const fakeDecisions: DecisionDto[] = Array.from({
+const fakeDecisions: DecisionDetailDto[] = Array.from({
   length: Number(faker.number.int(100)),
 }).map(() => ({
   id: faker.string.uuid(),
@@ -27,8 +27,10 @@ const fakeDecisions: DecisionDto[] = Array.from({
     name: faker.word.noun(),
     description: faker.lorem.sentence(),
     version: Number(faker.number.int(10)),
+    scenario_iteration_id: faker.string.uuid(),
   },
   rules: Array.from({ length: Number(faker.number.int(500)) }).map(() => ({
+    rule_id: faker.string.uuid(),
     name: faker.word.noun(),
     description: faker.lorem.sentence(),
     score_modifier: Number(faker.number.int(100)),

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -42,28 +42,6 @@ export type Pagination = {
     end_index: number;
     total_count: PaginationCount;
 };
-export type Error = {
-    code: number;
-    message: string;
-};
-export type DecisionWithoutRuleDto = {
-    id: string;
-    created_at: string;
-    trigger_object: {
-        [key: string]: any;
-    };
-    trigger_object_type: string;
-    outcome: Outcome;
-    scenario: {
-        id: string;
-        name: string;
-        description: string;
-        scenario_iteration_id: string;
-        version: number;
-    };
-    score: number;
-    error?: Error;
-};
 export type CaseStatus = "open" | "investigating" | "discarded" | "resolved";
 export type CaseContributor = {
     id: string;
@@ -87,40 +65,43 @@ export type Case = {
     contributors: CaseContributor[];
     tags: CaseTag[];
 };
-export type RuleExecutionDto = {
-    name: string;
-    description: string;
-    score_modifier: number;
-    result: boolean;
-    error?: Error;
+export type Error = {
+    code: number;
+    message: string;
 };
-export type ConstantDto = ((string | null) | (number | null) | (boolean | null) | (ConstantDto[] | null) | ({
-    [key: string]: ConstantDto;
-} | null)) | null;
-export type NodeDto = {
-    name?: string;
-    constant?: ConstantDto;
-    children?: NodeDto[];
-    named_children?: {
-        [key: string]: NodeDto;
+export type DecisionDto = {
+    id: string;
+    created_at: string;
+    trigger_object: {
+        [key: string]: any;
     };
-};
-export type RuleExecutionWithDetailDto = RuleExecutionDto & {
-    rule_detail: {
-        score_modifier: number;
-        formula_ast_expression?: (NodeDto) | null;
+    trigger_object_type: string;
+    outcome: Outcome;
+    scenario: {
+        id: string;
+        name: string;
+        description: string;
+        scenario_iteration_id: string;
+        version: number;
     };
-};
-export type DecisionDetailDto = DecisionWithoutRuleDto & {
+    score: number;
     "case"?: Case;
-    rules: RuleExecutionWithDetailDto[];
+    error?: Error;
 };
 export type CreateDecisionBody = {
     scenario_id: string;
     trigger_object: object;
     object_type: string;
 };
-export type DecisionDto = DecisionWithoutRuleDto & {
+export type RuleExecutionDto = {
+    name: string;
+    description: string;
+    score_modifier: number;
+    result: boolean;
+    error?: Error;
+    rule_id: string;
+};
+export type DecisionDetailDto = DecisionDto & {
     rules: RuleExecutionDto[];
 };
 export type CreateCaseBody = {
@@ -189,7 +170,24 @@ export type CaseFile = {
     file_name: string;
 };
 export type CaseDetailDto = Case & {
-    decisions: DecisionDto[];
+    decisions: {
+        id: string;
+        created_at: string;
+        trigger_object: {
+            [key: string]: any;
+        };
+        trigger_object_type: string;
+        outcome: Outcome;
+        scenario: {
+            id: string;
+            name: string;
+            description: string;
+            scenario_iteration_id: string;
+            version: number;
+        };
+        score: number;
+        error?: Error;
+    }[];
     events: CaseEventDto[];
     files: CaseFile[];
 };
@@ -275,6 +273,17 @@ export type ScenarioIterationDto = {
     version: number | null;
     createdAt: string;
     updatedAt: string;
+};
+export type ConstantDto = ((string | null) | (number | null) | (boolean | null) | (ConstantDto[] | null) | ({
+    [key: string]: ConstantDto;
+} | null)) | null;
+export type NodeDto = {
+    name?: string;
+    constant?: ConstantDto;
+    children?: NodeDto[];
+    named_children?: {
+        [key: string]: NodeDto;
+    };
 };
 export type CreateScenarioIterationRuleBody = {
     scenarioIterationId: string;
@@ -584,7 +593,7 @@ export function listDecisions({ outcome, scenarioId, triggerObject, startDate, e
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: Pagination & {
-            items: DecisionDetailDto[];
+            items: DecisionDto[];
         };
     } | {
         status: 401;
@@ -615,7 +624,7 @@ export function listDecisions({ outcome, scenarioId, triggerObject, startDate, e
 export function createDecision(createDecisionBody: CreateDecisionBody, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
-        data: DecisionDto;
+        data: DecisionDetailDto;
     } | {
         status: 401;
         data: string;

--- a/packages/marble-api/src/generated/marble-api.ts
+++ b/packages/marble-api/src/generated/marble-api.ts
@@ -58,6 +58,7 @@ export type DecisionWithoutRuleDto = {
         id: string;
         name: string;
         description: string;
+        scenario_iteration_id: string;
         version: number;
     };
     score: number;
@@ -104,12 +105,15 @@ export type NodeDto = {
         [key: string]: NodeDto;
     };
 };
-export type RuleExecutionWithAstDto = RuleExecutionDto & {
-    formula_ast_expression?: (NodeDto) | null;
+export type RuleExecutionWithDetailDto = RuleExecutionDto & {
+    rule_detail: {
+        score_modifier: number;
+        formula_ast_expression?: (NodeDto) | null;
+    };
 };
 export type DecisionDetailDto = DecisionWithoutRuleDto & {
     "case"?: Case;
-    rules: RuleExecutionWithAstDto[];
+    rules: RuleExecutionWithDetailDto[];
 };
 export type CreateDecisionBody = {
     scenario_id: string;


### PR DESCRIPTION
In this PR :
- introduce the `scenario_iteration_id` on decision
- add link on both `DecisionList` and `DecisionDetail` (cf screenshots)
- refactor to use the new `rule_detail` (cf backend PR): consume the real rule score modifier, not the result of the rule execution inside `RuleDetail`

![Screenshot 2024-03-15 at 16 28 41](https://github.com/checkmarble/marble-frontend/assets/40292402/742fbbd9-c755-4f5d-a544-73d6383388fc)
![Screenshot 2024-03-15 at 16 28 04](https://github.com/checkmarble/marble-frontend/assets/40292402/4c22a962-ed0b-420b-a55e-9b3836447914)

Bonus on case detail:
![image](https://github.com/checkmarble/marble-frontend/assets/40292402/0f4407a2-5e5a-462e-bd8d-4cc27443342c)
