### PR TITLE
fix(ScrollArea): fix stacking issue

### DIFF
--- a/packages/ui-design-system/src/ScrollArea/ScrollArea.tsx
+++ b/packages/ui-design-system/src/ScrollArea/ScrollArea.tsx
@@ -123,18 +123,18 @@ export const ScrollAreaV2 = forwardRef<ScrollAreaElement, ScrollAreaV2Props>(
         {orientation !== 'vertical' ? (
           <Scrollbar
             orientation="horizontal"
-            className="hover:bg-grey-10 z-50 m-px flex h-1 touch-none select-none flex-col rounded-full transition"
+            className="hover:bg-grey-10 m-px flex h-1 touch-none select-none flex-col rounded-full transition-colors"
           >
-            <Thumb className="bg-grey-25 hover:bg-grey-50 relative flex-1 rounded-full transition-colors" />
+            <Thumb className="bg-grey-25 hover:bg-grey-50 flex-1 rounded-full" />
           </Scrollbar>
         ) : null}
 
         {orientation !== 'horizontal' ? (
           <Scrollbar
             orientation="vertical"
-            className="hover:bg-grey-10 z-50 m-px flex w-1 touch-none select-none flex-row rounded-full transition"
+            className="hover:bg-grey-10 m-px flex w-1 touch-none select-none flex-row rounded-full transition-colors"
           >
-            <Thumb className="bg-grey-25 hover:bg-grey-50 relative flex-1 rounded-full transition-colors" />
+            <Thumb className="bg-grey-25 hover:bg-grey-50 flex-1 rounded-full" />
           </Scrollbar>
         ) : null}
 


### PR DESCRIPTION
Fix a stacking issue (due to `z-index` that display scroll thumbs above modals (like in the capture)

<img width="1014" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/72bb4ee9-e566-4810-b71a-4381725dc803">
