### PR TITLE
feat(sign-in): add loading spinner on sign in

### DIFF
--- a/packages/app-builder/src/components/Auth/SignInWithEmailAndPassword.tsx
+++ b/packages/app-builder/src/components/Auth/SignInWithEmailAndPassword.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   FormControl,
   FormError,
@@ -17,17 +16,19 @@ import {
 import { type AuthPayload } from '@app-builder/services/auth/auth.server';
 import { clientServices } from '@app-builder/services/init.client';
 import { getRoute } from '@app-builder/utils/routes';
+import { sleep } from '@app-builder/utils/sleep';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from '@remix-run/react';
 import * as Sentry from '@sentry/remix';
+import type * as React from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { ClientOnly } from 'remix-utils/client-only';
 import { Button, Input } from 'ui-design-system';
 import * as z from 'zod';
+
 import { Spinner } from '../Spinner';
-import { sleep } from '@app-builder/utils/sleep';
 
 const emailAndPasswordFormSchema = z.object({
   credentials: z.object({

--- a/packages/app-builder/src/components/Auth/SignInWithGoogle.tsx
+++ b/packages/app-builder/src/components/Auth/SignInWithGoogle.tsx
@@ -6,29 +6,41 @@ import {
 } from '@app-builder/services/auth/auth.client';
 import { type AuthPayload } from '@app-builder/services/auth/auth.server';
 import { clientServices } from '@app-builder/services/init.client';
+import useAsync from '@app-builder/utils/hooks/use-async';
 import * as Sentry from '@sentry/remix';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { ClientOnly } from 'remix-utils/client-only';
 import { Logo } from 'ui-icons';
 
+import { Spinner } from '../Spinner';
 import { PopupBlockedError } from './PopupBlockedError';
 
-function SignInWithGoogleButton({ onClick }: { onClick?: () => void }) {
+function SignInWithGoogleButton({
+  onClick,
+  loading,
+}: {
+  onClick?: () => void;
+  loading?: boolean;
+}) {
   const { t } = useTranslation(['auth']);
 
   return (
     <button
-      className="flex h-10 w-full items-center rounded border-2 border-[#1a73e8] bg-[#1a73e8] transition hover:bg-[rgb(69,128,233)]"
+      className="relative flex h-10 w-full items-center rounded border-2 border-[#1a73e8] bg-[#1a73e8] transition hover:bg-[rgb(69,128,233)] disabled:cursor-wait"
       onClick={() => {
         void onClick?.();
       }}
+      disabled={loading}
     >
       <div className="bg-grey-00 flex h-full w-10 items-center justify-center rounded-l-[3px]">
         <Logo logo="google-logo" className="size-6" />
       </div>
-      <span className="text-s text-grey-00 w-full whitespace-nowrap text-center align-middle font-medium">
+      <span className="text-s text-grey-00 w-full whitespace-nowrap px-8 text-center align-middle font-medium">
         {t('auth:sign_in.google')}
+      </span>
+      <span className="absolute right-0 mx-2 size-4">
+        {loading ? <Spinner className="size-4" /> : null}
       </span>
     </button>
   );
@@ -36,21 +48,23 @@ function SignInWithGoogleButton({ onClick }: { onClick?: () => void }) {
 
 function ClientSignInWithGoogle({
   signIn,
+  loading,
 }: {
   signIn: (authPayload: AuthPayload) => void;
+  loading?: boolean;
 }) {
   const { t } = useTranslation(['common']);
   const googleSignIn = useGoogleSignIn(
     clientServices.authenticationClientService,
   );
 
-  const handleGoogleSignIn = async () => {
+  const [handleGoogleSignIn, _state] = useAsync(async () => {
     try {
       const result = await googleSignIn();
       if (!result) return;
       const { idToken, csrf } = result;
       if (!idToken) return;
-      signIn({ idToken, csrf });
+      signIn({ type: 'google', idToken, csrf });
     } catch (error) {
       if (error instanceof AccountExistsWithDifferentCredential) {
         toast.error(
@@ -65,25 +79,29 @@ function ClientSignInWithGoogle({
         toast.error(t('common:errors.unknown'));
       }
     }
-  };
+  });
 
   return (
     <SignInWithGoogleButton
-      onClick={() => {
-        void handleGoogleSignIn();
-      }}
+      onClick={void handleGoogleSignIn}
+      // We can't rely on state.loading if the user closes the popup without signing in
+      // Related Firebase issue: https://github.com/firebase/firebase-js-sdk/issues/8061
+      loading={loading}
+      // loading={loading || state.loading} when the issue is resolved
     />
   );
 }
 
 export function SignInWithGoogle({
   signIn,
+  loading,
 }: {
   signIn: (authPayload: AuthPayload) => void;
+  loading?: boolean;
 }) {
   return (
-    <ClientOnly fallback={<SignInWithGoogleButton />}>
-      {() => <ClientSignInWithGoogle signIn={signIn} />}
+    <ClientOnly fallback={<SignInWithGoogleButton loading={loading} />}>
+      {() => <ClientSignInWithGoogle signIn={signIn} loading={loading} />}
     </ClientOnly>
   );
 }

--- a/packages/app-builder/src/components/Auth/SignInWithMicrosoft.tsx
+++ b/packages/app-builder/src/components/Auth/SignInWithMicrosoft.tsx
@@ -6,29 +6,41 @@ import {
 } from '@app-builder/services/auth/auth.client';
 import { type AuthPayload } from '@app-builder/services/auth/auth.server';
 import { clientServices } from '@app-builder/services/init.client';
+import useAsync from '@app-builder/utils/hooks/use-async';
 import * as Sentry from '@sentry/remix';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { ClientOnly } from 'remix-utils/client-only';
 import { Logo } from 'ui-icons';
 
+import { Spinner } from '../Spinner';
 import { PopupBlockedError } from './PopupBlockedError';
 
-function SignInWithMicrosoftButton({ onClick }: { onClick?: () => void }) {
+function SignInWithMicrosoftButton({
+  onClick,
+  loading,
+}: {
+  onClick?: () => void;
+  loading?: boolean;
+}) {
   const { t } = useTranslation(['auth']);
 
   return (
     <button
-      className="bg-grey-00 hover:bg-grey-05 active:bg-grey-10 flex h-10 w-full items-center gap-3 border border-[#8C8C8C] p-px transition"
+      className="bg-grey-00 hover:bg-grey-05 active:bg-grey-10 relative flex h-10 w-full items-center gap-3 border border-[#8C8C8C] p-px transition disabled:cursor-wait"
       onClick={() => {
         void onClick?.();
       }}
+      disabled={loading}
     >
       <div className="flex h-full w-10 items-center justify-center">
         <Logo logo="microsoft-logo" className="size-6" />
       </div>
-      <span className="text-s w-full whitespace-nowrap text-center align-middle font-semibold text-[#5E5E5E]">
+      <span className="text-s w-full whitespace-nowrap px-8 text-center align-middle font-semibold text-[#5E5E5E]">
         {t('auth:sign_in.microsoft')}
+      </span>
+      <span className="absolute right-0 mx-2 size-4">
+        {loading ? <Spinner className="size-4" /> : null}
       </span>
     </button>
   );
@@ -36,21 +48,23 @@ function SignInWithMicrosoftButton({ onClick }: { onClick?: () => void }) {
 
 function ClientSignInWithMicrosoft({
   signIn,
+  loading,
 }: {
   signIn: (authPayload: AuthPayload) => void;
+  loading?: boolean;
 }) {
   const { t } = useTranslation(['common']);
   const microsoftSignIn = useMicrosoftSignIn(
     clientServices.authenticationClientService,
   );
 
-  const handleMicrosoftSignIn = async () => {
+  const [handleMicrosoftSignIn, _state] = useAsync(async () => {
     try {
       const result = await microsoftSignIn();
       if (!result) return;
       const { idToken, csrf } = result;
       if (!idToken) return;
-      signIn({ idToken, csrf });
+      signIn({ type: 'microsoft', idToken, csrf });
     } catch (error) {
       if (error instanceof AccountExistsWithDifferentCredential) {
         toast.error(
@@ -65,25 +79,29 @@ function ClientSignInWithMicrosoft({
         toast.error(t('common:errors.unknown'));
       }
     }
-  };
+  });
 
   return (
     <SignInWithMicrosoftButton
-      onClick={() => {
-        void handleMicrosoftSignIn();
-      }}
+      onClick={void handleMicrosoftSignIn}
+      // We can't rely on state.loading if the user closes the popup without signing in
+      // Related Firebase issue: https://github.com/firebase/firebase-js-sdk/issues/8061
+      loading={loading}
+      // loading={loading || state.loading} when the issue is resolved
     />
   );
 }
 
 export function SignInWithMicrosoft({
   signIn,
+  loading,
 }: {
   signIn: (authPayload: AuthPayload) => void;
+  loading?: boolean;
 }) {
   return (
-    <ClientOnly fallback={<SignInWithMicrosoftButton />}>
-      {() => <ClientSignInWithMicrosoft signIn={signIn} />}
+    <ClientOnly fallback={<SignInWithMicrosoftButton loading={loading} />}>
+      {() => <ClientSignInWithMicrosoft signIn={signIn} loading={loading} />}
     </ClientOnly>
   );
 }

--- a/packages/app-builder/src/routes/_auth+/sign-in.tsx
+++ b/packages/app-builder/src/routes/_auth+/sign-in.tsx
@@ -69,13 +69,24 @@ export default function Login() {
         getRoute('/sign-in') + (redirectTo ? `?redirectTo=${redirectTo}` : ''),
     });
 
+  const loading = fetcher.state === 'loading';
+  const type = fetcher.formData?.get('type');
+
   return (
     <div className="flex w-full flex-col items-center">
       {isSSOAvailable ? (
         <>
           <div className="flex w-full flex-col gap-2">
-            <SignInWithGoogle signIn={signIn} />
-            <SignInWithMicrosoft signIn={signIn} />
+            <SignInWithGoogle
+              signIn={signIn}
+              // eslint-disable-next-line react/jsx-no-leaked-render
+              loading={loading && type === 'google'}
+            />
+            <SignInWithMicrosoft
+              signIn={signIn}
+              // eslint-disable-next-line react/jsx-no-leaked-render
+              loading={loading && type === 'microsoft'}
+            />
           </div>
 
           <div
@@ -90,7 +101,11 @@ export default function Login() {
       ) : null}
 
       <div className="flex w-full flex-col items-center gap-2">
-        <SignInWithEmailAndPassword signIn={signIn} />
+        <SignInWithEmailAndPassword
+          signIn={signIn}
+          // eslint-disable-next-line react/jsx-no-leaked-render
+          loading={loading && type === 'email'}
+        />
         <p className="w-fit text-xs">
           <Trans
             t={t}

--- a/packages/app-builder/src/services/auth/auth.server.ts
+++ b/packages/app-builder/src/services/auth/auth.server.ts
@@ -94,6 +94,7 @@ export interface AuthenticationServerService {
 }
 
 const schema = z.object({
+  type: z.enum(['google', 'microsoft', 'email']),
   idToken: z.string(),
   csrf: z.string(),
 });

--- a/packages/app-builder/src/utils/hooks/use-async.ts
+++ b/packages/app-builder/src/utils/hooks/use-async.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+import { useCallbackRef } from './use-callback-ref';
+
+/**
+ * A custom hook that wraps an async function and provides loading, error and value states
+ *
+ * Inspired from https://github.com/sergeyleschev/react-custom-hooks?tab=readme-ov-file#2-useasync
+ */
+export default function useAsync<Args extends Array<unknown>, Return>(
+  callback: (...args: Args) => Promise<Return>,
+) {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<unknown>();
+  const [value, setValue] = React.useState<Return>();
+
+  const callbackRef = useCallbackRef(callback);
+
+  const callbackMemoized = React.useCallback(
+    async (...args: Args): Promise<void> => {
+      try {
+        setLoading(true);
+        setError(undefined);
+        setValue(await callbackRef(...args));
+      } catch (error) {
+        setError(error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [callbackRef],
+  );
+
+  return [callbackMemoized, { loading, error, value }] as const;
+}


### PR DESCRIPTION
Small UI improvment: I realized the sign in page give no loading feedback. This is not a pain on local because the sign in promise is fast but on deployed env it's long enough to be weird.

I must admit I really ask myself why the app wasn't responding.

NB: it was longer than expected, mostly due to FB (= an async log in on the client with FB and an async log in on the server for Marble data)