### PR TITLE
Thomas/decisions list

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseStatus.tsx
+++ b/packages/app-builder/src/components/Cases/CaseStatus.tsx
@@ -59,7 +59,7 @@ export function CaseStatus({
       <div
         className={cx(
           caseStatusVariants({ color, variant: 'contained' }),
-          'text-s flex size-6 shrink-0 items-center justify-center rounded font-semibold capitalize',
+          'text-s flex shrink-0 items-center justify-center rounded font-semibold capitalize',
           className,
         )}
       >

--- a/packages/app-builder/src/components/Cases/CasesList.tsx
+++ b/packages/app-builder/src/components/Cases/CasesList.tsx
@@ -33,7 +33,9 @@ export function CasesList({
         id: 'status',
         header: t('cases:case.status'),
         size: 50,
-        cell: ({ getValue }) => <CaseStatus status={getValue()} />,
+        cell: ({ getValue }) => (
+          <CaseStatus className="size-8" status={getValue()} />
+        ),
       }),
       columnHelper.accessor(({ name }) => name, {
         id: 'name',

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/StatusesFilter.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/StatusesFilter.tsx
@@ -33,7 +33,7 @@ export function StatusesFilter() {
                 value={status.value}
                 className="align-baseline"
               >
-                <CaseStatus status={status.value} />
+                <CaseStatus className="size-6" status={status.value} />
                 <span className="text-grey-100 text-s font-normal first-letter:capitalize">
                   {status.label}
                 </span>

--- a/packages/app-builder/src/components/Decisions/DecisionDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionDetail.tsx
@@ -52,7 +52,7 @@ export function DecisionDetail({ decision }: { decision: DecisionDetail }) {
           <DetailLabel>{t('decisions:case')}</DetailLabel>
           {caseDetail ? (
             <div className="flex w-fit flex-row items-center justify-center gap-1 align-baseline">
-              <CaseStatus status={caseDetail.status} />
+              <CaseStatus className="size-6" status={caseDetail.status} />
               <Link
                 to={getRoute('/cases/:caseId', {
                   caseId: fromUUID(caseDetail.id),

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -16,7 +16,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Checkbox, Table, Tooltip, useTable } from 'ui-design-system';
+import { Checkbox, Table, Tag, Tooltip, useTable } from 'ui-design-system';
 
 import { OutcomeAndReviewStatus } from './OutcomeAndReviewStatus';
 import { Score } from './Score';
@@ -153,32 +153,25 @@ export function DecisionsList({
         header: t('decisions:scenario.name'),
         size: 200,
         cell: ({ getValue, row }) => (
-          <Link
-            to={getRoute('/scenarios/:scenarioId', {
-              scenarioId: fromUUID(row.original.scenario.id),
-            })}
-            onClick={(e) => e.stopPropagation()}
-            className="hover:text-purple-120 focus:text-purple-120 relative font-semibold text-purple-100 hover:underline focus:underline"
-          >
-            {getValue()}
-          </Link>
-        ),
-      }),
-      columnHelper.accessor((row) => row.scenario.version, {
-        id: 'scenario_version',
-        header: 'Vi',
-        size: 40,
-        cell: ({ getValue, row }) => (
-          <Link
-            to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
-              scenarioId: fromUUID(row.original.scenario.id),
-              iterationId: fromUUID(row.original.scenario.scenarioIterationId),
-            })}
-            onClick={(e) => e.stopPropagation()}
-            className="hover:text-purple-120 focus:text-purple-120 relative font-semibold text-purple-100 hover:underline focus:underline"
-          >
-            {`V${getValue()}`}
-          </Link>
+          <div className="flex flex-row items-center gap-2">
+            <Tooltip.Default content={getValue()}>
+              <Link
+                to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
+                  scenarioId: fromUUID(row.original.scenario.id),
+                  iterationId: fromUUID(
+                    row.original.scenario.scenarioIterationId,
+                  ),
+                })}
+                onClick={(e) => e.stopPropagation()}
+                className="hover:text-purple-120 focus:text-purple-120 relative line-clamp-2 font-semibold text-purple-100 hover:underline focus:underline"
+              >
+                {getValue()}
+              </Link>
+            </Tooltip.Default>
+            <div className="border-grey-10 text-grey-100 rounded-full border px-3 py-1 font-semibold">
+              {`V${row.original.scenario.version}`}
+            </div>
+          </div>
         ),
       }),
       columnHelper.accessor((row) => row.triggerObjectType, {
@@ -192,20 +185,22 @@ export function DecisionsList({
         size: 150,
         cell: ({ getValue, row }) =>
           row.original.case ? (
-            <div className="flex w-fit flex-row items-center justify-center gap-1 align-baseline">
+            <div className="flex w-fit flex-row items-center justify-center gap-2 align-baseline">
               <CaseStatus
-                className="isolate"
+                className="isolate size-8"
                 status={row.original.case.status}
               />
-              <Link
-                to={getRoute('/cases/:caseId', {
-                  caseId: fromUUID(row.original.case.id),
-                })}
-                onClick={(e) => e.stopPropagation()}
-                className="hover:text-purple-120 focus:text-purple-120 relative font-semibold text-purple-100 hover:underline focus:underline"
-              >
-                {getValue()}
-              </Link>
+              <Tooltip.Default content={getValue()}>
+                <Link
+                  to={getRoute('/cases/:caseId', {
+                    caseId: fromUUID(row.original.case.id),
+                  })}
+                  onClick={(e) => e.stopPropagation()}
+                  className="hover:text-purple-120 focus:text-purple-120 relative line-clamp-2 font-semibold text-purple-100 hover:underline focus:underline"
+                >
+                  {getValue()}
+                </Link>
+              </Tooltip.Default>
             </div>
           ) : (
             <span className="bg-grey-02 text-grey-100 text-s flex h-8 w-fit items-center justify-center rounded px-2 font-normal">

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -16,7 +16,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Checkbox, Table, Tag, Tooltip, useTable } from 'ui-design-system';
+import { Checkbox, Table, Tooltip, useTable } from 'ui-design-system';
 
 import { OutcomeAndReviewStatus } from './OutcomeAndReviewStatus';
 import { Score } from './Score';

--- a/packages/app-builder/src/routes/ressources+/cases+/edit-status.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/edit-status.tsx
@@ -132,7 +132,7 @@ export function EditCaseStatus({
                     event.preventDefault();
                   }}
                 >
-                  <CaseStatus status={nextStatus.value} />
+                  <CaseStatus className="size-6" status={nextStatus.value} />
                   <span className="text-s text-grey-100 first-letter:capitalize">
                     {nextStatus.label}
                   </span>

--- a/packages/app-builder/src/utils/format.ts
+++ b/packages/app-builder/src/utils/format.ts
@@ -11,16 +11,22 @@ import { Temporal } from 'temporal-polyfill';
 /**
  * Get the language of the user's browser.
  *
- * This is a workaround for the fact that we only support en, and we want to format dates in the user's language.
+ * This is a workaround for the fact we do not allow the user to change the data format.
  * Since we do not store the user's language preferences, we use the browser's language.
  *
+ * Note: Prefered translation language and data format language are not mandatory the same.
+ * You can have a user with a prefered language in 'en-US' but the data format in 'fr-FR' (for DateTime, Number, etc).
+ *
  * This introduce hydration issues for non 'fr-FR' browsers, as the language is not available on the server.
- * We use a hook to ease the migration to a better solution.
+ * We use a hook to ease the migration to a better solution (like storing the user's data format language preferences).
+ *
+ * A frontend only solution could be to store the user's language preferences in the already existing language session cookie.
+ * We just need to add an interface to allow the user to change it.
  */
 export function useFormatLanguage() {
   return useMemo(
     () =>
-      typeof navigator === 'undefined'
+      typeof window === 'undefined'
         ? 'fr-FR'
         : (navigator?.languages[0] ?? 'fr-FR'),
     [],

--- a/packages/app-builder/src/utils/format.ts
+++ b/packages/app-builder/src/utils/format.ts
@@ -14,7 +14,7 @@ import { Temporal } from 'temporal-polyfill';
  * This is a workaround for the fact we do not allow the user to change the data format.
  * Since we do not store the user's language preferences, we use the browser's language.
  *
- * Note: Prefered translation language and data format language are not mandatory the same.
+ * Note: Prefered translation language and data format language are not necessarily the same.
  * You can have a user with a prefered language in 'en-US' but the data format in 'fr-FR' (for DateTime, Number, etc).
  *
  * This introduce hydration issues for non 'fr-FR' browsers, as the language is not available on the server.

--- a/packages/ui-design-system/src/Table/Table.tsx
+++ b/packages/ui-design-system/src/Table/Table.tsx
@@ -82,7 +82,7 @@ function Header<TData extends RowData>({
                 <th
                   colSpan={header.colSpan}
                   key={header.id}
-                  className="bg-grey-02 border-grey-10 w-0 border-b"
+                  className="bg-grey-00 border-grey-10 w-0 border-b"
                 ></th>
               );
             }

--- a/packages/ui-design-system/src/Table/Table.tsx
+++ b/packages/ui-design-system/src/Table/Table.tsx
@@ -97,22 +97,24 @@ function Header<TData extends RowData>({
                       asc: <Icon icon="arrow-2-up" className="size-6" />,
                       desc: <Icon icon="arrow-2-down" className="size-6" />,
                     }[header.column.getIsSorted() as string] ?? null}
-                    <div
-                      className={clsx(
-                        'hover:bg-grey-10 active:bg-grey-50 absolute right-0 h-full w-1 cursor-col-resize touch-none select-none',
-                        // Hack to take scroll bar into account
-                        index === headerGroup.headers.length - 1 && 'right-2',
-                      )}
-                      onMouseDown={header.getResizeHandler()}
-                      onTouchStart={header.getResizeHandler()}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                      }}
-                      onDoubleClick={() => {
-                        header.column.resetSize();
-                      }}
-                      aria-hidden="true"
-                    />
+                    {header.column.getCanResize() ? (
+                      <div
+                        className={clsx(
+                          'hover:bg-grey-10 active:bg-grey-50 absolute right-0 h-full w-1 cursor-col-resize touch-none select-none',
+                          // Hack to take scroll bar into account
+                          index === headerGroup.headers.length - 1 && 'right-2',
+                        )}
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                        }}
+                        onDoubleClick={() => {
+                          header.column.resetSize();
+                        }}
+                        aria-hidden="true"
+                      />
+                    ) : null}
                   </div>
                 )}
               </Table.TH>


### PR DESCRIPTION
End of the work on decision list redesign.

NB: I'm not totally ISO Figma on :
- case UI: this is a link like scenario name, I do not think using a "boxed" UI is usefull (especially with new white/grey rows)
- keep version number but close to the scenario (ISO what is proposed in the case manager revamp on Figma)

Now, we can only navigate to the version by clicking the scenario (not the scenario): this should be mostly the same since we do not yet have the scenario home page

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/9b4baa53-1be3-4db7-b186-9a666c891435">
