### PR TITLE
fix(ci): update sentry release name

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -57,7 +57,7 @@ jobs:
           build-args: |
             SENTRY_ORG=checkmarble
             SENTRY_PROJECT=marble-frontend
-            VERSION=${{ env.VERSION }}
+            SENTRY_RELEASE=${{ env.GITHUB_SHA }}
           secrets: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/packages/app-builder/vite.config.ts
+++ b/packages/app-builder/vite.config.ts
@@ -43,18 +43,11 @@ if (!isVitest) {
   );
 }
 if (isSentryConfigured) {
-  const version = process.env['VERSION'];
-  const name =
-    version && /v\d+\.\d+\.\d+/.test(version)
-      ? version
-      : process.env['COMMIT_SHA'];
-
   plugins.push(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     sentryVitePlugin({
       telemetry: false,
       release: {
-        name,
         setCommits: {
           auto: true,
         },


### PR DESCRIPTION
Last of the week and also (🤞🏽) last of all...

The sentry release name logic do not work for staging (I expect it to work for prod since we do use the tag, but I prefer to use an explicit easy to understand logic)