### PR TITLE
refactor(operand-editor): improve discovery results grouping

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/Operand/OperandEditor/OperandEditor.tsx
@@ -32,6 +32,7 @@ import { OperandEditorDiscoveryResults } from './OperandEditorDiscoveryResults';
 import {
   OperandEditorProvider,
   useBottomOptions,
+  useDiscoveryResults,
   useOperandEditorActions,
   useOperandEditorOpen,
   useSearchValue,
@@ -103,6 +104,7 @@ function OperandEditorContent() {
 
   const bottomOptions = useBottomOptions();
   const searchValue = useSearchValue();
+  const discoveryResults = useDiscoveryResults();
 
   return (
     <>
@@ -119,7 +121,9 @@ function OperandEditorContent() {
       <MenuContent>
         <div className="scrollbar-gutter-stable flex flex-col gap-2 overflow-y-auto p-2 pr-[calc(0.5rem-var(--scrollbar-width))]">
           {searchValue === '' ? (
-            <OperandEditorDiscoveryResults />
+            <OperandEditorDiscoveryResults
+              discoveryResults={discoveryResults}
+            />
           ) : (
             <OperandEditorSearchResults />
           )}


### PR DESCRIPTION
In this PR:
- fix discovery result ordering
- refactor the comp so the discovery results is cached (= computed at first render)
- improve search logic with improved key generation logic (to prevent key colision)