### PR TITLE
hotfix(fuzzy-match): missing context provider issue

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilder.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilder.tsx
@@ -47,14 +47,16 @@ export function AstBuilder({
         <TimeAddEditModal>
           <AggregationEditModal>
             <FuzzyMatchComparatorEditModal>
-              <RootAstBuilderNode
-                setOperand={setOperand}
-                setOperator={setOperator}
-                appendChild={appendChild}
-                remove={remove}
-                editorNodeViewModel={editorNodeViewModel}
-                viewOnly={viewOnly}
-              />
+              <AggregationEditModal>
+                <RootAstBuilderNode
+                  setOperand={setOperand}
+                  setOperator={setOperator}
+                  appendChild={appendChild}
+                  remove={remove}
+                  editorNodeViewModel={editorNodeViewModel}
+                  viewOnly={viewOnly}
+                />
+              </AggregationEditModal>
             </FuzzyMatchComparatorEditModal>
           </AggregationEditModal>
         </TimeAddEditModal>


### PR DESCRIPTION
We finally hit the issue with "global modal context provider" pattern : Aggregation and FuzzyMatch Contexts require to be a child of one another... impossible theoritically.

I hack by duplicating one context, since we do not allow to open "Aggregation" modal on top of "Fuzzy" one, we can't reach another "missing provider" issue.

The long term solution would be to create modals "locally" directly where it's needed (here, inside the edit operand dropdown), meaning we create a local context for each menu option requiring it (no more shared global context)