### PR TITLE
feat(upload): handle 408 on data upload page

### DIFF
--- a/packages/app-builder/public/locales/en/upload.json
+++ b/packages/app-builder/public/locales/en/upload.json
@@ -8,6 +8,7 @@
   "success_message": "{{linesProcessed}} {{objectType}} will be added to your data",
   "failure_message": "We found an error:",
   "failure_additional_message": "No {{objectType}} were added to your data",
+  "errors.request_timeout": "The request timed out. Please try again, or try to cut your file into smaller parts.",
   "results": "Results",
   "past_uploads": "Past uploads",
   "upload_status": "Status",

--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -4,6 +4,7 @@ import { useBackendInfo } from '@app-builder/services/auth/auth.client';
 import { clientServices } from '@app-builder/services/init.client';
 import { serverServices } from '@app-builder/services/init.server';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
+import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData, useRevalidator } from '@remix-run/react';
@@ -129,13 +130,17 @@ const UploadForm = ({ objectType }: { objectType: string }) => {
         },
       );
       if (!response.ok) {
-        const errorMessage = await response.text();
         setIsModalOpen(true);
+        let errorMessage: string | undefined;
+        if (response.status === REQUEST_TIMEOUT) {
+          errorMessage = t('upload:errors.request_timeout');
+        } else {
+          errorMessage = (await response.text()).trim();
+        }
+
         computeModalMessage({
           success: false,
-          errorMessage: !errorMessage.trim()
-            ? t('common:global_error')
-            : errorMessage.trim(),
+          errorMessage: errorMessage ?? t('common:global_error'),
         });
         return;
       }


### PR DESCRIPTION
Use a specific error message when a Timeout occure in the frontend for data upload

![image](https://github.com/checkmarble/marble-frontend/assets/40292402/afb744e6-7aab-44ee-afaa-021699e8ab88)
