### PR TITLE
refactor(transfer-alert): improve validation

### DIFF
--- a/packages/app-builder/src/models/transfer-alert.ts
+++ b/packages/app-builder/src/models/transfer-alert.ts
@@ -5,6 +5,7 @@ import {
   type TransferAlertUpdateAsBeneficiaryBodyDto,
   type TransferAlertUpdateAsSenderBodyDto,
 } from 'marble-api/generated/transfercheck-api';
+import { z } from 'zod';
 
 export const transferAlerStatuses = [
   'pending',
@@ -70,9 +71,9 @@ export function adaptTransferAlertBeneficiary(
 export interface TransferAlertCreateBody {
   transferId: string;
   message: string;
-  transferEndToEndId: string;
-  beneficiaryIban: string;
-  senderIban: string;
+  transferEndToEndId?: string;
+  beneficiaryIban?: string;
+  senderIban?: string;
 }
 
 export function adaptTransferAlertCreateBodyDto(
@@ -81,9 +82,9 @@ export function adaptTransferAlertCreateBodyDto(
   return {
     transfer_id: createTransferAlert.transferId,
     message: createTransferAlert.message,
-    transfer_end_to_end_id: createTransferAlert.transferEndToEndId,
-    beneficiary_iban: createTransferAlert.beneficiaryIban,
-    sender_iban: createTransferAlert.senderIban,
+    transfer_end_to_end_id: createTransferAlert.transferEndToEndId ?? '',
+    beneficiary_iban: createTransferAlert.beneficiaryIban ?? '',
+    sender_iban: createTransferAlert.senderIban ?? '',
   };
 }
 
@@ -99,10 +100,10 @@ export function adaptTransferAlertUpdateAsSenderBodyDto(
   body: TransferAlertUpdateAsSenderBody,
 ): TransferAlertUpdateAsSenderBodyDto {
   return {
-    message: body.message,
-    transfer_end_to_end_id: body.transferEndToEndId,
-    beneficiary_iban: body.beneficiaryIban,
-    sender_iban: body.senderIban,
+    message: body.message ?? '',
+    transfer_end_to_end_id: body.transferEndToEndId ?? '',
+    beneficiary_iban: body.beneficiaryIban ?? '',
+    sender_iban: body.senderIban ?? '',
   };
 }
 
@@ -118,3 +119,19 @@ export function adaptUpdateTransferAlertAsBeneficiaryDto(
     status: body.status,
   };
 }
+
+export const messageSchema = z
+  .string({ required_error: 'required' })
+  .max(1000, { message: 'max 1000 characters' });
+
+export const transferEndToEndIdSchema = z
+  .string()
+  .max(100, { message: 'max 100 characters' });
+
+export const senderIbanSchema = z
+  .string()
+  .max(34, { message: 'max 34 characters' });
+
+export const beneficiaryIbanSchema = z
+  .string()
+  .max(34, { message: 'max 34 characters' });

--- a/packages/app-builder/src/routes/transfercheck+/ressources+/alert.create.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/ressources+/alert.create.tsx
@@ -4,10 +4,16 @@ import { FormInput } from '@app-builder/components/Form/FormInput';
 import { FormLabel } from '@app-builder/components/Form/FormLabel';
 import { FormTextArea } from '@app-builder/components/Form/FormTextArea';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
+import {
+  beneficiaryIbanSchema,
+  messageSchema,
+  senderIbanSchema,
+  transferEndToEndIdSchema,
+} from '@app-builder/models/transfer-alert';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { conform, useForm } from '@conform-to/react';
-import { getFieldsetConstraint, parse } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import * as React from 'react';
@@ -18,10 +24,10 @@ import { z } from 'zod';
 
 const createAlertFormSchema = z.object({
   transferId: z.string(),
-  message: z.string({ required_error: 'required' }),
-  transferEndToEndId: z.string(),
-  senderIban: z.string(),
-  beneficiaryIban: z.string(),
+  message: messageSchema,
+  transferEndToEndId: transferEndToEndIdSchema.optional(),
+  senderIban: senderIbanSchema.optional(),
+  beneficiaryIban: beneficiaryIbanSchema.optional(),
 });
 
 type CreateAlertForm = z.infer<typeof createAlertFormSchema>;
@@ -121,7 +127,6 @@ function CreateAlertContent({
     id: formId,
     defaultValue: { ...defaultValue, message: '' },
     lastSubmission: fetcher.data?.submission,
-    constraint: getFieldsetConstraint(createAlertFormSchema),
     onValidate({ formData }) {
       return parse(formData, {
         schema: createAlertFormSchema,
@@ -138,6 +143,17 @@ function CreateAlertContent({
       <ModalV2.Title>{t('transfercheck:alert.create.title')}</ModalV2.Title>
       <div className="flex flex-col gap-6 p-6">
         <input {...conform.input(fields.transferId, { type: 'hidden' })} />
+        <FormField
+          config={fields.message}
+          className="flex flex-col items-start gap-2"
+        >
+          <FormLabel>{t('transfercheck:alert.create.message')}</FormLabel>
+          <FormTextArea
+            className="w-full"
+            placeholder={t('transfercheck:alert.create.message.placeholder')}
+          />
+          <FormError />
+        </FormField>
         <FormField
           config={fields.transferEndToEndId}
           className="flex flex-col items-start gap-2"
@@ -176,17 +192,6 @@ function CreateAlertContent({
             placeholder={t(
               'transfercheck:alert.create.beneficiary_iban.placeholder',
             )}
-          />
-          <FormError />
-        </FormField>
-        <FormField
-          config={fields.message}
-          className="flex flex-col items-start gap-2"
-        >
-          <FormLabel>{t('transfercheck:alert.create.message')}</FormLabel>
-          <FormTextArea
-            className="w-full"
-            placeholder={t('transfercheck:alert.create.message.placeholder')}
           />
           <FormError />
         </FormField>

--- a/packages/app-builder/src/routes/transfercheck+/ressources+/alert.update.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/ressources+/alert.update.tsx
@@ -4,10 +4,16 @@ import { FormInput } from '@app-builder/components/Form/FormInput';
 import { FormLabel } from '@app-builder/components/Form/FormLabel';
 import { FormTextArea } from '@app-builder/components/Form/FormTextArea';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
+import {
+  beneficiaryIbanSchema,
+  messageSchema,
+  senderIbanSchema,
+  transferEndToEndIdSchema,
+} from '@app-builder/models/transfer-alert';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { conform, useForm } from '@conform-to/react';
-import { getFieldsetConstraint, parse } from '@conform-to/zod';
+import { parse } from '@conform-to/zod';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import * as React from 'react';
@@ -18,10 +24,10 @@ import { z } from 'zod';
 
 const updateAlertFormSchema = z.object({
   alertId: z.string(),
-  message: z.string({ required_error: 'required' }),
-  transferEndToEndId: z.string(),
-  senderIban: z.string(),
-  beneficiaryIban: z.string(),
+  message: messageSchema,
+  transferEndToEndId: transferEndToEndIdSchema.optional(),
+  senderIban: senderIbanSchema.optional(),
+  beneficiaryIban: beneficiaryIbanSchema.optional(),
 });
 
 type UpdateAlertForm = z.infer<typeof updateAlertFormSchema>;
@@ -121,7 +127,6 @@ function UpdateAlertContent({
     id: formId,
     defaultValue,
     lastSubmission: fetcher.data?.submission,
-    constraint: getFieldsetConstraint(updateAlertFormSchema),
     onValidate({ formData }) {
       return parse(formData, {
         schema: updateAlertFormSchema,
@@ -138,6 +143,17 @@ function UpdateAlertContent({
       <ModalV2.Title>{t('transfercheck:alert.update.title')}</ModalV2.Title>
       <div className="flex flex-col gap-6 p-6">
         <input {...conform.input(fields.alertId, { type: 'hidden' })} />
+        <FormField
+          config={fields.message}
+          className="flex flex-col items-start gap-2"
+        >
+          <FormLabel>{t('transfercheck:alert.update.message')}</FormLabel>
+          <FormTextArea
+            className="w-full"
+            placeholder={t('transfercheck:alert.update.message.placeholder')}
+          />
+          <FormError />
+        </FormField>
         <FormField
           config={fields.transferEndToEndId}
           className="flex flex-col items-start gap-2"
@@ -176,17 +192,6 @@ function UpdateAlertContent({
             placeholder={t(
               'transfercheck:alert.update.beneficiary_iban.placeholder',
             )}
-          />
-          <FormError />
-        </FormField>
-        <FormField
-          config={fields.message}
-          className="flex flex-col items-start gap-2"
-        >
-          <FormLabel>{t('transfercheck:alert.update.message')}</FormLabel>
-          <FormTextArea
-            className="w-full"
-            placeholder={t('transfercheck:alert.update.message.placeholder')}
           />
           <FormError />
         </FormField>


### PR DESCRIPTION
Small changes :
- better schema (only move optionnal + max length, based on what we discussed I didn't implemented a "smart" schema on IBAN or Transfer end2end id requirement)
- consistent ordering based on the same order used in the AlertData component
- small fixes on the adapters to allow the possibility to remove an optionnal field (with the current optionnal implem on the API, a missing field is equivalent to no PATCH changes, so we need to explicitly inform of removed fields)

NB: in fine, in a lot of places, I tends to inject "nullable values" for all missing fields to enforce the possibility to remove a field. Finally, I do more or less a PUT every time... not a big deal but if you have a better idea on how do deal with PATCH +  "delete some fileds" tell me your idea