### PR TITLE
correct display of upload log status

### DIFF
--- a/packages/app-builder/public/locales/en/upload.json
+++ b/packages/app-builder/public/locales/en/upload.json
@@ -13,6 +13,7 @@
   "past_uploads": "Past uploads",
   "upload_status": "Status",
   "lines_processed": "Records received",
+  "num_rows_ingested": "Number of records ingested",
   "started_at": "Started at",
   "finished_at": "Completed at",
   "status_success": "Complete",

--- a/packages/app-builder/public/locales/en/upload.json
+++ b/packages/app-builder/public/locales/en/upload.json
@@ -12,9 +12,11 @@
   "results": "Results",
   "past_uploads": "Past uploads",
   "upload_status": "Status",
-  "lines_processed": "Records processed",
+  "lines_processed": "Records received",
   "started_at": "Started at",
   "finished_at": "Completed at",
   "status_success": "Complete",
-  "status_pending": "Processing"
+  "status_pending": "Pending",
+  "status_processing": "Processing",
+  "status_failure": "Failed"
 }

--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -349,12 +349,22 @@ const getStatusIcon = (status: string) => {
   if (status === 'success') {
     return <Icon icon="tick" className="size-6 text-green-100" />;
   }
+  if (status === 'failure') {
+    return <Icon icon="cross" className="size-6 text-red-100" />;
+  }
   return <Icon icon="restart-alt" className="text-grey-50 size-6" />;
 };
 
 const getStatusTKey = (status: string): ParseKeys<['upload']> => {
+  console.log(status);
   if (status === 'success') {
     return 'upload:status_success';
+  }
+  if (status === 'failure') {
+    return 'upload:status_failure';
+  }
+  if (status === 'processing') {
+    return 'upload:status_processing';
   }
   return 'upload:status_pending';
 };

--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -371,7 +371,6 @@ const getStatusIcon = (status: string) => {
 };
 
 const getStatusTKey = (status: string): ParseKeys<['upload']> => {
-  console.log(status);
   if (status === 'success') {
     return 'upload:status_success';
   }

--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -5,7 +5,11 @@ import { useBackendInfo } from '@app-builder/services/auth/auth.client';
 import { ingestingDataByCsvDocHref } from '@app-builder/services/documentation-href';
 import { clientServices } from '@app-builder/services/init.client';
 import { serverServices } from '@app-builder/services/init.server';
-import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
+import {
+  formatDateTime,
+  formatNumber,
+  useFormatLanguage,
+} from '@app-builder/utils/format';
 import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -304,7 +308,18 @@ const PastUploads = ({ uploadLogs }: { uploadLogs: UploadLog[] }) => {
       }),
       columnHelper.accessor((row) => row.lines_processed, {
         id: 'upload.lines_processed',
+        cell: ({ getValue }) => (
+          <span>{formatNumber(getValue(), { language })}</span>
+        ),
         header: t('upload:lines_processed'),
+        size: 200,
+      }),
+      columnHelper.accessor((row) => row.num_rows_ingested, {
+        id: 'upload.num_rows_ingested',
+        cell: ({ getValue }) => (
+          <span>{formatNumber(getValue(), { language })}</span>
+        ),
+        header: t('upload:num_rows_ingested'),
         size: 200,
       }),
       columnHelper.accessor((row) => row.status, {

--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -4654,6 +4654,7 @@ components:
           format: date-time
         status:
           type: string
+          enum: ['success', 'failure', 'progressing', 'pending']
         lines_processed:
           type: integer
         num_rows_ingested:

--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -4644,6 +4644,7 @@ components:
         - finished_at
         - status
         - lines_processed
+        - num_rows_ingested
       properties:
         started_at:
           type: string
@@ -4654,6 +4655,8 @@ components:
         status:
           type: string
         lines_processed:
+          type: integer
+        num_rows_ingested:
           type: integer
     Pagination:
       type: object

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -252,6 +252,7 @@ export type UploadLog = {
     finished_at: string;
     status: string;
     lines_processed: number;
+    num_rows_ingested: number;
 };
 export type CustomList = {
     id: string;

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -250,7 +250,7 @@ export type ScheduledExecution = {
 export type UploadLog = {
     started_at: string;
     finished_at: string;
-    status: string;
+    status: "success" | "failure" | "progressing" | "pending";
     lines_processed: number;
     num_rows_ingested: number;
 };


### PR DESCRIPTION
Goes with https://github.com/checkmarble/marble-backend/pull/659

---
# After
<img width="1752" alt="Capture d’écran 2024-08-29 à 17 14 30" src="https://github.com/user-attachments/assets/ff186de4-4c64-47f6-bb6c-dd6762b80340">

# Before
<img width="1756" alt="Capture d’écran 2024-08-29 à 17 15 08" src="https://github.com/user-attachments/assets/282afa68-763f-439f-8959-d3c00bf5c574">
