### PR TITLE
chore(ci): update google-github-actions to v2

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -55,19 +55,19 @@ jobs:
           tags: ${{ env.IMAGE }}
           file: ./Dockerfile
           build-args: |
-            "SENTRY_ORG=${{ env.SENTRY_ORG }}"
-            "SENTRY_PROJECT=${{ env.SENTRY_PROJECT }}"
-            "VERSION"=${{ env.VERSION }}
+            SENTRY_ORG='checkmarble'
+            SENTRY_PROJECT='marble-frontend'
+            VERSION=${{ env.VERSION }}
           secrets: |
             "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
 
       - name: Auth
-        uses: 'google-github-actions/auth@v1'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.GCP_SA_KEY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
         with:
           install_components: beta
 


### PR DESCRIPTION
In this PR :
- inject sentry env vars (since they are not created anymore by the previous dedicated action)
- update some actions to resolve warnings from the CI (due to Node version updation in Github Actions)