### PR TITLE
refactor(alerts): split sent and received alerts and add filters

### DIFF
--- a/packages/app-builder/public/locales/en/navigation.json
+++ b/packages/app-builder/public/locales/en/navigation.json
@@ -25,5 +25,7 @@
   "settings.inboxes": "Inboxes",
   "settings.tags": "Tags",
   "transfercheck.transfers": "Transfers",
-  "transfercheck.alerts": "Alerts"
+  "transfercheck.alerts": "Alerts",
+  "transfercheck.alerts.received": "Received alerts",
+  "transfercheck.alerts.sent": "Sent alerts"
 }

--- a/packages/app-builder/public/locales/en/transfercheck.json
+++ b/packages/app-builder/public/locales/en/transfercheck.json
@@ -40,7 +40,15 @@
   "alert.create.success": "The alert has been created",
   "alerts.empty": "You have no alerts",
   "alerts.search.empty": "No alert found",
+  "alerts.search.placeholder": "Search alert by message",
+  "alerts.filters.date_range.title": "creation date is:",
+  "alerts.list.status": "Status",
+  "alerts.list.message": "Message",
+  "alerts.list.created_at": "Created at",
   "alert_detail.title": "Alert details",
   "alert_detail.alert_data.title": "Alert data",
-  "alert_detail.alert_data.transfer_id": "Here is the transfer end to end id associated to this alert: <TransferIdValue>{{transferEndToEndId}}</TransferIdValue>"
+  "alert_detail.alert_data.transfer_id": "Here is the transfer end to end id associated to this alert: <TransferIdValue>{{transferEndToEndId}}</TransferIdValue>",
+  "alert_status.unread": "Unread",
+  "alert_status.read": "Read",
+  "alert_status.resolved": "Resolved"
 }

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
@@ -1,7 +1,7 @@
+import { caseStatuses } from '@app-builder/models/cases';
 import { createSimpleContext } from '@app-builder/utils/create-context';
 import { useCallbackRef } from '@app-builder/utils/hooks';
 import {
-  caseStatusSchema,
   type DateRangeFilterForm,
   dateRangeSchema,
 } from '@app-builder/utils/schema/filterSchema';
@@ -19,7 +19,7 @@ import * as z from 'zod';
 import { type CasesFilterName, casesFilterNames } from './filters';
 
 export const casesFiltersSchema = z.object({
-  statuses: z.array(caseStatusSchema).optional(),
+  statuses: z.array(z.enum(caseStatuses)).optional(),
   dateRange: dateRangeSchema.optional(),
 });
 

--- a/packages/app-builder/src/components/TransferAlerts/AlertStatus.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/AlertStatus.tsx
@@ -1,0 +1,94 @@
+import {
+  transferAlerStatuses,
+  type TransferAlertStatus,
+} from '@app-builder/models/transfer-alert';
+import { cva, cx, type VariantProps } from 'class-variance-authority';
+import { type ParseKeys } from 'i18next';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Tooltip } from 'ui-design-system';
+
+import { alertsI18n } from './alerts-i18n';
+
+export const alertStatusVariants = cva(undefined, {
+  variants: {
+    color: {
+      red: 'text-red-100',
+      blue: 'text-blue-100',
+      grey: 'text-grey-50',
+    },
+    variant: {
+      text: undefined,
+      contained: undefined,
+    },
+  },
+  compoundVariants: [
+    {
+      variant: 'contained',
+      color: 'red',
+      className: 'bg-red-10',
+    },
+    {
+      variant: 'contained',
+      color: 'blue',
+      className: 'bg-blue-10',
+    },
+    {
+      variant: 'contained',
+      color: 'grey',
+      className: 'bg-grey-10',
+    },
+  ],
+});
+
+export function AlertStatus({ status }: { status: TransferAlertStatus }) {
+  const { t } = useTranslation(alertsI18n);
+  const { color, tKey } = alertStatusMapping[status];
+
+  return (
+    <Tooltip.Default content={t(tKey)}>
+      <div
+        className={cx(
+          alertStatusVariants({ color, variant: 'contained' }),
+          'text-s flex size-6 items-center justify-center rounded font-semibold capitalize',
+        )}
+      >
+        {t(tKey)[0]}
+      </div>
+    </Tooltip.Default>
+  );
+}
+
+export const alertStatusMapping = {
+  unread: {
+    color: 'red',
+    tKey: 'transfercheck:alert_status.unread',
+  },
+  read: {
+    color: 'blue',
+    tKey: 'transfercheck:alert_status.read',
+  },
+  archived: {
+    color: 'grey',
+    tKey: 'transfercheck:alert_status.resolved',
+  },
+} satisfies Record<
+  TransferAlertStatus,
+  {
+    color: VariantProps<typeof alertStatusVariants>['color'];
+    tKey: ParseKeys<['transfercheck']>;
+  }
+>;
+
+export function useAlertStatuses() {
+  const { t } = useTranslation(alertsI18n);
+
+  return React.useMemo(
+    () =>
+      transferAlerStatuses.map((status) => ({
+        value: status,
+        label: t(alertStatusMapping[status].tKey),
+      })),
+    [t],
+  );
+}

--- a/packages/app-builder/src/components/TransferAlerts/AlertsList.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/AlertsList.tsx
@@ -1,23 +1,126 @@
-import { type TransferAlert } from '@app-builder/models/transfer-alert';
+import { Highlight } from '@app-builder/components/Highlight';
+import {
+  type TransferAlert,
+  type TransferAlertStatus,
+} from '@app-builder/models/transfer-alert';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
+import { type DateRangeFilter } from '@app-builder/utils/schema/filterSchema';
 import { fromUUID } from '@app-builder/utils/short-uuid';
+import {
+  arrIncludesExactSome,
+  dateRangeFilterFn,
+} from '@app-builder/utils/table-filter-fn';
 import { Link } from '@remix-run/react';
-import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type OnChangeFn,
+} from '@tanstack/react-table';
 import clsx from 'clsx';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Table, useTable } from 'ui-design-system';
 
+import { FiltersButton } from '../Filters/FiltersButton';
 import { alertsI18n } from './alerts-i18n';
+import {
+  type AlertsFilters,
+  AlertsFiltersBar,
+  AlertsFiltersMenu,
+  AlertsFiltersProvider,
+} from './Filters';
+import { MessageFilter } from './Filters/FilterDetail/MessageFilter';
+import { alertsFilterNames } from './Filters/filters';
 
 interface AlertsListProps {
   alerts: TransferAlert[];
+  className?: string;
+}
+
+type TransferAlertColumnFiltersState = (
+  | { id: 'status'; value: TransferAlertStatus[] }
+  | { id: 'createdAt'; value: DateRangeFilter }
+  | { id: 'message'; value: string }
+)[];
+
+export function AlertsList({ alerts, className }: AlertsListProps) {
+  const [columnFilters, setColumnFilters] =
+    React.useState<TransferAlertColumnFiltersState>([]);
+
+  const filterValues: AlertsFilters = columnFilters.reduce<AlertsFilters>(
+    (acc, filter) => {
+      if (filter.id === 'status') {
+        acc.statuses = filter.value;
+      }
+      if (filter.id === 'createdAt') {
+        acc.dateRange = filter.value;
+      }
+      if (filter.id === 'message') {
+        acc.message = filter.value;
+      }
+      return acc;
+    },
+    {},
+  );
+  const submitRulesFilters = React.useCallback((filters: AlertsFilters) => {
+    const nextColumnFilters: TransferAlertColumnFiltersState = [];
+    if (filters.statuses) {
+      nextColumnFilters.push({ id: 'status', value: filters.statuses });
+    }
+    if (filters.dateRange) {
+      nextColumnFilters.push({ id: 'createdAt', value: filters.dateRange });
+    }
+    if (filters.message) {
+      nextColumnFilters.push({ id: 'message', value: filters.message });
+    }
+    setColumnFilters(nextColumnFilters);
+  }, []);
+
+  return (
+    <AlertsFiltersProvider
+      filterValues={filterValues}
+      submitAlertsFilters={submitRulesFilters}
+    >
+      <div className="flex flex-col gap-2 lg:gap-4">
+        <div className="flex flex-row gap-2 lg:gap-4">
+          <MessageFilter disabled={alerts.length === 0} />
+
+          <div className="flex flex-row gap-4">
+            <AlertsFiltersMenu filterNames={alertsFilterNames}>
+              <FiltersButton />
+            </AlertsFiltersMenu>
+          </div>
+        </div>
+        <AlertsFiltersBar />
+        <AlertsListTable
+          alerts={alerts}
+          className={className}
+          columnFilters={columnFilters}
+          setColumnFilters={setColumnFilters}
+        />
+      </div>
+    </AlertsFiltersProvider>
+  );
+}
+
+interface AlertsListTableProps {
+  alerts: TransferAlert[];
+  className?: string;
+  columnFilters: TransferAlertColumnFiltersState;
+  setColumnFilters: OnChangeFn<TransferAlertColumnFiltersState>;
 }
 
 const columnHelper = createColumnHelper<TransferAlert>();
 
-export function AlertsList({ alerts }: AlertsListProps) {
+function AlertsListTable({
+  alerts,
+  className,
+  columnFilters,
+  setColumnFilters,
+}: AlertsListTableProps) {
   const { t } = useTranslation(alertsI18n);
   const language = useFormatLanguage();
 
@@ -25,22 +128,32 @@ export function AlertsList({ alerts }: AlertsListProps) {
     () => [
       columnHelper.accessor((row) => row.status, {
         id: 'status',
-        header: 'Status',
+        header: t('transfercheck:alerts.list.status'),
         size: 50,
+        filterFn: arrIncludesExactSome,
+        // TODO: cell renderer
       }),
       columnHelper.accessor((row) => row.message, {
-        id: 'message',
-        header: 'Message',
+        id: 'message', // Used for filtering, change in both places
+        header: t('transfercheck:alerts.list.message'),
         size: 200,
-        cell: ({ getValue }) => {
-          const message = getValue();
-          return <div className="py-2">{message}</div>;
+        cell: ({ getValue, column }) => {
+          const columnFilterValue = column.getFilterValue();
+          const query =
+            typeof columnFilterValue === 'string' ? columnFilterValue : '';
+
+          return (
+            <div className="py-2">
+              <Highlight text={getValue()} query={query} />
+            </div>
+          );
         },
       }),
       columnHelper.accessor((row) => row.createdAt, {
         id: 'createdAt',
-        header: 'Created At',
+        header: t('transfercheck:alerts.list.created_at'),
         size: 100,
+        filterFn: dateRangeFilterFn,
         cell: ({ getValue }) => {
           const dateTime = getValue();
           return (
@@ -51,14 +164,19 @@ export function AlertsList({ alerts }: AlertsListProps) {
         },
       }),
     ],
-    [language],
+    [language, t],
   );
 
   const { rows, table, getBodyProps, getContainerProps } = useTable({
     data: alerts,
     columns,
     columnResizeMode: 'onChange',
+    state: { columnFilters },
+    // @ts-expect-error ColumnFiltersState is currently not customizable
+    onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     rowLink: (alert) => (
       <Link
         to={getRoute('/transfercheck/alerts/:alertId', {
@@ -68,20 +186,20 @@ export function AlertsList({ alerts }: AlertsListProps) {
     ),
   });
 
-  if (rows.length === 0 || alerts.length === 0) {
-    const emptyMessage =
-      alerts.length === 0
-        ? t('transfercheck:alerts.empty')
-        : t('transfercheck:alerts.search.empty');
+  if (rows.length === 0) {
     return (
       <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
-        <p className="text-s font-medium">{emptyMessage}</p>
+        <p className="text-s font-medium">
+          {alerts.length === 0
+            ? t('transfercheck:alerts.empty')
+            : t('transfercheck:alerts.search.empty')}
+        </p>
       </div>
     );
   }
 
   return (
-    <Table.Container {...getContainerProps()}>
+    <Table.Container {...getContainerProps()} className={className}>
       <Table.Header headerGroups={table.getHeaderGroups()} />
       <Table.Body {...getBodyProps()}>
         {rows.map((row) => {

--- a/packages/app-builder/src/components/TransferAlerts/Filters/AlertsFiltersBar.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/AlertsFiltersBar.tsx
@@ -1,0 +1,89 @@
+import {
+  AddNewFilterButton,
+  ClearAllFiltersButton,
+  FilterItem,
+  FilterPopover,
+} from '@app-builder/components/Filters';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Separator } from 'ui-design-system';
+import { Icon } from 'ui-icons';
+
+import { alertsI18n } from '../alerts-i18n';
+import {
+  useAlertsFiltersContext,
+  useAlertsFiltersPartition,
+  useClearAllFilters,
+  useClearFilter,
+} from './AlertsFiltersContext';
+import { AlertsFiltersMenu } from './AlertsFiltersMenu';
+import { FilterDetail } from './FilterDetail';
+import { type AlertsFilterName, getFilterIcon, getFilterTKey } from './filters';
+
+export function AlertsFiltersBar() {
+  const { undefinedAlertsFilterNames, definedAlertsFilterNames } =
+    useAlertsFiltersPartition();
+  const clearAllFilters = useClearAllFilters();
+
+  if (definedAlertsFilterNames.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Separator className="bg-grey-10" decorative />
+      <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex flex-row flex-wrap gap-2">
+          {definedAlertsFilterNames.map((filterName) => (
+            <FiltersBarItem key={filterName} filterName={filterName} />
+          ))}
+          {undefinedAlertsFilterNames.length > 0 ? (
+            <AlertsFiltersMenu filterNames={undefinedAlertsFilterNames}>
+              <AddNewFilterButton />
+            </AlertsFiltersMenu>
+          ) : null}
+        </div>
+        <ClearAllFiltersButton onClick={clearAllFilters} />
+      </div>
+    </>
+  );
+}
+
+function FiltersBarItem({ filterName }: { filterName: AlertsFilterName }) {
+  const { t } = useTranslation(alertsI18n);
+  const icon = getFilterIcon(filterName);
+  const tKey = getFilterTKey(filterName);
+
+  const clearFilter = useClearFilter();
+  const { onAlertsFilterClose } = useAlertsFiltersContext();
+
+  const onOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onAlertsFilterClose();
+      }
+    },
+    [onAlertsFilterClose],
+  );
+
+  return (
+    <FilterPopover.Root onOpenChange={onOpenChange}>
+      <FilterItem.Root>
+        <FilterItem.Trigger>
+          <Icon icon={icon} className="size-5" />
+          <span className="text-s font-semibold first-letter:capitalize">
+            {t(tKey)}
+          </span>
+        </FilterItem.Trigger>
+        <FilterItem.Clear
+          onClick={() => {
+            clearFilter(filterName);
+          }}
+        />
+      </FilterItem.Root>
+      <FilterPopover.Content>
+        <FilterDetail filterName={filterName} />
+      </FilterPopover.Content>
+    </FilterPopover.Root>
+  );
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/AlertsFiltersContext.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/AlertsFiltersContext.tsx
@@ -1,0 +1,219 @@
+import {
+  transferAlerStatuses,
+  type TransferAlertStatus,
+} from '@app-builder/models/transfer-alert';
+import { createSimpleContext } from '@app-builder/utils/create-context';
+import { useCallbackRef } from '@app-builder/utils/hooks';
+import {
+  type DateRangeFilterForm,
+  dateRangeSchema,
+} from '@app-builder/utils/schema/filterSchema';
+import * as React from 'react';
+import {
+  FormProvider,
+  useController,
+  useForm,
+  useFormContext,
+} from 'react-hook-form';
+import * as R from 'remeda';
+import * as z from 'zod';
+
+import { type AlertsFilterName, alertsFilterNames } from './filters';
+
+export const alertsFiltersSchema = z.object({
+  message: z.string().optional(),
+  statuses: z.array(z.enum(transferAlerStatuses)).optional(),
+  dateRange: dateRangeSchema.optional(),
+});
+
+export type AlertsFilters = z.infer<typeof alertsFiltersSchema>;
+
+interface AlertsFiltersContextValue {
+  filterValues: AlertsFilters;
+  submitAlertsFilters: () => void;
+  onAlertsFilterClose: () => void;
+}
+
+const AlertsFiltersContext = createSimpleContext<AlertsFiltersContextValue>(
+  'AlertsFiltersContext',
+);
+
+export type AlertsFiltersForm = {
+  message: string | null;
+  statuses: TransferAlertStatus[];
+  dateRange: DateRangeFilterForm;
+};
+const emptyAlertsFilters: AlertsFiltersForm = {
+  message: null,
+  statuses: [],
+  dateRange: null,
+};
+
+function adaptAlertsFiltersForm({
+  dateRange,
+  ...otherFilters
+}: AlertsFilters): AlertsFiltersForm {
+  const adaptedFilterValues: AlertsFiltersForm = {
+    ...emptyAlertsFilters,
+    ...otherFilters,
+  };
+  if (dateRange?.type === 'static') {
+    adaptedFilterValues.dateRange = {
+      type: 'static',
+      startDate: dateRange.startDate ?? '',
+      endDate: dateRange.endDate ?? '',
+    };
+  }
+  if (dateRange?.type === 'dynamic' && dateRange.fromNow) {
+    adaptedFilterValues.dateRange = {
+      type: 'dynamic',
+      fromNow: dateRange.fromNow,
+    };
+  }
+  return adaptedFilterValues;
+}
+function adaptAlertsFilters(filters: AlertsFiltersForm): AlertsFilters {
+  const adaptedFilters: AlertsFilters = {};
+  if (R.isNonNull(filters.message)) {
+    adaptedFilters.message = filters.message;
+  }
+  if (!R.isEmpty(filters.statuses)) {
+    adaptedFilters.statuses = filters.statuses;
+  }
+  if (filters.dateRange) {
+    if (filters.dateRange.type === 'static') {
+      adaptedFilters.dateRange = {
+        type: 'static',
+        startDate: filters.dateRange.startDate,
+        endDate: filters.dateRange.endDate,
+      };
+    }
+    if (filters.dateRange.type === 'dynamic') {
+      adaptedFilters.dateRange = {
+        type: 'dynamic',
+        fromNow: filters.dateRange.fromNow,
+      };
+    }
+  }
+  return adaptedFilters;
+}
+
+export function AlertsFiltersProvider({
+  filterValues,
+  submitAlertsFilters: _submitAlertsFilters,
+  children,
+}: {
+  filterValues: AlertsFilters;
+  submitAlertsFilters: (filterValues: AlertsFilters) => void;
+  children: React.ReactNode;
+}) {
+  const formMethods = useForm<AlertsFiltersForm>({
+    defaultValues: emptyAlertsFilters,
+    values: adaptAlertsFiltersForm(filterValues),
+  });
+  const { isDirty } = formMethods.formState;
+  const submitAlertsFilters = useCallbackRef(() => {
+    const formValues = formMethods.getValues();
+    _submitAlertsFilters(adaptAlertsFilters(formValues));
+  });
+  const onAlertsFilterClose = useCallbackRef(() => {
+    if (isDirty) {
+      submitAlertsFilters();
+    }
+  });
+
+  const value = React.useMemo(
+    () => ({
+      submitAlertsFilters,
+      onAlertsFilterClose,
+      filterValues,
+    }),
+    [filterValues, onAlertsFilterClose, submitAlertsFilters],
+  );
+  return (
+    <FormProvider {...formMethods}>
+      <AlertsFiltersContext.Provider value={value}>
+        {children}
+      </AlertsFiltersContext.Provider>
+    </FormProvider>
+  );
+}
+
+export const useAlertsFiltersContext = AlertsFiltersContext.useValue;
+
+export function useMessageFilter() {
+  const { submitAlertsFilters } = useAlertsFiltersContext();
+  const { field } = useController<AlertsFiltersForm, 'message'>({
+    name: 'message',
+  });
+  const messageFilter = field.value;
+  const setMessageFilter = useCallbackRef((e) => {
+    field.onChange(e);
+    submitAlertsFilters();
+  });
+  return { messageFilter, setMessageFilter };
+}
+
+export function useStatusesFilter() {
+  const { field } = useController<AlertsFiltersForm, 'statuses'>({
+    name: 'statuses',
+  });
+  const selectedStatuses = field.value;
+  const setSelectedStatuses = field.onChange;
+  return { selectedStatuses, setSelectedStatuses };
+}
+
+export function useDateRangeFilter() {
+  const { field } = useController<AlertsFiltersForm, 'dateRange'>({
+    name: 'dateRange',
+  });
+  const dateRange = field.value;
+  const setDateRange = field.onChange;
+  return { dateRange, setDateRange };
+}
+
+/**
+ * Split alerts filters in two partitions:
+ * - undefinedAlertsFilterNames: filter values are undefined
+ * - definedAlertsFilterNames: filter values are defined
+ */
+export function useAlertsFiltersPartition() {
+  const { filterValues } = useAlertsFiltersContext();
+
+  const [undefinedAlertsFilterNames, definedAlertsFilterNames] = R.pipe(
+    alertsFilterNames,
+    R.partition((filterName) => {
+      const value = filterValues[filterName];
+      if (R.isArray(value)) return value.length === 0;
+      if (R.isPlainObject(value)) return R.isEmpty(value);
+      return R.isNullish(value);
+    }),
+  );
+  return {
+    undefinedAlertsFilterNames,
+    definedAlertsFilterNames,
+  };
+}
+
+export function useClearFilter() {
+  const { submitAlertsFilters } = useAlertsFiltersContext();
+  const { setValue } = useFormContext<AlertsFiltersForm>();
+
+  return React.useCallback(
+    (filterName: AlertsFilterName) => {
+      setValue(filterName, emptyAlertsFilters[filterName]);
+      submitAlertsFilters();
+    },
+    [setValue, submitAlertsFilters],
+  );
+}
+
+export function useClearAllFilters() {
+  const { submitAlertsFilters } = useAlertsFiltersContext();
+  const { reset } = useFormContext<AlertsFiltersForm>();
+
+  return React.useCallback(() => {
+    reset(emptyAlertsFilters);
+    submitAlertsFilters();
+  }, [reset, submitAlertsFilters]);
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/AlertsFiltersMenu.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/AlertsFiltersMenu.tsx
@@ -1,0 +1,87 @@
+import { FiltersDropdownMenu } from '@app-builder/components/Filters';
+import { forwardRef, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Icon } from 'ui-icons';
+
+import { alertsI18n } from '../alerts-i18n';
+import { useAlertsFiltersContext } from './AlertsFiltersContext';
+import { FilterDetail } from './FilterDetail';
+import { type AlertsFilterName, getFilterIcon, getFilterTKey } from './filters';
+
+export function AlertsFiltersMenu({
+  children,
+  filterNames,
+}: {
+  children: React.ReactNode;
+  filterNames: readonly AlertsFilterName[];
+}) {
+  const { onAlertsFilterClose } = useAlertsFiltersContext();
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onAlertsFilterClose();
+      }
+    },
+    [onAlertsFilterClose],
+  );
+
+  return (
+    <FiltersDropdownMenu.Root onOpenChange={onOpenChange}>
+      <FiltersDropdownMenu.Trigger asChild>
+        {children}
+      </FiltersDropdownMenu.Trigger>
+      <FiltersDropdownMenu.Content>
+        <FilterContent filterNames={filterNames} />
+      </FiltersDropdownMenu.Content>
+    </FiltersDropdownMenu.Root>
+  );
+}
+
+const FiltersMenuItem = forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof FiltersDropdownMenu.Item> & {
+    filterName: AlertsFilterName;
+  }
+>(({ filterName, ...props }, ref) => {
+  const { t } = useTranslation(alertsI18n);
+  const icon = getFilterIcon(filterName);
+  const tKey = getFilterTKey(filterName);
+
+  return (
+    <FiltersDropdownMenu.Item {...props} ref={ref}>
+      <Icon icon={icon} className="size-5" />
+      <span className="text-s text-grey-100 font-normal first-letter:capitalize">
+        {t(tKey)}
+      </span>
+    </FiltersDropdownMenu.Item>
+  );
+});
+FiltersMenuItem.displayName = 'FiltersMenuItem';
+
+function FilterContent({
+  filterNames,
+}: {
+  filterNames: readonly AlertsFilterName[];
+}) {
+  const [selectedFilter, setSelectedFilter] = useState<AlertsFilterName>();
+
+  if (selectedFilter) {
+    return <FilterDetail filterName={selectedFilter} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-1 p-2">
+      {filterNames.map((filterName) => (
+        <FiltersMenuItem
+          key={filterName}
+          filterName={filterName}
+          onClick={(e) => {
+            e.preventDefault();
+            setSelectedFilter(filterName);
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/AlertsDateRangeFilter.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/AlertsDateRangeFilter.tsx
@@ -1,0 +1,31 @@
+import { DateRangeFilter } from '@app-builder/components/Filters';
+import { useTranslation } from 'react-i18next';
+import { Separator } from 'ui-design-system';
+
+import { alertsI18n } from '../../alerts-i18n';
+import { useDateRangeFilter } from '../AlertsFiltersContext';
+
+export function AlertsDateRangeFilter() {
+  const { t } = useTranslation(alertsI18n);
+  const { dateRange, setDateRange } = useDateRangeFilter();
+
+  return (
+    <DateRangeFilter.Root
+      dateRangeFilter={dateRange}
+      setDateRangeFilter={setDateRange}
+      className="grid"
+    >
+      <DateRangeFilter.FromNowPicker
+        title={t('transfercheck:alerts.filters.date_range.title')}
+      />
+      <Separator className="bg-grey-10" decorative orientation="vertical" />
+      <DateRangeFilter.Calendar />
+      <Separator
+        className="bg-grey-10 col-span-3"
+        decorative
+        orientation="horizontal"
+      />
+      <DateRangeFilter.Summary className="col-span-3 row-span-1" />
+    </DateRangeFilter.Root>
+  );
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/FilterDetail.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/FilterDetail.tsx
@@ -1,0 +1,16 @@
+import { assertNever } from 'typescript-utils';
+
+import { type AlertsFilterName } from '../filters';
+import { AlertsDateRangeFilter } from './AlertsDateRangeFilter';
+import { StatusesFilter } from './StatusesFilter';
+
+export function FilterDetail({ filterName }: { filterName: AlertsFilterName }) {
+  switch (filterName) {
+    case 'dateRange':
+      return <AlertsDateRangeFilter />;
+    case 'statuses':
+      return <StatusesFilter />;
+    default:
+      assertNever('[CasesFilter] unknown filter:', filterName);
+  }
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/MessageFilter.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/MessageFilter.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { Input } from 'ui-design-system';
+
+import { alertsI18n } from '../../alerts-i18n';
+import { useMessageFilter } from '../AlertsFiltersContext';
+
+export function MessageFilter({ disabled }: { disabled: boolean }) {
+  const { t } = useTranslation(alertsI18n);
+  const { messageFilter, setMessageFilter } = useMessageFilter();
+
+  return (
+    <form className="flex grow items-center">
+      <Input
+        className="w-full max-w-md"
+        disabled={disabled}
+        type="search"
+        aria-label={t('transfercheck:alerts.search.placeholder')}
+        placeholder={t('transfercheck:alerts.search.placeholder')}
+        startAdornment="search"
+        value={messageFilter ?? ''}
+        onChange={(event) => {
+          setMessageFilter(event.target.value || null);
+        }}
+      />
+    </form>
+  );
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/StatusesFilter.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/StatusesFilter.tsx
@@ -1,0 +1,46 @@
+import { matchSorter } from '@app-builder/utils/search';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { Input, SelectWithCombobox } from 'ui-design-system';
+
+import { AlertStatus, useAlertStatuses } from '../../AlertStatus';
+import { useStatusesFilter } from '../AlertsFiltersContext';
+
+export function StatusesFilter() {
+  const [value, setSearchValue] = useState('');
+  const { selectedStatuses, setSelectedStatuses } = useStatusesFilter();
+  const deferredValue = useDeferredValue(value);
+  const statuses = useAlertStatuses();
+
+  const matches = useMemo(
+    () => matchSorter(statuses, deferredValue, { keys: ['label'] }),
+    [deferredValue, statuses],
+  );
+
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <SelectWithCombobox.Root
+        open
+        onSearchValueChange={setSearchValue}
+        selectedValue={selectedStatuses}
+        onSelectedValueChange={setSelectedStatuses}
+      >
+        <SelectWithCombobox.Combobox render={<Input />} autoSelect autoFocus />
+        <SelectWithCombobox.ComboboxList className="max-h-40">
+          {matches.map((status) => {
+            return (
+              <SelectWithCombobox.ComboboxItem
+                key={status.value}
+                value={status.value}
+              >
+                <AlertStatus status={status.value} />
+                <span className="text-grey-100 text-s font-normal first-letter:capitalize">
+                  {status.label}
+                </span>
+              </SelectWithCombobox.ComboboxItem>
+            );
+          })}
+        </SelectWithCombobox.ComboboxList>
+      </SelectWithCombobox.Root>
+    </div>
+  );
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/index.ts
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/FilterDetail/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterDetail';

--- a/packages/app-builder/src/components/TransferAlerts/Filters/filters.ts
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/filters.ts
@@ -1,0 +1,28 @@
+import { assertNever } from 'typescript-utils';
+import { type IconName } from 'ui-icons';
+
+export const alertsFilterNames = ['dateRange', 'statuses'] as const;
+
+export type AlertsFilterName = (typeof alertsFilterNames)[number];
+
+export function getFilterIcon(filterName: AlertsFilterName): IconName {
+  switch (filterName) {
+    case 'dateRange':
+      return 'calendar-month';
+    case 'statuses':
+      return 'category';
+    default:
+      assertNever('[AlertsFilterName] unknown filter:', filterName);
+  }
+}
+
+export function getFilterTKey(filterName: AlertsFilterName) {
+  switch (filterName) {
+    case 'dateRange':
+      return 'transfercheck:alerts.list.created_at';
+    case 'statuses':
+      return 'transfercheck:alerts.list.status';
+    default:
+      assertNever('[AlertsFilterName] unknown filter:', filterName);
+  }
+}

--- a/packages/app-builder/src/components/TransferAlerts/Filters/index.ts
+++ b/packages/app-builder/src/components/TransferAlerts/Filters/index.ts
@@ -1,0 +1,3 @@
+export * from './AlertsFiltersBar';
+export * from './AlertsFiltersContext';
+export * from './AlertsFiltersMenu';

--- a/packages/app-builder/src/models/cases.ts
+++ b/packages/app-builder/src/models/cases.ts
@@ -83,6 +83,13 @@ export interface CaseDetail
   events: CaseEvent[];
 }
 
+export const caseStatuses = [
+  'open',
+  'investigating',
+  'discarded',
+  'resolved',
+] as const;
+
 export function adaptCaseDetailDto({
   events,
   decisions,

--- a/packages/app-builder/src/models/transfer-alert.ts
+++ b/packages/app-builder/src/models/transfer-alert.ts
@@ -4,9 +4,10 @@ import {
   type UpdateTransferAlertDto,
 } from 'marble-api/generated/transfercheck-api';
 
-export type TransferAlerStatus = 'unread' | 'read' | 'archived';
+export const transferAlerStatuses = ['unread', 'read', 'archived'] as const;
+export type TransferAlertStatus = (typeof transferAlerStatuses)[number];
 
-export type TransferAlertType = 'sender' | 'beneficiary';
+export type TransferAlertType = 'sent' | 'received';
 
 export interface TransferAlert {
   id: string;
@@ -15,7 +16,7 @@ export interface TransferAlert {
   senderPartnerId: string;
   beneficiaryPartnerId: string;
   createdAt: string;
-  status: TransferAlerStatus;
+  status: TransferAlertStatus;
   message: string;
   transferEndToEndId: string;
   beneficiaryIban: string;
@@ -28,9 +29,9 @@ export function adaptTransferAlert(
 ): TransferAlert {
   let type: TransferAlertType;
   if (dto.sender_partner_id === partnerId) {
-    type = 'sender';
+    type = 'sent';
   } else if (dto.beneficiary_partner_id === partnerId) {
-    type = 'beneficiary';
+    type = 'received';
   } else {
     throw new Error('Invalid partner id');
   }
@@ -79,7 +80,7 @@ export type UpdateTransferAlert =
     }
   | {
       type: 'beneficiary';
-      status: TransferAlerStatus;
+      status: TransferAlertStatus;
     };
 
 export function adaptUpdateTransferAlertDto(

--- a/packages/app-builder/src/routes/ressources+/cases+/edit-status.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/edit-status.tsx
@@ -5,9 +5,9 @@ import {
   caseStatusVariants,
   useCaseStatuses,
 } from '@app-builder/components/Cases';
+import { caseStatuses } from '@app-builder/models/cases';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { caseStatusSchema } from '@app-builder/utils/schema/filterSchema';
 import { conform, useForm } from '@conform-to/react';
 import { getFieldsetConstraint, parse } from '@conform-to/zod';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
@@ -26,8 +26,8 @@ export const handle = {
 
 const schema = z.object({
   caseId: z.string(),
-  status: caseStatusSchema,
-  nextStatus: caseStatusSchema,
+  status: z.enum(caseStatuses),
+  nextStatus: z.enum(caseStatuses),
 });
 type Schema = z.infer<typeof schema>;
 

--- a/packages/app-builder/src/routes/transfercheck+/_layout.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/_layout.tsx
@@ -112,7 +112,7 @@ export default function Builder() {
                 <li>
                   <SidebarLink
                     labelTKey="navigation:transfercheck.alerts"
-                    to={getRoute('/transfercheck/alerts/')}
+                    to={getRoute('/transfercheck/alerts/inboxes')}
                     Icon={(props) => <Icon icon="notifications" {...props} />}
                   />
                 </li>

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes._index.tsx
@@ -1,0 +1,11 @@
+import { serverServices } from '@app-builder/services/init.server';
+import { getRoute } from '@app-builder/utils/routes';
+import { type LoaderFunctionArgs } from '@remix-run/node';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { authService } = serverServices;
+  return authService.isAuthenticated(request, {
+    successRedirect: getRoute('/transfercheck/alerts/inboxes/received'),
+    failureRedirect: getRoute('/sign-in'),
+  });
+}

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes._layout.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes._layout.tsx
@@ -1,10 +1,10 @@
-import { Page } from '@app-builder/components';
+import { Page, TabLink } from '@app-builder/components';
 import { alertsI18n } from '@app-builder/components/TransferAlerts/alerts-i18n';
-import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
 import { serverServices } from '@app-builder/services/init.server';
+import { AlertsContextProvider } from '@app-builder/services/transfercheck/alerts/alerts';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { useLoaderData } from '@remix-run/react';
+import { Outlet, useLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Icon } from 'ui-icons';
@@ -24,9 +24,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const alerts = await transferAlertRepository.listAlerts();
 
-  return json({
-    alerts,
-  });
+  return json({ alerts });
 }
 
 export default function AlertsPage() {
@@ -41,15 +39,27 @@ export default function AlertsPage() {
       </Page.Header>
 
       <Page.Content className="max-w-3xl">
-        {/* 
-        TODO: 
-        - think about split between received and sent alerts
-        - add filters (local at least) 
-        - add pagination (local at least)
-        - add sorting (local at least)
-        - add search (local at least)
-        */}
-        <AlertsList alerts={alerts} />
+        <nav className="bg-grey-00 border-grey-10 w-fit rounded border p-1">
+          <ul className="flex flex-row gap-2">
+            <li>
+              <TabLink
+                labelTKey="navigation:transfercheck.alerts.received"
+                to={getRoute('/transfercheck/alerts/inboxes/received')}
+                Icon={(props) => <Icon {...props} icon="inbox" />}
+              />
+            </li>
+            <li>
+              <TabLink
+                labelTKey="navigation:transfercheck.alerts.sent"
+                to={getRoute('/transfercheck/alerts/inboxes/sent')}
+                Icon={(props) => <Icon {...props} icon="send" />}
+              />
+            </li>
+          </ul>
+        </nav>
+        <AlertsContextProvider alerts={alerts}>
+          <Outlet />
+        </AlertsContextProvider>
       </Page.Content>
     </Page.Container>
   );

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes.received.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes.received.tsx
@@ -1,0 +1,8 @@
+import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
+import { useReceivedAlerts } from '@app-builder/services/transfercheck/alerts/alerts';
+
+export default function ReceivedAlertsPage() {
+  const alerts = useReceivedAlerts();
+
+  return <AlertsList alerts={alerts} className="max-h-[60dvh]" />;
+}

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes.sent.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/inboxes.sent.tsx
@@ -1,0 +1,8 @@
+import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
+import { useSentAlerts } from '@app-builder/services/transfercheck/alerts/alerts';
+
+export default function SentAlertsPage() {
+  const alerts = useSentAlerts();
+
+  return <AlertsList alerts={alerts} className="max-h-[60dvh]" />;
+}

--- a/packages/app-builder/src/services/transfercheck/alerts/alerts.tsx
+++ b/packages/app-builder/src/services/transfercheck/alerts/alerts.tsx
@@ -1,0 +1,33 @@
+import { type TransferAlert } from '@app-builder/models/transfer-alert';
+import { createSimpleContext } from '@app-builder/utils/create-context';
+import * as React from 'react';
+
+interface AlertContext {
+  receivedAlerts: TransferAlert[];
+  sentAlerts: TransferAlert[];
+}
+
+const AlertsContext = createSimpleContext<AlertContext>('AlertsContext');
+
+export function AlertsContextProvider({
+  alerts,
+  children,
+}: {
+  alerts: TransferAlert[];
+  children: React.ReactNode;
+}) {
+  const value = React.useMemo(
+    () => ({
+      receivedAlerts: alerts.filter((alert) => alert.type === 'received'),
+      sentAlerts: alerts.filter((alert) => alert.type === 'sent'),
+    }),
+    [alerts],
+  );
+
+  return (
+    <AlertsContext.Provider value={value}>{children}</AlertsContext.Provider>
+  );
+}
+
+export const useReceivedAlerts = () => AlertsContext.useValue().receivedAlerts;
+export const useSentAlerts = () => AlertsContext.useValue().sentAlerts;

--- a/packages/app-builder/src/utils/routes/routes.ts
+++ b/packages/app-builder/src/utils/routes/routes.ts
@@ -510,10 +510,26 @@ export const routes = [
             "file": "routes/transfercheck+/alerts+/$alertId.tsx"
           },
           {
-            "id": "routes/transfercheck+/alerts+/_index",
-            "index": true,
-            "path": "alerts/",
-            "file": "routes/transfercheck+/alerts+/_index.tsx"
+            "id": "routes/transfercheck+/alerts+/inboxes._layout",
+            "path": "alerts/inboxes",
+            "file": "routes/transfercheck+/alerts+/inboxes._layout.tsx",
+            "children": [
+              {
+                "id": "routes/transfercheck+/alerts+/inboxes._index",
+                "index": true,
+                "file": "routes/transfercheck+/alerts+/inboxes._index.tsx"
+              },
+              {
+                "id": "routes/transfercheck+/alerts+/inboxes.received",
+                "path": "received",
+                "file": "routes/transfercheck+/alerts+/inboxes.received.tsx"
+              },
+              {
+                "id": "routes/transfercheck+/alerts+/inboxes.sent",
+                "path": "sent",
+                "file": "routes/transfercheck+/alerts+/inboxes.sent.tsx"
+              }
+            ]
           },
           {
             "id": "routes/transfercheck+/ressources+/alert.create",

--- a/packages/app-builder/src/utils/routes/types.ts
+++ b/packages/app-builder/src/utils/routes/types.ts
@@ -87,7 +87,9 @@ export type RoutePath =
   | '/transfercheck'
   | '/transfercheck/*'
   | '/transfercheck/alerts/:alertId'
-  | '/transfercheck/alerts/'
+  | '/transfercheck/alerts/inboxes'
+  | '/transfercheck/alerts/inboxes/received'
+  | '/transfercheck/alerts/inboxes/sent'
   | '/transfercheck/ressources/alert/create'
   | '/transfercheck/transfers/:transferId'
   | '/transfercheck/transfers/';
@@ -191,7 +193,10 @@ export type RouteID =
   | 'routes/transfercheck+/$'
   | 'routes/transfercheck+/_index'
   | 'routes/transfercheck+/alerts+/$alertId'
-  | 'routes/transfercheck+/alerts+/_index'
+  | 'routes/transfercheck+/alerts+/inboxes._layout'
+  | 'routes/transfercheck+/alerts+/inboxes._index'
+  | 'routes/transfercheck+/alerts+/inboxes.received'
+  | 'routes/transfercheck+/alerts+/inboxes.sent'
   | 'routes/transfercheck+/ressources+/alert.create'
   | 'routes/transfercheck+/transfers+/$transferId'
   | 'routes/transfercheck+/transfers+/_index';

--- a/packages/app-builder/src/utils/schema/filterSchema.ts
+++ b/packages/app-builder/src/utils/schema/filterSchema.ts
@@ -20,6 +20,8 @@ export const dateRangeSchema = z.discriminatedUnion('type', [
   }),
 ]);
 
+export type DateRangeFilter = z.infer<typeof dateRangeSchema>;
+
 export type DateRangeFilterForm =
   | {
       type: 'static';
@@ -31,10 +33,3 @@ export type DateRangeFilterForm =
       fromNow: string;
     }
   | null;
-
-export const caseStatusSchema = z.enum([
-  'open',
-  'investigating',
-  'discarded',
-  'resolved',
-]);

--- a/packages/app-builder/src/utils/table-filter-fn.ts
+++ b/packages/app-builder/src/utils/table-filter-fn.ts
@@ -1,0 +1,38 @@
+import { type Row, type RowData } from '@tanstack/react-table';
+import { Temporal } from 'temporal-polyfill';
+
+import { type DateRangeFilter } from './schema/filterSchema';
+
+export function dateRangeFilterFn<TData extends RowData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue?: DateRangeFilter,
+) {
+  if (!filterValue) return true;
+  const date = row.getValue<string>(columnId);
+  if (filterValue.type === 'static') {
+    if (filterValue.startDate && filterValue.startDate > date) return false;
+    if (filterValue.endDate && filterValue.endDate < date) return false;
+    return true;
+  }
+  if (filterValue.type === 'dynamic') {
+    const dateInstant = Temporal.Instant.from(date);
+    const now = Temporal.Now.instant();
+    const durationFromNow = Temporal.Duration.from(filterValue.fromNow);
+
+    return (
+      Temporal.Duration.compare(now.until(dateInstant), durationFromNow) >= 0
+    );
+  }
+  return false;
+}
+
+export function arrIncludesExactSome<TData extends RowData>(
+  row: Row<TData>,
+  columnId: string,
+  filterValue: string[],
+) {
+  if (!filterValue) return true;
+  const value = row.getValue<string>(columnId);
+  return filterValue.some((filter) => filter === value);
+}


### PR DESCRIPTION
Huge PR to introduce :
- split between sent and received alerts
- implement filters on the alerts list
  - full text search on message
  - status filter
  - created_at filter (= date range)

NB: alert detail split will come in a future PR and proper alert status also (currently it's the old `read`, `unread`, `archived`)

![image](https://github.com/checkmarble/marble-frontend/assets/40292402/2177a3f2-aec4-4e6e-b509-23b3d01e593f)
