### PR TITLE
chore(docker): try to use a distroless image

### DIFF
--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,22 +1,19 @@
-FROM node:20-slim AS base
+FROM node:22-slim AS build
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-FROM base AS build
-RUN apt-get update
-RUN apt-get -y install ca-certificates
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter=app-builder run build
 RUN pnpm deploy --filter=app-builder --prod /prod/app-builder
 
-FROM base AS app-builder
-ENV NODE_ENV=production
+FROM gcr.io/distroless/nodejs22-debian12 AS app-builder
 ENV PORT=${PORT:-8080}
-RUN apt-get update && apt-get install -y curl
-COPY --from=build /prod/app-builder /prod/app-builder
+COPY --from=build /prod/app-builder/node_modules /prod/app-builder/node_modules
+COPY --from=build /prod/app-builder/build /prod/app-builder/build
 WORKDIR /prod/app-builder
+USER nonroot
 EXPOSE $PORT
-CMD [ "pnpm", "start"]
+CMD ["./node_modules/@remix-run/serve/dist/cli.js", "./build/server/index.js"]


### PR DESCRIPTION
I tried to iterate locally, it seems to be working (at least, the server start and return an error since there is no backend etc...)

Let's see how it behaves on CI + staging