### PR TITLE
feat(models): add fuzzy match functions

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
@@ -10,6 +10,7 @@ import {
   CustomListEditableAstNode,
   DatabaseAccessEditableAstNode,
   type EditableAstNode,
+  FuzzyMatchComparatorEditableAstNode,
   getOperandTypeIcon,
   getOperandTypeTKey,
   type OperandType,
@@ -146,7 +147,9 @@ function OperandDescription({
   if (
     editableAstNode instanceof ConstantEditableAstNode ||
     editableAstNode instanceof UndefinedEditableAstNode ||
-    editableAstNode instanceof TimeAddEditableAstNode
+    editableAstNode instanceof TimeAddEditableAstNode ||
+    // TODO: implement description like AggregatorDescription
+    editableAstNode instanceof FuzzyMatchComparatorEditableAstNode
   ) {
     return null;
   }

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operator.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operator.tsx
@@ -1,7 +1,7 @@
-import { undefinedAstNodeName } from '@app-builder/models';
 import {
   getOperatorName,
   type OperatorFunction,
+  undefinedAstNodeName,
 } from '@app-builder/models/editable-operators';
 import { type EvaluationError } from '@app-builder/models/node-evaluation';
 import { Trigger, Value } from '@radix-ui/react-select';

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TwoOperandsLine.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/TwoOperandsLine.tsx
@@ -1,6 +1,6 @@
 import {
   type AstNode,
-  functionNodeNames,
+  isFunctionAstNode,
   NewUndefinedAstNode,
 } from '@app-builder/models';
 import {
@@ -70,7 +70,7 @@ export function TwoOperandsLine({
   const operators = useTwoLineOperandOperatorFunctions();
 
   return (
-    <div className="flex justify-between">
+    <div className="flex justify-between gap-2">
       <div className="flex flex-row flex-wrap items-center gap-2">
         {!root ? <span className="text-grey-25">(</span> : null}
         <AstBuilderNode
@@ -125,6 +125,8 @@ export function TwoOperandsLine({
 export function adaptTwoOperandsLineViewModel(
   vm: EditorNodeViewModel,
 ): TwoOperandsLineViewModel | null {
+  if (isFunctionAstNode(adaptAstNodeFromEditorViewModel(vm))) return null;
+
   if (vm.children.length !== 2) return null;
   if (Object.keys(vm.namedChildren).length > 0) return null;
   if (vm.funcName == null || !isTwoLineOperandOperatorFunction(vm.funcName))
@@ -146,7 +148,8 @@ export function adaptTwoOperandsLineViewModel(
 export const computeLineErrors = (
   viewModel: EditorNodeViewModel,
 ): EvaluationError[] => {
-  if (viewModel.funcName && functionNodeNames.includes(viewModel.funcName)) {
+  const astNode = adaptAstNodeFromEditorViewModel(viewModel);
+  if (isFunctionAstNode(astNode)) {
     const { nodeErrors } = separateChildrenErrors(viewModel.errors);
     return nodeErrors;
   } else {

--- a/packages/app-builder/src/models/editable-operators.ts
+++ b/packages/app-builder/src/models/editable-operators.ts
@@ -1,7 +1,7 @@
 import { type TFunction } from 'i18next';
 import { assertNever } from 'typescript-utils';
 
-import { undefinedAstNodeName } from './ast-node';
+export const undefinedAstNodeName = 'Undefined';
 
 const twoLineOperandOperatorFunctions = [
   undefinedAstNodeName,
@@ -72,17 +72,35 @@ export function isAggregatorOperator(
   return (aggregatorOperators as ReadonlyArray<string>).includes(value);
 }
 
+export const fuzzyMatchAlgorithms = [
+  'ratio',
+  'partial_ratio',
+  'token_sort_ratio',
+  'partial_token_sort_ratio',
+  'token_set_ratio',
+  'partial_token_set_ratio',
+] as const;
+export type FuzzyMatchAlgorithm = (typeof fuzzyMatchAlgorithms)[number];
+
+export function isFuzzyMatchAlgorithm(
+  value: string,
+): value is AggregatorOperator {
+  return (aggregatorOperators as ReadonlyArray<string>).includes(value);
+}
+
 export type OperatorFunction =
   | TwoLineOperandOperatorFunction
   | FilterOperator
   | TimeAddOperator
-  | AggregatorOperator;
+  | AggregatorOperator
+  | FuzzyMatchAlgorithm;
 export function isOperatorFunction(value: string): value is OperatorFunction {
   return (
     isTwoLineOperandOperatorFunction(value) ||
     isFilterOperator(value) ||
     isTimeAddOperator(value) ||
-    isAggregatorOperator(value)
+    isAggregatorOperator(value) ||
+    isFuzzyMatchAlgorithm(value)
   );
 }
 
@@ -137,6 +155,18 @@ export function getOperatorName(
         return t('scenarios:aggregator.min');
       case 'SUM':
         return t('scenarios:aggregator.sum');
+      case 'ratio':
+        return 'ratio';
+      case 'partial_ratio':
+        return 'partial_ratio';
+      case 'token_sort_ratio':
+        return 'token_sort_ratio';
+      case 'partial_token_sort_ratio':
+        return 'partial_token_sort_ratio';
+      case 'token_set_ratio':
+        return 'token_set_ratio';
+      case 'partial_token_set_ratio':
+        return 'partial_token_set_ratio';
       case undefinedAstNodeName:
         return '...';
       default:

--- a/packages/app-builder/src/services/editor/ast-editor.ts
+++ b/packages/app-builder/src/services/editor/ast-editor.ts
@@ -1,7 +1,7 @@
 import {
   type AstNode,
   type ConstantType,
-  functionNodeNames,
+  isFunctionAstNode,
 } from '@app-builder/models';
 import {
   type EvaluationError,
@@ -41,7 +41,7 @@ export function adaptEditorNodeViewModel({
     parent: parent ?? null,
     funcName: ast.name,
     constant: ast.constant,
-    errors: computeEvaluationErrors(ast.name, evaluation),
+    errors: computeEvaluationErrors(evaluation, isFunctionAstNode(ast)),
     children: [],
     namedChildren: {},
     returnValue: evaluation.returnValue,
@@ -310,7 +310,10 @@ function updateEvaluation({
 
   const currentNode: EditorNodeViewModel = {
     ...editorNodeViewModel,
-    errors: computeEvaluationErrors(editorNodeViewModel.funcName, evaluation),
+    errors: computeEvaluationErrors(
+      evaluation,
+      isFunctionAstNode(adaptAstNodeFromEditorViewModel(editorNodeViewModel)),
+    ),
     parent: parent ?? null,
     children: [],
     namedChildren: {},
@@ -336,8 +339,8 @@ function updateEvaluation({
 }
 
 function computeEvaluationErrors(
-  funcName: EditorNodeViewModel['funcName'],
   evaluation: NodeEvaluation,
+  isFunction: boolean = false,
 ): EvaluationError[] {
   const errors: EvaluationError[] = [];
   if (evaluation.errors) {
@@ -345,11 +348,7 @@ function computeEvaluationErrors(
   }
 
   //TODO(validation): refactor to move this on a "getError(nodeId)" function (this is a internal business logic specificity of the editor)
-  if (
-    funcName &&
-    functionNodeNames.includes(funcName) &&
-    hasNestedErrors(evaluation)
-  ) {
+  if (isFunction && hasNestedErrors(evaluation)) {
     errors.push({ error: 'FUNCTION_ERROR', message: 'function has error' });
   }
 


### PR DESCRIPTION
In this PR :
- create all models required to handle new fuzzy match operators
- implement "sumarry display" logic
- editability is out of scope

Caveat: currently, "editability" and specific "display" logic are heavilly compled, so it's not easilly possible to implement a "non editable" specific node with a custom "display" logic, so in "two line operand" specific case, you can display a fuzzy match node, and edit it (so you can remove it without the possibility to re-add it since this is not fully editable yet).

Still we are in a feature branch and this is temporary.

Bellow, some example on how this is rendered in the UI using different possibility :
- in left OR operator:
  - single comparison
  - multiple possibility (constants, with database access, with list...)
  - non editable (this is a special case that should nether happen with an AST created from the UI: the editor handle non "two line operand" but it's non editable by default)
- in the right OR operator:
  - classic future behaviour
  - wanted to test that the "Fuzzy" node is not considered accidentally as a "two line operator" (since this is a `>` with two children)

<img width="1582" alt="Screenshot 2024-03-29 at 12 28 00" src="https://github.com/checkmarble/marble-frontend/assets/40292402/ea43d12f-99f2-41f8-b97a-e8de5024b51c">
