### PR TITLE
DisplayReturnValuesSwitch only when rule has been evaluated

### DIFF
--- a/packages/app-builder/src/components/Decisions/RulesDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/RulesDetail.tsx
@@ -162,7 +162,7 @@ export function RuleExecutionDetail({
             }}
           />
         </div>
-        <DisplayReturnValuesSwitch />
+        {ruleExecution.evaluation ? <DisplayReturnValuesSwitch /> : null}
       </div>
 
       <RuleFormula


### PR DESCRIPTION
Do not display the switch when no evaluation data is prevent (toggle a switch with no visual change feels buggy)

## Before:
<img width="796" alt="image" src="https://github.com/user-attachments/assets/8cdc849f-967d-453a-b144-152db0417a71">
☝🏽 nothing happen when we toggle the switch

## After:
<img width="947" alt="image" src="https://github.com/user-attachments/assets/7edaf9ba-0f9e-4dae-83d1-fe636398a224">
