### PR TITLE
feat(pivot): filter out field pivot options used in link options

### DIFF
--- a/packages/app-builder/src/services/data/pivot.tsx
+++ b/packages/app-builder/src/services/data/pivot.tsx
@@ -79,6 +79,13 @@ function getFieldPivotOptions(tableModel: TableModel): FieldPivotOption[] {
     tableModel.fields,
     // Only allow pivots on string fields
     R.filter((field) => field.dataType === 'String'),
+    // Exclude fields that are already links
+    R.filter(
+      (field) =>
+        tableModel.linksToSingle.find(
+          (link) => link.childFieldId === field.id,
+        ) === undefined,
+    ),
     R.map((field) =>
       adaptFieldPivotOption({ baseTableId: tableModel.id, field }),
     ),


### PR DESCRIPTION
Opinionated way to remove possible "duplicate" pivot options (cf Linear issue for an example).

As a reminder, a pivot field is identified by the field name while an "equivalent" link field by the link name. If they both have the same value, this may introduce confusion (like in the example from Linear issue).