### PR TITLE
chore: update dev license to disable webhooks in dev environment

### DIFF
--- a/packages/app-builder/src/repositories/LicenseRepository.ts
+++ b/packages/app-builder/src/repositories/LicenseRepository.ts
@@ -23,7 +23,8 @@ export function getLicenseRepository(
             analytics: true,
             dataEnrichment: true,
             userRoles: true,
-            webhooks: true,
+            // In dev environment (like docker-compose), webhooks are disabled since we do not have Convoy dedicated for dev
+            webhooks: false,
           },
         });
       }


### PR DESCRIPTION
Should fix the issue described in [this Slack thread](https://checkmarble.slack.com/archives/C063SMVJ4BY/p1724062869469469)

Note: I realised we do not have consistency in the license used in dev between `api` and `app`, I propose a solution in [this backend PR](https://github.com/checkmarble/marble-backend/pull/650) but we can merge the frontend PR without the backend and it should fix the above issue
