### PR TITLE
refactor(header): better handling of long titles

### DIFF
--- a/packages/app-builder/src/components/CopyToClipboardButton.tsx
+++ b/packages/app-builder/src/components/CopyToClipboardButton.tsx
@@ -17,7 +17,7 @@ export const CopyToClipboardButton = forwardRef<
       {...props}
     >
       {children}
-      <Icon icon="duplicate" className="size-4" />
+      <Icon icon="duplicate" className="size-4 shrink-0" />
     </div>
   );
 });

--- a/packages/app-builder/src/routes/_builder+/analytics.tsx
+++ b/packages/app-builder/src/routes/_builder+/analytics.tsx
@@ -47,7 +47,9 @@ export default function Analytics() {
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center">
           <Icon icon="analytics" className="mr-2 size-6" />
-          {t('navigation:analytics')}
+          <span className="line-clamp-1 text-left">
+            {t('navigation:analytics')}
+          </span>
         </div>
       </Page.Header>
       <iframe

--- a/packages/app-builder/src/routes/_builder+/api.tsx
+++ b/packages/app-builder/src/routes/_builder+/api.tsx
@@ -45,7 +45,7 @@ export default function Api() {
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center">
           <Icon icon="harddrive" className="mr-2 size-6" />
-          {t('navigation:api')}
+          <span className="line-clamp-1 text-left">{t('navigation:api')}</span>
         </div>
       </Page.Header>
       <Page.Content>

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId.tsx
@@ -63,12 +63,12 @@ export default function CasePage() {
 
   return (
     <Page.Container>
-      <Page.Header className="justify-between">
+      <Page.Header className="justify-between gap-8">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
-          {caseDetail.name}
+          <span className="line-clamp-2 text-left">{caseDetail.name}</span>
           <CopyToClipboardButton toCopy={caseDetail.id}>
-            <span className="text-s font-normal">
+            <span className="text-s line-clamp-1 font-normal">
               <span className="font-medium">ID</span> {caseDetail.id}
             </span>
           </CopyToClipboardButton>

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -126,12 +126,14 @@ export default function DecisionPage() {
   return (
     <DecisionRightPanel.Root>
       <Page.Container>
-        <Page.Header className="justify-between">
+        <Page.Header className="justify-between gap-8">
           <div className="flex flex-row items-center gap-4">
             <Page.BackButton />
-            {t('decisions:decision')}
+            <span className="line-clamp-1 text-left">
+              {t('decisions:decision')}
+            </span>
             <CopyToClipboardButton toCopy={decision.id}>
-              <span className="text-s font-normal">
+              <span className="text-s line-clamp-1 font-normal">
                 <span className="font-medium">ID</span> {decision.id}
               </span>
             </CopyToClipboardButton>

--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -105,7 +105,7 @@ export default function Lists() {
         <div className="flex w-full flex-row items-center justify-between	gap-4">
           <div className="flex flex-row items-center gap-4">
             <Page.BackButton />
-            {customList.name}
+            <span className="line-clamp-2 text-left">{customList.name}</span>
           </div>
           {canManageList ? (
             <EditList

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -231,7 +231,9 @@ export default function RuleDetail() {
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
-          {rule.name ?? fromUUID(ruleId)}
+          <span className="line-clamp-2 text-left">
+            {rule.name ?? fromUUID(ruleId)}
+          </span>
           {editorMode === 'edit' ? (
             <Tag size="big" border="square">
               {t('common:edit')}

--- a/packages/app-builder/src/routes/_builder+/settings+/api-keys.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/api-keys.tsx
@@ -135,7 +135,9 @@ function CreatedAPIKey({ createdApiKey }: { createdApiKey: CreatedApiKey }) {
         <span className="font-bold">{t('settings:api_keys.new_api_key')}</span>
         <span>{t('settings:api_keys.copy_api_key')}</span>
         <CopyToClipboardButton toCopy={createdApiKey.key}>
-          <span className="text-s font-semibold">{createdApiKey.key}</span>
+          <span className="text-s line-clamp-1 font-semibold">
+            {createdApiKey.key}
+          </span>
         </CopyToClipboardButton>
       </div>
     </Callout>

--- a/packages/app-builder/src/routes/_builder+/workflows+/$scenarioId.tsx
+++ b/packages/app-builder/src/routes/_builder+/workflows+/$scenarioId.tsx
@@ -137,7 +137,7 @@ export default function Workflow() {
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
-          {scenarioName}
+          <span className="line-clamp-2 text-left">{scenarioName}</span>
         </div>
       </Page.Header>
       <WorkflowProvider

--- a/packages/app-builder/src/routes/transfercheck+/transfers+/$transferId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/transfers+/$transferId.tsx
@@ -126,9 +126,11 @@ export default function TransferDetailPage() {
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
-          {t('transfercheck:transfer_detail.title')}
+          <span className="line-clamp-1 text-left">
+            {t('transfercheck:transfer_detail.title')}
+          </span>
           <CopyToClipboardButton toCopy={transfer.id}>
-            <span className="text-s font-normal">
+            <span className="text-s line-clamp-1 font-normal">
               <span className="font-medium">ID</span> {transfer.id}
             </span>
           </CopyToClipboardButton>


### PR DESCRIPTION
Small UI update to better handle long titles.

An example :

Before:
![image](https://github.com/checkmarble/marble-frontend/assets/40292402/bdf4ca04-ffb2-4834-a33a-53633720b391)

After:
![image](https://github.com/checkmarble/marble-frontend/assets/40292402/fbdab31e-bd8e-461f-b896-14432b707361)
