### PR TITLE
fix(coerceToConstant): coercion of single letter string constant

### DIFF
--- a/packages/app-builder/src/services/editor/coerceToConstantEditableAstNode.spec.ts
+++ b/packages/app-builder/src/services/editor/coerceToConstantEditableAstNode.spec.ts
@@ -66,10 +66,10 @@ describe('coerceToConstantEditableAstNode', () => {
 
   describe('return an array given a string convertible to an array', () => {
     it('String[]', () => {
-      const valueToCoerce = '["fr" , 13  , null, sp ace]';
+      const valueToCoerce = '[a, "fr" , 13  , null, sp ace]';
       const expected = [
         helperConstantArrayOperandOption({
-          constant: ['fr', '13', 'null', 'sp ace'],
+          constant: ['a', 'fr', '13', 'null', 'sp ace'],
           dataType: 'String[]',
         }),
         helperConstantOperandOption({ valueToCoerce, dataType: 'String' }),
@@ -80,10 +80,10 @@ describe('coerceToConstantEditableAstNode', () => {
     });
 
     it('Int[]', () => {
-      const valueToCoerce = '[23, 13  , 1233  ]';
+      const valueToCoerce = '[1, 23, 13  , 1233  ]';
       const expected = [
         helperConstantArrayOperandOption({
-          constant: [23, 13, 1233],
+          constant: [1, 23, 13, 1233],
           dataType: 'Int[]',
         }),
         helperConstantOperandOption({ valueToCoerce, dataType: 'String' }),

--- a/packages/app-builder/src/services/editor/coerceToConstantEditableAstNode.ts
+++ b/packages/app-builder/src/services/editor/coerceToConstantEditableAstNode.ts
@@ -48,11 +48,11 @@ export function coerceToConstantEditableAstNode(
   return results;
 }
 
-const isNumberArray = /^\[(\s*(\d+(.\d+)?)\s*,?)*(\s*|\])$/;
+const isNumberArray = /^\[(\s*(\d+(\.\d+)?)\s*,?)*(\s*|\])$/;
 const isStringArray = /^\[(\s*"?(\w+)"?\s*,?)*(\s*|\])$/;
 
 const captureNumbers = /(?:\s*(?<numbers>\d+(\.\d+)?)\s*,?)/g;
-const captureStrings = /(?:\s*"?(?<strings>\w(\w|\s)*\w)"?\s*,?)/g;
+const captureStrings = /(?:\s*"?(?<strings>(\w|\s)*\w)"?\s*,?)/g;
 
 function coerceToConstantArray(
   t: TFunction<['common']>,


### PR DESCRIPTION
Fix this issue :
<img width="387" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/0957bfd4-2fc6-4f5e-b372-4c8d74ef563d">

NB: the problem only occured for single letter items, see exemple

<img width="400" alt="image" src="https://github.com/checkmarble/marble-frontend/assets/40292402/adec3165-312e-4b95-a8bf-f68ffd5b8c43">
