### PR TITLE
fix(TriggerObjectDetail): handle long text in trigger object detail

### DIFF
--- a/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
@@ -1,6 +1,6 @@
 import { useFormatLanguage } from '@app-builder/utils/format';
 import { parseUnknownData } from '@app-builder/utils/parse';
-import { useMemo } from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Collapsible } from 'ui-design-system';
@@ -16,7 +16,7 @@ export const TriggerObjectDetail = ({
   const { t } = useTranslation(decisionsI18n);
   const language = useFormatLanguage();
 
-  const parsedTriggerObject = useMemo(
+  const parsedTriggerObject = React.useMemo(
     () => R.pipe(triggerObject, R.mapValues(parseUnknownData), R.entries()),
     [triggerObject],
   );
@@ -27,13 +27,12 @@ export const TriggerObjectDetail = ({
         {t('decisions:trigger_object.type')}
       </Collapsible.Title>
       <Collapsible.Content>
-        <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-[max-content_1fr] gap-2 break-all">
           {parsedTriggerObject.map(([property, data]) => (
-            <div key={property}>
-              <span className="font-semibold capitalize">{property}:</span>
-              &nbsp;
+            <React.Fragment key={property}>
+              <span className="font-semibold capitalize">{property}</span>
               <FormatData data={data} language={language} />
-            </div>
+            </React.Fragment>
           ))}
         </div>
       </Collapsible.Content>


### PR DESCRIPTION
Improve `TriggerObjectDetail`:
- Handle long text with `break-all`
- cleaner UI using grid (ISO Figma) so it's clearer to read

**Before**
<img width="802" alt="image" src="https://github.com/user-attachments/assets/d95cd4dc-2b08-4e63-93f9-fc5e0eafdc85">

**After**
<img width="409" alt="image" src="https://github.com/user-attachments/assets/f742ce37-d5de-439e-abd8-26f02557c61e">
