### PR TITLE
feat(sign-in): refresh csrf on window focus

### DIFF
--- a/packages/app-builder/src/root.tsx
+++ b/packages/app-builder/src/root.tsx
@@ -12,6 +12,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  type ShouldRevalidateFunctionArgs,
   useLoaderData,
   useRouteError,
 } from '@remix-run/react';
@@ -191,3 +192,15 @@ function App() {
 }
 
 export default withSentry(App);
+
+export function shouldRevalidate({
+  defaultShouldRevalidate,
+  nextUrl,
+}: ShouldRevalidateFunctionArgs) {
+  // Revalidate when navigating to the sign-in page to ensure a fresh CSRF token
+  if (nextUrl.pathname === getRoute('/sign-in')) {
+    return true;
+  }
+
+  return defaultShouldRevalidate;
+}


### PR DESCRIPTION
Small improvment to finish the day: revalidate root loader (the one that handle the CSRF) on the `/sign-in` page