### PR TITLE
Thomas/display decision rule exec values

### DIFF
--- a/packages/app-builder/public/locales/en/decisions.json
+++ b/packages/app-builder/public/locales/en/decisions.json
@@ -34,5 +34,6 @@
   "rules.status.error": "error",
   "rules.status.no_hit": "no hit",
   "rules.description": "Description",
-  "rules.error.not_found": "The associated rule info could not be found. Please try again or contact your admin."
+  "rules.error.not_found": "The associated rule info could not be found. Please try again or contact your admin.",
+  "rules.show_contextual_values": "Show contextual values"
 }

--- a/packages/app-builder/src/components/Decisions/RulesDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/RulesDetail.tsx
@@ -14,6 +14,10 @@ import {
 } from '@app-builder/models/decision';
 import { type OperatorFunction } from '@app-builder/models/editable-operators';
 import { type NodeEvaluation } from '@app-builder/models/node-evaluation';
+import {
+  DisplayReturnValuesProvider,
+  useDisplayReturnValues,
+} from '@app-builder/services/ast-node/return-value';
 import { useAstBuilder } from '@app-builder/services/editor/ast-editor';
 import { formatNumber, useFormatLanguage } from '@app-builder/utils/format';
 import { Await } from '@remix-run/react';
@@ -21,7 +25,7 @@ import { type TFunction } from 'i18next';
 import { type CustomList } from 'marble-api';
 import { Suspense, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Accordion, Collapsible, Tag } from 'ui-design-system';
+import { Accordion, Collapsible, Switch, Tag } from 'ui-design-system';
 
 import { AstBuilder } from '../Scenario/AstBuilder';
 
@@ -140,21 +144,24 @@ function RuleExecutionDetail({
   }
 
   return (
-    <>
-      <div className="bg-purple-10 inline-flex h-8 w-fit items-center justify-center whitespace-pre rounded px-2 font-normal text-purple-100">
-        <Trans
-          t={t}
-          i18nKey="scenarios:rules.consequence.score_modifier"
-          components={{
-            Score: <span className="font-semibold" />,
-          }}
-          values={{
-            score: formatNumber(currentRule.scoreModifier, {
-              language,
-              signDisplay: 'always',
-            }),
-          }}
-        />
+    <DisplayReturnValuesProvider>
+      <div className="flex w-full items-center justify-between gap-2">
+        <div className="bg-purple-10 inline-flex h-8 w-fit items-center justify-center whitespace-pre rounded px-2 font-normal text-purple-100">
+          <Trans
+            t={t}
+            i18nKey="scenarios:rules.consequence.score_modifier"
+            components={{
+              Score: <span className="font-semibold" />,
+            }}
+            values={{
+              score: formatNumber(currentRule.scoreModifier, {
+                language,
+                signDisplay: 'always',
+              }),
+            }}
+          />
+        </div>
+        <DisplayReturnValuesSwitch />
       </div>
 
       <RuleFormula
@@ -167,7 +174,25 @@ function RuleExecutionDetail({
         customLists={astRuleData.customLists}
         triggerObjectType={triggerObjectType}
       />
-    </>
+    </DisplayReturnValuesProvider>
+  );
+}
+
+function DisplayReturnValuesSwitch() {
+  const { t } = useTranslation(decisionsI18n);
+  const [displayReturnValues, setDisplayReturnValues] =
+    useDisplayReturnValues();
+  return (
+    <div className="flex flex-row justify-between gap-2">
+      <label htmlFor="displayReturnValues" className="select-none">
+        {t('decisions:rules.show_contextual_values')}
+      </label>
+      <Switch
+        id="displayReturnValues"
+        checked={displayReturnValues}
+        onCheckedChange={setDisplayReturnValues}
+      />
+    </div>
   );
 }
 

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/EditFilters.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/EditFilters.tsx
@@ -111,7 +111,7 @@ export function EditFilters({
               <div className="border-grey-10 col-start-2 h-5 border-b" />
               <LogicalOperatorLabel
                 operator={isFirstCondition ? 'where' : 'and'}
-                className="bg-grey-02 border-grey-02 text-grey-25 border p-2"
+                type="contained"
               />
               <div className="col-start-4 flex flex-col gap-2 px-2">
                 <div className="flex flex-row items-center gap-2">

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/Operand.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/Operand.tsx
@@ -39,6 +39,7 @@ export function Operand({
         editableAstNode={editableAstNode}
         validationStatus={getValidationStatus(operandViewModel)}
         type="viewer"
+        returnValue={operandViewModel.returnValue}
       />
     );
   }

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
@@ -237,8 +237,8 @@ function AggregatorDescription({
         return (
           <Fragment key={`filter_${index}`}>
             <LogicalOperatorLabel
-              className="text-grey-50"
               operator={index === 0 ? 'where' : 'and'}
+              type="text"
             />
             <div className="flex items-center gap-1">
               {/* TODO: replace with OperandLable for consistency */}

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
@@ -155,6 +155,7 @@ function OperandDescription({
 }
 
 function Description({ description }: { description: string }) {
+  if (!description) return null;
   return (
     <p className="text-grey-50 max-w-[300px] text-xs font-normal first-letter:capitalize">
       {description}

--- a/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/LogicalOperator.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/LogicalOperator.tsx
@@ -1,27 +1,59 @@
-import clsx from 'clsx';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { useTranslation } from 'react-i18next';
 
 import { scenarioI18n } from '../../scenario-i18n';
 
+const logicalOperatorClassnames = cva(
+  'flex h-fit min-h-[40px] min-w-[40px] flex-wrap items-center justify-center gap-1 rounded p-2 border',
+  {
+    variants: {
+      type: {
+        text: '',
+        contained: 'bg-grey-02',
+      },
+      validationStatus: {
+        valid: 'text-grey-25',
+        error: 'text-red-100 border-red-100',
+      },
+    },
+    compoundVariants: [
+      {
+        type: 'text',
+        validationStatus: 'valid',
+        className: 'border-transparent',
+      },
+      {
+        type: 'contained',
+        validationStatus: 'valid',
+        className: 'border-grey-02',
+      },
+    ],
+  },
+);
+
 export type LogicalOperatorType = 'if' | 'and' | 'or' | 'where';
 
-interface LogicalOperatorLabelProps {
+interface LogicalOperatorLabelProps
+  extends VariantProps<typeof logicalOperatorClassnames> {
   operator: LogicalOperatorType;
   className?: string;
 }
 
 export function LogicalOperatorLabel({
   operator,
+  type = 'text',
+  validationStatus = 'valid',
   className,
 }: LogicalOperatorLabelProps) {
   const { t } = useTranslation(scenarioI18n);
 
   return (
     <div
-      className={clsx(
-        'flex h-fit min-h-[40px] min-w-[40px] flex-wrap items-center justify-center gap-1 rounded',
+      className={logicalOperatorClassnames({
+        type,
+        validationStatus,
         className,
-      )}
+      })}
     >
       <span className="text-s w-full text-center font-semibold">
         {t(`scenarios:logical_operator.${operator}`)}

--- a/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootAnd.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootAnd.tsx
@@ -136,12 +136,11 @@ export function RootAnd({
               <div className="border-grey-10 col-start-2 h-5 border-b" />
               <LogicalOperatorLabel
                 operator={isFirstCondition ? 'where' : 'and'}
-                className={clsx(
-                  'bg-grey-02 col-start-3 border p-2',
-                  hasArgumentIndexErrorsFromParent(child)
-                    ? ' border-red-100 text-red-100'
-                    : 'border-grey-02 text-grey-25',
-                )}
+                className="col-start-3"
+                type="contained"
+                validationStatus={
+                  hasArgumentIndexErrorsFromParent(child) ? 'error' : 'valid'
+                }
               />
 
               <div

--- a/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootOrWithAnd.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/RootAstBuilderNode/RootOrWithAnd.tsx
@@ -130,7 +130,8 @@ export function RootOrWithAnd({
               <>
                 <LogicalOperatorLabel
                   operator="or"
-                  className="bg-grey-02 text-grey-25 uppercase"
+                  className="uppercase"
+                  type="contained"
                 />
                 <div className="col-span-2 flex flex-1 items-center">
                   <div className="bg-grey-10 h-px w-full" />
@@ -149,10 +150,11 @@ export function RootOrWithAnd({
                 <Fragment key={child.nodeId}>
                   <LogicalOperatorLabel
                     operator={childIndex === 0 ? 'if' : 'and'}
-                    className={
+                    type="text"
+                    validationStatus={
                       hasArgumentIndexErrorsFromParent(child)
-                        ? 'border border-red-100 text-red-100'
-                        : 'text-grey-25 border border-transparent'
+                        ? 'error'
+                        : 'valid'
                     }
                   />
                   <div

--- a/packages/app-builder/src/services/ast-node/return-value.tsx
+++ b/packages/app-builder/src/services/ast-node/return-value.tsx
@@ -1,0 +1,67 @@
+import { type ConstantType } from '@app-builder/models';
+import { createContext, useContext, useState } from 'react';
+import * as R from 'remeda';
+import { noop } from 'typescript-utils';
+
+type ReturnValue =
+  | {
+      value: ConstantType;
+      isOmitted: false;
+    }
+  | {
+      isOmitted: true;
+    };
+
+// This method is close to ConstantEditableAstNode.getConstantDisplayName
+// We may need to refactor this method in the future
+function formatConstantType(constant: ConstantType): string {
+  if (R.isNil(constant)) return 'NULL';
+
+  if (R.isArray(constant)) {
+    return `[${constant.map(formatConstantType).join(', ')}]`;
+  }
+
+  if (R.isString(constant)) {
+    //TODO(combobox): handle Timestamp here, if we do manipulate them as ISOstring
+    return `"${constant.toString()}"`;
+  }
+
+  if (R.isNumber(constant) || R.isBoolean(constant)) {
+    return constant.toString();
+  }
+
+  // Handle other cases when needed
+  return JSON.stringify(R.mapValues(constant, formatConstantType));
+}
+
+export function formatReturnValue(returnValue?: ReturnValue) {
+  if (returnValue?.isOmitted === false) {
+    return formatConstantType(returnValue.value);
+  }
+  return undefined;
+}
+
+const DisplayReturnValues = createContext<[boolean, (val: boolean) => void]>([
+  false,
+  noop,
+]);
+DisplayReturnValues.displayName = 'DisplayReturnValues';
+
+export function DisplayReturnValuesProvider({
+  children,
+  initialDisplayReturnValues,
+}: {
+  children: React.ReactNode;
+  initialDisplayReturnValues?: boolean;
+}) {
+  const value = useState(initialDisplayReturnValues ?? false);
+  return (
+    <DisplayReturnValues.Provider value={value}>
+      {children}
+    </DisplayReturnValues.Provider>
+  );
+}
+
+export function useDisplayReturnValues() {
+  return useContext(DisplayReturnValues);
+}

--- a/packages/app-builder/src/services/editor/ast-editor.ts
+++ b/packages/app-builder/src/services/editor/ast-editor.ts
@@ -340,6 +340,8 @@ function computeEvaluationErrors(
   if (evaluation.errors) {
     errors.push(...evaluation.errors);
   }
+
+  //TODO(validation): refactor to move this on a "getError(nodeId)" function (this is a internal business logic specificity of the editor)
   if (
     funcName &&
     functionNodeNames.includes(funcName) &&

--- a/packages/app-builder/src/services/editor/ast-editor.ts
+++ b/packages/app-builder/src/services/editor/ast-editor.ts
@@ -13,6 +13,7 @@ import { nanoid } from 'nanoid';
 import { useCallback, useEffect, useState } from 'react';
 import * as R from 'remeda';
 
+import { formatReturnValue } from '../ast-node/return-value';
 import { findAndReplaceNode } from './FindAndReplaceNode';
 
 export interface EditorNodeViewModel {
@@ -23,6 +24,7 @@ export interface EditorNodeViewModel {
   children: EditorNodeViewModel[];
   namedChildren: Record<string, EditorNodeViewModel>;
   parent: EditorNodeViewModel | null;
+  returnValue?: string;
 }
 
 export function adaptEditorNodeViewModel({
@@ -42,6 +44,7 @@ export function adaptEditorNodeViewModel({
     errors: computeEvaluationErrors(ast.name, evaluation),
     children: [],
     namedChildren: {},
+    returnValue: formatReturnValue(evaluation.returnValue),
   };
 
   currentNode.children = ast.children.map((child, i) =>


### PR DESCRIPTION
In this PR :
- store formatted return values inside the view model
- add a switch to control the rule detail display (AST spec or return values)
    - if no return values, display the spec by default
    - you can still visualize spec info in the `OperandInfos` popover

![output](https://github.com/checkmarble/marble-frontend/assets/40292402/93c4a77d-6af7-4f71-8f10-4bb7278d8cc7)
