### PR TITLE
feat(webhooks): add documentation for webhooks

### DIFF
--- a/packages/app-builder/public/locales/en/settings.json
+++ b/packages/app-builder/public/locales/en/settings.json
@@ -97,5 +97,7 @@
   "webhooks.secret.created_at": "Created at",
   "webhooks.secret.deleted_at": "Deleted at",
   "webhooks.secret.expires_at": "Expires at",
-  "webhooks.secret.value": "Value"
+  "webhooks.secret.value": "Value",
+  "webhooks.setup_documentation": "For more information on webhooks, please refer to <DocLink>the documentation</DocLink>.",
+  "webhooks.events_documentation": "For more information on events, please refer to <DocLink>the documentation</DocLink>."
 }

--- a/packages/app-builder/src/components/Form/FormField.tsx
+++ b/packages/app-builder/src/components/Form/FormField.tsx
@@ -4,21 +4,23 @@ import * as React from 'react';
 
 interface FieldNameContextValue {
   name: string;
-  description?: string;
+  description?: React.ReactNode;
 }
 
 const FieldNameContext =
   createSimpleContext<FieldNameContextValue>('FieldName');
 export const useFieldName = FieldNameContext.useValue;
 
+interface FormFieldProps<Schema> extends React.ComponentPropsWithoutRef<'div'> {
+  name: FieldName<Schema>;
+  description?: React.ReactNode;
+}
+
 export function FormField<Schema>({
   name,
   description,
   ...props
-}: {
-  name: FieldName<Schema>;
-  description?: string;
-} & React.ComponentPropsWithoutRef<'div'>) {
+}: FormFieldProps<Schema>) {
   const value = React.useMemo(
     () => ({
       name,

--- a/packages/app-builder/src/components/HelpCenter.tsx
+++ b/packages/app-builder/src/components/HelpCenter.tsx
@@ -2,6 +2,8 @@ import {
   executeAScenarioDocHref,
   pivotValuesDocHref,
   scenarioDecisionDocHref,
+  webhooksEventsDocHref,
+  webhooksSetupDocHref,
 } from '@app-builder/services/documentation-href';
 import { formatNumber, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
@@ -139,6 +141,9 @@ function HelpCenterContent({
               return (
                 <Ariakit.Tab
                   key={category}
+                  ref={(element) => {
+                    if (category === defaultTab) element?.scrollIntoView();
+                  }}
                   id={category}
                   className="aria-selected:bg-purple-10 aria-selected:border-purple-10 text-grey-100 bg-grey-05 border-grey-05 flex h-6 scroll-mx-2 flex-row items-center justify-center gap-1 whitespace-pre rounded-full border px-2 text-xs font-medium capitalize aria-selected:text-purple-100 data-[active-item]:border-purple-100"
                   accessibleWhenDisabled={false}
@@ -238,6 +243,8 @@ export function useMarbleCoreResources() {
       return t('navigation:workflows');
     if (location.pathname.startsWith(getRoute('/data')))
       return t('navigation:data');
+    if (location.pathname.startsWith(getRoute('/settings')))
+      return t('navigation:settings');
 
     return t('navigation:scenarios');
   }, [location.pathname, t]);
@@ -360,6 +367,22 @@ export function useMarbleCoreResources() {
           label: 'Ingesting Data',
           tags: ['Manual', 'CSV'],
           href: 'https://docs.checkmarble.com/docs/ingesting-data',
+        },
+      ],
+      [t('navigation:settings')]: [
+        {
+          label: 'Create a webhook',
+          href: webhooksSetupDocHref,
+        },
+        {
+          label: 'Receive a webhook',
+          tags: ['Payload', 'Validate'],
+          href: 'https://docs.checkmarble.com/docs/receiving-webhooks',
+        },
+        {
+          label: 'Available events',
+          tags: ['Format', 'Payload'],
+          href: webhooksEventsDocHref,
         },
       ],
     }),

--- a/packages/app-builder/src/routes/_builder+/settings+/webhooks.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/webhooks.tsx
@@ -1,7 +1,9 @@
-import { CollapsiblePaper, Page } from '@app-builder/components';
+import { Callout, CollapsiblePaper, Page } from '@app-builder/components';
+import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { EventTypes } from '@app-builder/components/Webhooks/EventTypes';
 import { type Webhook } from '@app-builder/models/webhook';
 import { CreateWebhook } from '@app-builder/routes/ressources+/settings+/webhooks+/create';
+import { webhooksSetupDocHref } from '@app-builder/services/documentation-href';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -10,7 +12,7 @@ import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Button, Table, useTable } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
@@ -117,6 +119,18 @@ export default function Webhooks() {
             ) : null}
           </CollapsiblePaper.Title>
           <CollapsiblePaper.Content>
+            <Callout className="mb-4 lg:mb-6" variant="outlined">
+              <p className="whitespace-pre text-wrap">
+                <Trans
+                  t={t}
+                  i18nKey="settings:webhooks.setup_documentation"
+                  components={{
+                    DocLink: <ExternalLink href={webhooksSetupDocHref} />,
+                  }}
+                />
+              </p>
+            </Callout>
+
             <Table.Container {...getContainerProps()} className="max-h-96">
               <Table.Header headerGroups={table.getHeaderGroups()} />
               <Table.Body {...getBodyProps()}>

--- a/packages/app-builder/src/routes/ressources+/settings+/webhooks+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/webhooks+/create.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { FormErrorOrDescription } from '@app-builder/components/Form/FormErrorOrDescription';
 import { FormField } from '@app-builder/components/Form/FormField';
 import { FormInput } from '@app-builder/components/Form/FormInput';
@@ -7,6 +8,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { LoadingIcon } from '@app-builder/components/Spinner';
 import { FormSelectEvents } from '@app-builder/components/Webhooks/EventTypes';
 import { eventTypes } from '@app-builder/models/webhook';
+import { webhooksEventsDocHref } from '@app-builder/services/documentation-href';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { FormProvider, getFormProps, useForm } from '@conform-to/react';
@@ -14,7 +16,7 @@ import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Button, ModalV2 } from 'ui-design-system';
 import { z } from 'zod';
 
@@ -124,6 +126,17 @@ function CreateWebhookContent() {
           <FormField
             name={fields.eventTypes.name}
             className="flex flex-col items-start gap-2"
+            description={
+              <span className="whitespace-pre text-wrap">
+                <Trans
+                  t={t}
+                  i18nKey="settings:webhooks.events_documentation"
+                  components={{
+                    DocLink: <ExternalLink href={webhooksEventsDocHref} />,
+                  }}
+                />
+              </span>
+            }
           >
             <FormLabel>{t('settings:webhooks.event_types')}</FormLabel>
             <FormSelectWithCombobox.Control

--- a/packages/app-builder/src/routes/ressources+/settings+/webhooks+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/webhooks+/update.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { FormErrorOrDescription } from '@app-builder/components/Form/FormErrorOrDescription';
 import { FormField } from '@app-builder/components/Form/FormField';
 import { FormInput } from '@app-builder/components/Form/FormInput';
@@ -7,6 +8,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { LoadingIcon } from '@app-builder/components/Spinner';
 import { FormSelectEvents } from '@app-builder/components/Webhooks/EventTypes';
 import { eventTypes } from '@app-builder/models/webhook';
+import { webhooksEventsDocHref } from '@app-builder/services/documentation-href';
 import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { FormProvider, getFormProps, useForm } from '@conform-to/react';
@@ -14,7 +16,7 @@ import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Button, ModalV2 } from 'ui-design-system';
 import { z } from 'zod';
 
@@ -130,6 +132,17 @@ function UpdateWebhookContent({
           <FormField
             name={fields.eventTypes.name}
             className="flex flex-col items-start gap-2"
+            description={
+              <span className="whitespace-pre text-wrap">
+                <Trans
+                  t={t}
+                  i18nKey="settings:webhooks.events_documentation"
+                  components={{
+                    DocLink: <ExternalLink href={webhooksEventsDocHref} />,
+                  }}
+                />
+              </span>
+            }
           >
             <FormLabel>{t('settings:webhooks.event_types')}</FormLabel>
             <FormSelectWithCombobox.Control

--- a/packages/app-builder/src/services/chatlio/ChatlioWidget.tsx
+++ b/packages/app-builder/src/services/chatlio/ChatlioWidget.tsx
@@ -57,7 +57,7 @@ export function ChatlioProvider({ chatlio, children }: ChatlioProviderProps) {
 export const ChatlioButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
   function ChatlioWidget(props, ref) {
     const { t } = useTranslation(['common']);
-    const chatlio = ChatlioContext.useValue();
+    const chatlio = ChatlioContext.useOptionalValue();
 
     if (!chatlio) return null;
 

--- a/packages/app-builder/src/services/documentation-href.ts
+++ b/packages/app-builder/src/services/documentation-href.ts
@@ -25,3 +25,9 @@ export const workflowsDocHref =
 
 export const scenarioDecisionDocHref =
   'https://docs.checkmarble.com/docs/decision-1';
+
+export const webhooksSetupDocHref =
+  'https://docs.checkmarble.com/docs/setting-up-the-webhooks';
+
+export const webhooksEventsDocHref =
+  'https://docs.checkmarble.com/docs/available-events-and-webhooks-format';


### PR DESCRIPTION
In short :

![image](https://github.com/user-attachments/assets/478634c2-84b7-4271-907f-ef16421a67ca)
![image](https://github.com/user-attachments/assets/2c257747-7790-4177-a024-3fdf588fc877)
![image](https://github.com/user-attachments/assets/d42af537-9599-4256-ab33-48bf8af454e0)


Bonnus: 
- allow to open `HelpCenter` w\ Chalio config (usefull for on premise/open source users that do not configure it)
- allow to inject "component" (= formatted string with link mostly) in decsription form field