### PR TITLE
feat(auth): add redirect to for logout

### DIFF
--- a/packages/app-builder/src/routes/ressources+/auth+/logout.tsx
+++ b/packages/app-builder/src/routes/ressources+/auth+/logout.tsx
@@ -1,13 +1,27 @@
 import { serverServices } from '@app-builder/services/init.server';
+import { getRoute } from '@app-builder/utils/routes';
 import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  await serverServices.authService.logout(request, { redirectTo: '/sign-in' });
+  const url = new URL(request.url);
+
+  const redirectToParam = url.searchParams.get('redirectTo');
+
+  let redirectTo = getRoute('/sign-in');
+  if (redirectToParam) {
+    redirectTo = `${redirectTo}?redirectTo=${redirectToParam}`;
+  }
+
+  await serverServices.authService.logout(request, {
+    redirectTo,
+  });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  await serverServices.authService.logout(request, { redirectTo: '/sign-in' });
+  await serverServices.authService.logout(request, {
+    redirectTo: getRoute('/sign-in'),
+  });
 }

--- a/packages/app-builder/src/routes/ressources+/auth+/refresh.tsx
+++ b/packages/app-builder/src/routes/ressources+/auth+/refresh.tsx
@@ -41,7 +41,16 @@ export function useRefreshToken() {
           );
         },
         () => {
-          navigate(getRoute('/ressources/auth/logout'));
+          let redirectUrl = getRoute('/ressources/auth/logout');
+          if (window) {
+            const searchParams = new URLSearchParams();
+            searchParams.set(
+              'redirectTo',
+              `${window.location.pathname}${window.location.search}`,
+            );
+            redirectUrl = `${redirectUrl}?${searchParams.toString()}`;
+          }
+          navigate(redirectUrl);
         },
       );
     },

--- a/packages/app-builder/src/services/auth/auth.server.ts
+++ b/packages/app-builder/src/services/auth/auth.server.ts
@@ -19,7 +19,6 @@ import { type TransferRepository } from '@app-builder/repositories/TransferRepos
 import { type UserRepository } from '@app-builder/repositories/UserRepository';
 import { getServerEnv } from '@app-builder/utils/environment';
 import { parseForm } from '@app-builder/utils/input-validation';
-import { type RoutePath } from '@app-builder/utils/routes/types';
 import { json, redirect } from '@remix-run/node';
 import * as Sentry from '@sentry/remix';
 import { marbleApi } from 'marble-api';
@@ -268,7 +267,7 @@ export function makeAuthenticationServerService(
 
   async function logout(
     request: Request,
-    options: { redirectTo: RoutePath },
+    options: { redirectTo: string },
   ): Promise<never> {
     const authSession = await authSessionService.getSession(request);
 


### PR DESCRIPTION
Implement `redirectTo` feature for sign in :
- if `redirectTo` is a safe path (= relative path, only internal to the app)
- then redirect to the provided location

Caveat: I only use this feature for "client" logout comming from the firebase auto-refresh hook. IMO, this is the main source of the problem. If the problem persist, I can look into doing the same for the `isAuthenticated(...)` guard used in loaders/actions.

I prefer to iterate slowly on the auth service since the Firebase integ is kind of hacky with SSR (+ Remix still don't provide serious middleware integration to plug into the server)