### PR TITLE
refactor(env): better handling of firebase config

### DIFF
--- a/packages/app-builder/src/entry.client.tsx
+++ b/packages/app-builder/src/entry.client.tsx
@@ -36,8 +36,7 @@ Sentry.init({
   // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
   tracePropagationTargets: [
     getClientEnv('MARBLE_APP_DOMAIN'),
-    getClientEnv('MARBLE_API_DOMAIN_CLIENT'),
-    getClientEnv('MARBLE_API_DOMAIN_SERVER'),
+    getClientEnv('MARBLE_API_DOMAIN'),
   ],
 
   // Capture Replay for 10% of all sessions,

--- a/packages/app-builder/src/infra/firebase.ts
+++ b/packages/app-builder/src/infra/firebase.ts
@@ -31,20 +31,26 @@ export type FirebaseClientWrapper = {
   logout: typeof signOut;
 };
 
-export function initializeFirebaseClient({
-  firebaseOptions,
-  authEmulatorHost,
-}: {
-  firebaseOptions: FirebaseOptions;
-  authEmulatorHost?: string;
-}): FirebaseClientWrapper {
-  const app = initializeApp(firebaseOptions);
+export type FirebaseConfig =
+  | {
+      withEmulator: false;
+      options: FirebaseOptions;
+    }
+  | {
+      withEmulator: true;
+      authEmulatorUrl: string;
+      options: FirebaseOptions;
+    };
+
+export function initializeFirebaseClient(
+  config: FirebaseConfig,
+): FirebaseClientWrapper {
+  const app = initializeApp(config.options);
 
   const clientAuth = getAuth(app);
 
-  if (authEmulatorHost && !('emulator' in clientAuth.config)) {
-    const url = new URL('http://' + authEmulatorHost);
-    connectAuthEmulator(clientAuth, url.toString());
+  if (config.withEmulator) {
+    connectAuthEmulator(clientAuth, config.authEmulatorUrl);
   }
 
   const googleAuthProvider = new GoogleAuthProvider();
@@ -55,7 +61,7 @@ export function initializeFirebaseClient({
   return {
     app,
     clientAuth,
-    isFirebaseEmulator: 'emulator' in clientAuth.config,
+    isFirebaseEmulator: config.withEmulator,
     googleAuthProvider,
     microsoftAuthProvider,
     signInWithOAuth: signInWithPopup,

--- a/packages/app-builder/src/services/auth/auth.client.ts
+++ b/packages/app-builder/src/services/auth/auth.client.ts
@@ -229,7 +229,7 @@ export function useSendPasswordResetEmail({
 export function useBackendInfo({
   authenticationClientRepository,
 }: AuthenticationClientService) {
-  const backendUrl = getClientEnv('MARBLE_API_DOMAIN_CLIENT');
+  const backendUrl = getClientEnv('MARBLE_API_DOMAIN');
 
   const getAccessToken = async () => {
     try {

--- a/packages/app-builder/src/services/init.client.ts
+++ b/packages/app-builder/src/services/init.client.ts
@@ -18,10 +18,9 @@ function makeClientServices(repositories: ClientRepositories) {
 }
 
 function initClientServices() {
-  const firebaseClient = initializeFirebaseClient({
-    firebaseOptions: getClientEnv('FIREBASE_OPTIONS'),
-    authEmulatorHost: getClientEnv('FIREBASE_AUTH_EMULATOR_HOST'),
-  });
+  const firebaseClient = initializeFirebaseClient(
+    getClientEnv('FIREBASE_CONFIG'),
+  );
   const clientRepositories = makeClientRepositories({ firebaseClient });
   return makeClientServices(clientRepositories);
 }

--- a/packages/app-builder/src/services/init.server.ts
+++ b/packages/app-builder/src/services/init.server.ts
@@ -5,7 +5,7 @@ import {
   makeServerRepositories,
   type ServerRepositories,
 } from '@app-builder/repositories/init.server';
-import { checkServerEnv, getServerEnv } from '@app-builder/utils/environment';
+import { checkEnv, getServerEnv } from '@app-builder/utils/environment';
 import { CSRF } from 'remix-utils/csrf/server';
 
 import { makeAuthenticationServerService } from './auth/auth.server';
@@ -50,10 +50,9 @@ function makeServerServices(repositories: ServerRepositories) {
 }
 
 function initServerServices() {
-  checkServerEnv();
+  checkEnv();
 
-  const devEnvironment =
-    getServerEnv('FIREBASE_AUTH_EMULATOR_HOST') !== undefined;
+  const devEnvironment = getServerEnv('FIREBASE_CONFIG').withEmulator;
 
   const { getMarbleCoreAPIClientWithAuth } = initializeMarbleCoreAPIClient({
     baseUrl: getServerEnv('MARBLE_API_DOMAIN_SERVER'),


### PR DESCRIPTION
Refactor of the `environment` file in order to abstract away the "parsing" of some dependant environment variables (= here the Firebase config).

It should not introduce any breaking change since the expected env vars from the infra are still the same.