### PR TITLE
chore(deps): move remix-flat-routes to devDependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
       export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN && \
       pnpm --filter=app-builder run build
 ENV NODE_ENV=production
-RUN pnpm deploy --filter=app-builder --prod /prod/app-builder
+RUN pnpm --filter=app-builder --prod deploy /prod/app-builder
 
 FROM gcr.io/distroless/nodejs22-debian12 AS app-builder
 ENV NODE_ENV=production

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -7,7 +7,7 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter=app-builder run build
-RUN pnpm deploy --filter=app-builder --prod /prod/app-builder
+RUN pnpm --filter=app-builder --prod deploy /prod/app-builder
 
 FROM gcr.io/distroless/nodejs22-debian12 AS app-builder
 ENV PORT=${PORT:-8080}

--- a/packages/app-builder/package.json
+++ b/packages/app-builder/package.json
@@ -33,6 +33,7 @@
     "jsdom": "25.0.1",
     "ora": "^8.1.0",
     "postcss": "^8.4.47",
+    "remix-flat-routes": "^0.6.5",
     "tailwindcss": "3.4.13",
     "tsx": "^4.19.1",
     "vite": "^5.4.8"
@@ -97,7 +98,6 @@
     "reactflow": "^11.11.4",
     "remeda": "^2.14.0",
     "remix": "^2.12.1",
-    "remix-flat-routes": "^0.6.5",
     "remix-i18next": "^6.4.1",
     "remix-utils": "^7.7.0",
     "short-uuid": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,9 +215,6 @@ importers:
       remix:
         specifier: ^2.12.1
         version: 2.12.1
-      remix-flat-routes:
-        specifier: ^0.6.5
-        version: 0.6.5(@remix-run/dev@2.12.1(@remix-run/react@2.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.1(typescript@5.6.2))(@types/node@22.7.2)(babel-plugin-macros@3.1.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.2)))
       remix-i18next:
         specifier: ^6.4.1
         version: 6.4.1(@remix-run/node@2.12.1(typescript@5.6.2))(@remix-run/react@2.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(i18next@23.15.1)(react-i18next@15.0.2(i18next@23.15.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -300,6 +297,9 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
+      remix-flat-routes:
+        specifier: ^0.6.5
+        version: 0.6.5(@remix-run/dev@2.12.1(@remix-run/react@2.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2))(@remix-run/serve@2.12.1(typescript@5.6.2))(@types/node@22.7.2)(babel-plugin-macros@3.1.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.2)))
       tailwindcss:
         specifier: 3.4.13
         version: 3.4.13


### PR DESCRIPTION
I think I found the issue with the esbuild thing in Docker image