### PR TITLE
feat(i18n): improve lng persistence

### DIFF
--- a/packages/app-builder/src/models/marble-session.ts
+++ b/packages/app-builder/src/models/marble-session.ts
@@ -5,7 +5,7 @@ import { type CreatedApiKey } from './api-keys';
 import { type AuthErrors } from './auth-errors';
 import { type CurrentUser } from './user';
 
-export type AuthData = { authToken: Token; lng: string; user: CurrentUser };
+export type AuthData = { authToken: Token; user: CurrentUser };
 export type AuthFlashData = {
   authError: { message: AuthErrors };
   createdApiKey: CreatedApiKey;

--- a/packages/app-builder/src/repositories/SessionStorageRepositories/LngStorageRepository.ts
+++ b/packages/app-builder/src/repositories/SessionStorageRepositories/LngStorageRepository.ts
@@ -1,0 +1,27 @@
+import { createCookie, createCookieSessionStorage } from '@remix-run/node';
+
+import { type SessionStorageRepositoryOptions } from './SessionStorageRepository';
+
+export function getLngStorageRepository({
+  secrets,
+  secure,
+}: Omit<SessionStorageRepositoryOptions, 'maxAge'>) {
+  const lngCookie = createCookie('lng', {
+    sameSite: 'lax', // this helps with CSRF
+    path: '/', // remember to add this so the cookie will work in all routes
+    httpOnly: true,
+    secrets,
+    secure,
+  });
+
+  // export the whole sessionStorage object
+  const lngStorage = createCookieSessionStorage<{
+    lng: string;
+  }>({
+    cookie: lngCookie,
+  });
+
+  return { lngStorage };
+}
+
+export type LngStorageRepository = ReturnType<typeof getLngStorageRepository>;

--- a/packages/app-builder/src/repositories/SessionStorageRepositories/index.ts
+++ b/packages/app-builder/src/repositories/SessionStorageRepositories/index.ts
@@ -1,4 +1,5 @@
 export * from './AuthStorageRepository';
 export * from './CsrfStorageRepository';
+export * from './LngStorageRepository';
 export * from './SessionStorageRepository';
 export * from './ToastStorageRepository';

--- a/packages/app-builder/src/repositories/init.server.ts
+++ b/packages/app-builder/src/repositories/init.server.ts
@@ -19,6 +19,7 @@ import { makeGetScenarioRepository } from './ScenarioRepository';
 import {
   getAuthStorageRepository,
   getCsrfCookie,
+  getLngStorageRepository,
   getToastStorageRepository,
   type SessionStorageRepositoryOptions,
 } from './SessionStorageRepositories';
@@ -46,6 +47,9 @@ export function makeServerRepositories({
     ),
     csrfCookie: getCsrfCookie(sessionStorageRepositoryOptions),
     toastStorageRepository: getToastStorageRepository(
+      sessionStorageRepositoryOptions,
+    ),
+    lngStorageRepository: getLngStorageRepository(
       sessionStorageRepositoryOptions,
     ),
     getMarbleCoreAPIClientWithAuth,

--- a/packages/app-builder/src/routes/ressources+/user+/language.tsx
+++ b/packages/app-builder/src/routes/ressources+/user+/language.tsx
@@ -16,28 +16,20 @@ const formSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { i18nextService, authSessionService, toastSessionService } =
-    serverServices;
+  const { i18nextService, toastSessionService } = serverServices;
 
   try {
     const { preferredLanguage } = await parseForm(request, formSchema);
-    const authSession = await authSessionService.getSession(request);
 
-    // const user = await authenticator.isAuthenticated(request);
-    // if (user)
-    //   await usersApi.putUsersUserId({
-    //     userId: user.id,
-    //     userPreferences: {
-    //       preferredLanguage,
-    //     },
-    //   });
-
-    i18nextService.setLanguage(authSession, preferredLanguage);
+    const { cookie } = await i18nextService.setLanguage(
+      request,
+      preferredLanguage,
+    );
 
     return redirectBack(request, {
       fallback: getRoute('/scenarios/'),
       headers: {
-        'Set-Cookie': await authSessionService.commitSession(authSession),
+        'Set-Cookie': cookie,
       },
     });
   } catch (error) {

--- a/packages/app-builder/src/services/init.server.ts
+++ b/packages/app-builder/src/services/init.server.ts
@@ -39,9 +39,7 @@ function makeServerServices(repositories: ServerRepositories) {
       authSessionService,
       csrfService,
     }),
-    i18nextService: makeI18nextServerService({
-      authStorage: repositories.authStorageRepository.authStorage,
-    }),
+    i18nextService: makeI18nextServerService(repositories.lngStorageRepository),
     licenseService,
     featureAccessService: makeFeatureAccessService({
       getLicenseEntitlements: licenseService.getLicenseEntitlements,


### PR DESCRIPTION
Small refacto to store the `lng` preference in a separate cookie.
Before that, the `lng` pref was stored on the user session. On each logout, the user session is destroyed and thus the `lng` pref is lost, defaulting to the inferred lng from the browser.