### PR TITLE
fix: regression in mapping to case update DTO

### DIFF
--- a/packages/app-builder/src/repositories/CaseRepository.ts
+++ b/packages/app-builder/src/repositories/CaseRepository.ts
@@ -3,6 +3,7 @@ import {
   adaptCase,
   adaptCaseCreateBody,
   adaptCaseDetail,
+  adaptUpdateCaseBodyDto,
   type Case,
   type CaseDetail,
   type CaseStatus,
@@ -96,7 +97,10 @@ export function makeGetCaseRepository() {
       return adaptCaseDetail(result);
     },
     updateCase: async ({ caseId, body }) => {
-      const result = await marbleCoreApiClient.updateCase(caseId, body);
+      const result = await marbleCoreApiClient.updateCase(
+        caseId,
+        adaptUpdateCaseBodyDto(body),
+      );
       return adaptCaseDetail(result.case);
     },
     addComment: async ({ caseId, body }) => {


### PR DESCRIPTION
I suppose it was not caught by typescript because all the attributes to the update body are optional, and typescript is not designed to prevent additional properties from being passed in an object ?
Before merging (we'll do a hotfix release later today), could you please have a look if there may be other such cases introduced by your PR earlier this week on models & dtos @balzdur ?