### PR TITLE
feat(AstBuilder): handle long text in OperandEditor

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/EditDataModelField.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AggregationEdit/EditDataModelField.tsx
@@ -93,7 +93,7 @@ const selectDisplayText = cva(undefined, {
       value: 'text-grey-100',
     },
     size: {
-      long: 'hyphens-auto [overflow-wrap:anywhere]',
+      long: 'break-all',
       short: 'shrink-0',
     },
   },

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
@@ -70,7 +70,7 @@ export function OperandEditor({
           />
         }
       />
-      <MenuPopover className="w-80 flex-col">
+      <MenuPopover className="w-96 flex-col">
         <OperandEditorContent
           onSave={onSave}
           operandViewModel={operandViewModel}
@@ -163,24 +163,22 @@ function OperandEditorContent({
         }
       />
       <MenuContent>
-        <ScrollAreaV2 type="auto">
-          <div className="flex flex-col gap-2 p-2">
-            {searchValue === '' ? (
-              <OperandEditorDiscoveryResults
-                options={options}
-                searchValue={searchValue}
-                onClick={onClick}
-              />
-            ) : (
-              <OperandEditorSearchResults
-                searchValue={searchValue}
-                constantOptions={constantOptions}
-                matchOptions={matchOptions}
-                onClick={onClick}
-              />
-            )}
-          </div>
-        </ScrollAreaV2>
+        <div className="scrollbar-gutter-stable flex flex-col gap-2 overflow-y-auto p-2 pr-[calc(0.5rem-var(--scrollbar-width))]">
+          {searchValue === '' ? (
+            <OperandEditorDiscoveryResults
+              options={options}
+              searchValue={searchValue}
+              onClick={onClick}
+            />
+          ) : (
+            <OperandEditorSearchResults
+              searchValue={searchValue}
+              constantOptions={constantOptions}
+              matchOptions={matchOptions}
+              onClick={onClick}
+            />
+          )}
+        </div>
         {bottomOptions.length > 0 ? (
           <BottomOptions options={bottomOptions} />
         ) : null}

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditorDiscoveryResults.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditorDiscoveryResults.tsx
@@ -18,7 +18,6 @@ import {
   MenuGroupLabel,
   MenuPopover,
   MenuRoot,
-  ScrollAreaV2,
 } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
@@ -98,20 +97,18 @@ function Submenu({
           className="size-5 shrink-0"
         />
       </MenuButton>
-      <MenuPopover className="max-h-64 w-64 flex-col" gutter={16}>
+      <MenuPopover className="max-h-64 w-96 flex-col" gutter={16}>
         <MenuContent>
-          <ScrollAreaV2 type="auto">
-            <div className="flex flex-col gap-2 p-2">
-              {options.map((option) => (
-                <OperandOption
-                  key={option.displayName}
-                  editableAstNode={option}
-                  searchValue={searchValue}
-                  onClick={() => onClick(option)}
-                />
-              ))}
-            </div>
-          </ScrollAreaV2>
+          <div className="scrollbar-gutter-stable flex flex-col gap-2 overflow-y-auto p-2 pr-[calc(0.5rem-var(--scrollbar-width))]">
+            {options.map((option) => (
+              <OperandOption
+                key={option.displayName}
+                editableAstNode={option}
+                searchValue={searchValue}
+                onClick={() => onClick(option)}
+              />
+            ))}
+          </div>
         </MenuContent>
       </MenuPopover>
     </MenuRoot>
@@ -166,7 +163,7 @@ const FieldGroupGetter: GroupGetter = ({
         operandType={operandType}
         count={count}
         className="min-h-10 p-2"
-        renderLabel={<MenuGroupLabel />}
+        renderLabel={<MenuGroupLabel render={<span />} />}
       />
       {fieldByPathOptions.map(([path, subOptions]) => (
         <Submenu
@@ -200,7 +197,7 @@ function OperandDiscoveryTitle({
   return (
     <div
       className={clsx(
-        'flex select-none flex-row items-center gap-1 truncate',
+        'flex select-none flex-row items-center gap-1',
         className,
       )}
     >
@@ -212,16 +209,13 @@ function OperandDiscoveryTitle({
         />
       ) : null}
       {tKey ? (
-        <span className="flex w-full items-baseline gap-1 truncate">
-          <Ariakit.Role.span
-            className="text-grey-100 text-m flex items-baseline truncate whitespace-pre font-semibold"
-            render={renderLabel}
-          >
+        <span className="text-grey-100 text-m flex-1 items-baseline break-all">
+          <Ariakit.Role.span className="font-semibold" render={renderLabel}>
             {t(tKey, {
               count: count,
             })}
           </Ariakit.Role.span>
-          <span className="text-grey-25 text-xs font-medium">{count}</span>
+          <span className="text-grey-25 text-xs font-medium">{` ${count}`}</span>
         </span>
       ) : null}
     </div>
@@ -232,21 +226,19 @@ function FieldByPathLabel({ path, count }: { path: string; count: number }) {
   const { t } = useTranslation('scenarios');
 
   return (
-    <div className="flex select-none flex-row items-baseline gap-1 truncate pl-9">
-      <span className="text-grey-100 text-s flex items-baseline truncate whitespace-pre">
-        <Trans
-          t={t}
-          i18nKey="edit_operand.operator_discovery.from"
-          components={{
-            Path: <span className="truncate font-semibold" />,
-          }}
-          values={{
-            path,
-          }}
-        />
-      </span>
-      <span className="text-grey-25 text-xs font-medium">{count}</span>
-    </div>
+    <span className="text-grey-100 text-s select-none items-baseline break-all pl-9">
+      <Trans
+        t={t}
+        i18nKey="edit_operand.operator_discovery.from"
+        components={{
+          Path: <span className="font-semibold" />,
+        }}
+        values={{
+          path,
+        }}
+      />
+      <span className="text-grey-25 text-xs font-medium">{` ${count}`}</span>
+    </span>
   );
 }
 

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandMenuItem.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandMenuItem.tsx
@@ -48,7 +48,7 @@ function MenuItemLabel({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       className={clsx(
-        'text-grey-100 text-s w-full overflow-hidden text-ellipsis text-start font-normal',
+        'text-grey-100 text-s w-full break-all text-start font-normal',
         className,
       )}
       {...props}
@@ -107,7 +107,7 @@ export function OperandOption({
       <OperandInfos
         gutter={24}
         shift={-8}
-        className="size-5 shrink-0 text-transparent transition-colors group-data-[active-item]:text-purple-50 group-data-[active-item]:hover:text-purple-100"
+        className="size-5 shrink-0 text-transparent group-data-[active-item]:text-purple-50 group-data-[active-item]:hover:text-purple-100"
         editableAstNode={editableAstNode}
       />
     </MenuItemContainer>

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandInfos.tsx
@@ -24,7 +24,6 @@ import * as Ariakit from '@ariakit/react';
 import { Fragment } from 'react/jsx-runtime';
 import { useTranslation } from 'react-i18next';
 import { assertNever } from 'typescript-utils';
-import { ScrollAreaV2 } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 import { LogicalOperatorLabel } from '../../RootAstBuilderNode/LogicalOperator';
@@ -60,22 +59,20 @@ export function OperandInfos({
         gutter={gutter}
         shift={shift}
         portal
-        className="bg-grey-00 border-grey-10 flex max-h-[400px] overflow-y-auto overflow-x-hidden rounded border shadow-md"
+        className="bg-grey-00 border-grey-10 flex max-h-[min(var(--popover-available-height),_400px)] max-w-[var(--popover-available-width)] rounded border shadow-md"
       >
-        <ScrollAreaV2>
-          <div className="flex flex-col gap-2 p-4">
-            <div className="flex flex-col gap-1">
-              <TypeInfos
-                operandType={editableAstNode.operandType}
-                dataType={editableAstNode.dataType}
-              />
-              <p className="text-grey-100 text-s text-ellipsis hyphens-auto font-normal">
-                {editableAstNode.displayName}
-              </p>
-            </div>
-            <OperandDescription editableAstNode={editableAstNode} />
+        <div className="scrollbar-gutter-stable flex flex-col gap-2 overflow-auto p-4 pr-[calc(1rem-var(--scrollbar-width))]">
+          <div className="flex flex-col gap-1">
+            <TypeInfos
+              operandType={editableAstNode.operandType}
+              dataType={editableAstNode.dataType}
+            />
+            <p className="text-grey-100 text-s text-ellipsis hyphens-auto font-normal">
+              {editableAstNode.displayName}
+            </p>
           </div>
-        </ScrollAreaV2>
+          <OperandDescription editableAstNode={editableAstNode} />
+        </div>
       </Ariakit.Hovercard>
     </Ariakit.HovercardProvider>
   );

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandLabel.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandLabel.tsx
@@ -241,7 +241,7 @@ const selectDisplayText = cva(
         value: 'text-grey-100',
       },
       size: {
-        long: 'hyphens-auto [overflow-wrap:anywhere]',
+        long: 'break-all',
         short: '',
       },
     },

--- a/packages/ui-design-system/src/Menu/Menu.tsx
+++ b/packages/ui-design-system/src/Menu/Menu.tsx
@@ -115,7 +115,7 @@ export const MenuPopover = React.forwardRef<HTMLDivElement, MenuProps>(
           gutter={8}
           {...props}
           className={clsx(
-            'bg-grey-00 border-grey-10 flex max-h-[min(var(--popover-available-height),_300px)] -translate-y-1 overflow-hidden rounded border opacity-0 shadow-md outline-none transition-all data-[enter]:translate-y-0 data-[enter]:opacity-100',
+            'bg-grey-00 border-grey-10 flex max-h-[min(var(--popover-available-height),_400px)] -translate-y-1 overflow-hidden rounded border opacity-0 shadow-md outline-none transition-all data-[enter]:translate-y-0 data-[enter]:opacity-100',
             props.className,
           )}
         />


### PR DESCRIPTION
In short :
- enlarge the combobox popups
- better handling of long operand labels

**Some screenshots**
![image](https://github.com/user-attachments/assets/adabf119-71e5-4d31-9acb-e2c76a9fb7f7)
![image](https://github.com/user-attachments/assets/c64a1de6-de40-4cc1-b7ba-4922523b93e5)
![image](https://github.com/user-attachments/assets/998acc55-30be-4d52-983f-fe01c62d81ba)
![image](https://github.com/user-attachments/assets/4e075034-c185-4128-bd6d-a69f01ca617f)

