### PR TITLE
refactor(layout): better semantic and structure for layout components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "i18n-ally.localesPaths": ["packages/app-builder/public/locales"],
+  "i18n-ally.localesPaths": ["packages/app-builder/public/locales","packages/app-builder/src/locales"],
   "i18n-ally.keystyle": "flat",
   "i18n-ally.enabledFrameworks": ["react", "i18next", "react-i18next"],
   "i18n-ally.namespace": true,

--- a/packages/app-builder/src/components/Cases/CasesList.tsx
+++ b/packages/app-builder/src/components/Cases/CasesList.tsx
@@ -98,7 +98,7 @@ export function CasesList({
           return (
             <Table.Row
               key={row.id}
-              className={clsx('hover:bg-purple-05 cursor-pointer')}
+              className="hover:bg-purple-05 cursor-pointer"
               row={row}
               onClick={() => {
                 navigate(

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -294,7 +294,7 @@ export function DecisionsList({
             <Table.Row
               key={row.id}
               tabIndex={0}
-              className={clsx('hover:bg-purple-05 relative cursor-pointer')}
+              className="hover:bg-purple-05 relative cursor-pointer"
               row={row}
             />
           );

--- a/packages/app-builder/src/components/Layout/LeftSidebar.tsx
+++ b/packages/app-builder/src/components/Layout/LeftSidebar.tsx
@@ -4,29 +4,29 @@ import { Icon } from 'ui-icons';
 
 import { SidebarButton } from '../Navigation';
 
-const ToggleHeaderContext = createSimpleContext<[boolean, () => void]>(
-  'ToggleHeaderContext',
+const ToggleSidebarContext = createSimpleContext<[boolean, () => void]>(
+  'ToggleSidebarContext',
 );
 
-export function Header({ children }: { children: React.ReactNode }) {
+export function LeftSidebar({ children }: { children: React.ReactNode }) {
   const [expanded, setExpanded] = React.useState(true);
 
   const toggleExpanded = () => setExpanded((prev) => !prev);
 
   return (
-    <header
+    <div
       aria-expanded={expanded}
       className="bg-grey-00 border-r-grey-10 group/nav flex max-h-screen w-14 shrink-0 flex-col border-r transition-all aria-expanded:w-[235px]"
     >
-      <ToggleHeaderContext.Provider value={[expanded, toggleExpanded]}>
+      <ToggleSidebarContext.Provider value={[expanded, toggleExpanded]}>
         {children}
-      </ToggleHeaderContext.Provider>
-    </header>
+      </ToggleSidebarContext.Provider>
+    </div>
   );
 }
 
-export function ToggleHeader() {
-  const [expanded, toggleExpanded] = ToggleHeaderContext.useValue();
+export function ToggleSidebar() {
+  const [expanded, toggleExpanded] = ToggleSidebarContext.useValue();
 
   return (
     <SidebarButton

--- a/packages/app-builder/src/components/Page.tsx
+++ b/packages/app-builder/src/components/Page.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Tooltip } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
-function PageContainer({ className, ...props }: React.ComponentProps<'div'>) {
+function PageMain({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <main
       className={clsx(
@@ -44,24 +44,47 @@ function PageHeader({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function PageContent({ className, ...props }: React.ComponentProps<'div'>) {
+function PageContainer({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     // eslint-disable-next-line tailwindcss/no-custom-classname
-    <div className="scrollbar-gutter-stable size-full overflow-y-scroll">
-      <div
-        className={clsx(
-          'flex flex-1 flex-col',
-          'gap-4 p-4 pr-[calc(1rem-var(--scrollbar-width))] lg:gap-6 lg:p-6 lg:pr-[calc(1.5rem-var(--scrollbar-width))]',
-          className,
-        )}
-        {...props}
-      />
-    </div>
+    <div
+      className="scrollbar-gutter-stable size-full overflow-y-scroll"
+      {...props}
+    />
   );
 }
 
-const style =
-  'border-grey-10 hover:bg-grey-02 flex items-center justify-center rounded-md border p-2';
+function PageDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <aside
+      className={clsx(
+        'bg-purple-05 text-s flex flex-row gap-2 p-4 font-normal text-purple-100 lg:px-6 lg:py-4',
+        className,
+      )}
+      {...props}
+    >
+      <Icon icon="tip" className="size-5 shrink-0" />
+      {props.children}
+    </aside>
+  );
+}
+
+function PageContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={clsx(
+        'flex flex-1 flex-col',
+        'gap-4 p-4 pr-[calc(1rem-var(--scrollbar-width))] lg:gap-6 lg:p-6 lg:pr-[calc(1.5rem-var(--scrollbar-width))]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const pageBack = cva(
+  'border-grey-10 hover:bg-grey-02 flex items-center justify-center rounded-md border p-2',
+);
 
 function PageBackButton({
   className,
@@ -72,7 +95,7 @@ function PageBackButton({
   return (
     <Tooltip.Default content={t('common:go_back')}>
       <button
-        className={clsx(style, className)}
+        className={pageBack({ className })}
         onClick={() => navigate(-1)}
         {...props}
       >
@@ -88,16 +111,35 @@ function PageBackLink({
   ...props
 }: React.ComponentProps<typeof Link>) {
   return (
-    <Link className={clsx(style, className)} {...props}>
+    <Link className={pageBack({ className })} {...props}>
       <Icon icon="arrow-left" className="size-5" aria-hidden />
     </Link>
   );
 }
 
+/**
+ * Example:
+ * ```tsx
+ * <Page.Main>
+ *     <Page.Header> // Fixed header
+ *       ...
+ *     </Page.Header>
+ *     <Page.Container> // Scrollable container
+ *         <Page.Description> // Optional
+ *           ...
+ *         </Page.Description>
+ *         <Page.Content> // Main content of the page
+ *           ...
+ *         </Page.Content>
+ *     </Page.Container>
+ * </Page.Main>
+ */
 export const Page = {
-  Container: PageContainer,
+  Main: PageMain,
   Header: PageHeader,
   BackButton: PageBackButton,
   BackLink: PageBackLink,
+  Container: PageContainer,
   Content: PageContent,
+  Description: PageDescription,
 };

--- a/packages/app-builder/src/components/ScheduledExecutions/ScheduledExecutionsList.tsx
+++ b/packages/app-builder/src/components/ScheduledExecutions/ScheduledExecutionsList.tsx
@@ -7,7 +7,6 @@ import {
 import { getRoute } from '@app-builder/utils/routes';
 import { Link } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { type ParseKeys } from 'i18next';
 import qs from 'qs';
 import { useMemo } from 'react';
@@ -142,7 +141,7 @@ export function ScheduledExecutionsList({
           return (
             <Table.Row
               key={row.id}
-              className={clsx('hover:bg-purple-05 cursor-pointer')}
+              className="hover:bg-purple-05 cursor-pointer"
               row={row}
             />
           );

--- a/packages/app-builder/src/components/TransferAlerts/AlertsList.tsx
+++ b/packages/app-builder/src/components/TransferAlerts/AlertsList.tsx
@@ -1,5 +1,8 @@
 import { Highlight } from '@app-builder/components/Highlight';
-import { type TransferAlertStatus } from '@app-builder/models/transfer-alert';
+import {
+  transferAlerStatusesWithoutArchived,
+  type TransferAlertStatus,
+} from '@app-builder/models/transfer-alert';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { type DateRangeFilter } from '@app-builder/utils/schema/filterSchema';
 import {
@@ -44,7 +47,10 @@ type TransferAlertColumnFiltersState = (
 
 export function AlertsList({ alerts, className, rowLink }: AlertsListProps) {
   const [columnFilters, setColumnFilters] =
-    React.useState<TransferAlertColumnFiltersState>([]);
+    React.useState<TransferAlertColumnFiltersState>([
+      // archived status is not included in the default filter
+      { id: 'status', value: transferAlerStatusesWithoutArchived },
+    ]);
 
   const filterValues: AlertsFilters = columnFilters.reduce<AlertsFilters>(
     (acc, filter) => {
@@ -202,20 +208,18 @@ function AlertsListTable({
   }
 
   return (
-    <Table.Container {...getContainerProps()} className={className}>
+    <Table.Container
+      {...getContainerProps()}
+      className={clsx('bg-grey-00', className)}
+    >
       <Table.Header headerGroups={table.getHeaderGroups()} />
       <Table.Body {...getBodyProps()}>
         {rows.map((row) => {
-          const bgClassName =
-            row.original.status === 'archived' ? 'transparent' : 'bg-grey-00';
           return (
             <Table.Row
               key={row.id}
               tabIndex={0}
-              className={clsx(
-                'hover:bg-purple-05 relative cursor-pointer',
-                bgClassName,
-              )}
+              className="hover:bg-purple-05 relative cursor-pointer"
               row={row}
             />
           );

--- a/packages/app-builder/src/components/Transfers/TransfersList.tsx
+++ b/packages/app-builder/src/components/Transfers/TransfersList.tsx
@@ -87,7 +87,7 @@ export function TransfersList({ className, transfers }: TransfersListProps) {
             <Table.Row
               key={row.id}
               tabIndex={0}
-              className={clsx('hover:bg-purple-05 relative cursor-pointer')}
+              className="hover:bg-purple-05 relative cursor-pointer"
               row={row}
             />
           );

--- a/packages/app-builder/src/locales/en/scenarios.json
+++ b/packages/app-builder/src/locales/en/scenarios.json
@@ -92,6 +92,7 @@
   "deployment_modal.deactivate.helper": "You can roll back to a previous version directly from the version page",
   "deployment_modal_success.deactivate.title": "Version deactivated",
   "deployment_modal_success.deactivate.description": "The live version has been successfully deactivated, the scenario has ceased to operate",
+  "scenarios.description": "A scenario is used to detect a certain type of risk, following specific business rules, for a specific triggering event.",
   "create_scenario.title": "New Scenario",
   "create_scenario.callout": "A scenario identifies a certain risk type, triggered by a specific event (<DocLink>learn more</DocLink>)",
   "create_scenario.name": "Name",

--- a/packages/app-builder/src/locales/fr/scenarios.json
+++ b/packages/app-builder/src/locales/fr/scenarios.json
@@ -247,5 +247,6 @@
   "validation.evaluation_error.undefined_function_one": "requis",
   "validation.evaluation_error.undefined_function_other": "{{count}} requis",
   "validation.evaluation_error.wrong_number_of_arguments": "mauvais nombre d'arguments",
-  "custom_list.unknown": "Liste inconnue"
+  "custom_list.unknown": "Liste inconnue",
+  "scenarios.description": "Un scénario permet de détecter un certain type de risque, selon des règles métier spécifiques, pour un événement déclencheur spécifique."
 }

--- a/packages/app-builder/src/models/transfer-alert.ts
+++ b/packages/app-builder/src/models/transfer-alert.ts
@@ -12,6 +12,9 @@ export const transferAlerStatuses = [
   'acknowledged',
   'archived',
 ] as const;
+export const transferAlerStatusesWithoutArchived = transferAlerStatuses.filter(
+  (status) => status !== 'archived',
+);
 export type TransferAlertStatus = (typeof transferAlerStatuses)[number];
 
 export interface TransferAlertSender {

--- a/packages/app-builder/src/routes/_builder+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/_layout.tsx
@@ -9,9 +9,9 @@ import {
   useMarbleCoreResources,
 } from '@app-builder/components/HelpCenter';
 import {
-  Header,
-  ToggleHeader,
-} from '@app-builder/components/Layout/MainLayout';
+  LeftSidebar,
+  ToggleSidebar,
+} from '@app-builder/components/Layout/LeftSidebar';
 import { UserInfo } from '@app-builder/components/UserInfo';
 import { isMarbleAdmin, isMarbleCoreUser } from '@app-builder/models';
 import { useRefreshToken } from '@app-builder/routes/ressources+/auth+/refresh';
@@ -124,7 +124,7 @@ export default function Builder() {
     <OrganizationUsersContextProvider orgUsers={orgUsers}>
       <OrganizationTagsContextProvider orgTags={orgTags}>
         <div className="flex h-full flex-1 flex-row overflow-hidden">
-          <Header>
+          <LeftSidebar>
             <div className="h-24 px-2 pt-3">
               <UserInfo
                 email={user.actorIdentity.email}
@@ -265,11 +265,11 @@ export default function Builder() {
                   </ChatlioProvider>
                 </li>
                 <li>
-                  <ToggleHeader />
+                  <ToggleSidebar />
                 </li>
               </ul>
             </nav>
-          </Header>
+          </LeftSidebar>
 
           <Outlet />
         </div>

--- a/packages/app-builder/src/routes/_builder+/analytics.tsx
+++ b/packages/app-builder/src/routes/_builder+/analytics.tsx
@@ -45,7 +45,7 @@ export default function Analytics() {
   const { globalDashbord } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center">
           <Icon icon="analytics" className="mr-2 size-6" />
@@ -59,7 +59,7 @@ export default function Analytics() {
         title={globalDashbord.title}
         className="size-full"
       ></iframe>
-    </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/api.tsx
+++ b/packages/app-builder/src/routes/_builder+/api.tsx
@@ -43,40 +43,42 @@ export default function Api() {
   const { openapi } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center">
           <Icon icon="world" className="mr-2 size-6" />
           <span className="line-clamp-1 text-left">{t('navigation:api')}</span>
         </div>
       </Page.Header>
-      <Page.Content>
-        <div className="flex">
-          <Button
-            variant="secondary"
-            onClick={() => {
-              const blob = new Blob([JSON.stringify(openapi)], {
-                type: 'application/json;charset=utf-8,',
-              });
-              void downloadBlob(blob, 'openapi.json');
-            }}
-          >
-            <Icon icon="download" className="mr-2 size-6" />
-            {t('api:download_openapi_spec')}
-          </Button>
-        </div>
-        <div className="-mx-5">
-          <React.Suspense fallback={t('common:loading')}>
-            {/* Issue with UNSAFE_componentWillReceiveProps: https://github.com/swagger-api/swagger-ui/issues/5729 */}
-            <SwaggerUI
-              spec={openapi}
-              supportedSubmitMethods={[]}
-              defaultModelExpandDepth={5}
-              defaultModelsExpandDepth={4}
-            />
-          </React.Suspense>
-        </div>
-      </Page.Content>
-    </Page.Container>
+      <Page.Container>
+        <Page.Content>
+          <div className="flex">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                const blob = new Blob([JSON.stringify(openapi)], {
+                  type: 'application/json;charset=utf-8,',
+                });
+                void downloadBlob(blob, 'openapi.json');
+              }}
+            >
+              <Icon icon="download" className="mr-2 size-6" />
+              {t('api:download_openapi_spec')}
+            </Button>
+          </div>
+          <div className="-mx-5">
+            <React.Suspense fallback={t('common:loading')}>
+              {/* Issue with UNSAFE_componentWillReceiveProps: https://github.com/swagger-api/swagger-ui/issues/5729 */}
+              <SwaggerUI
+                spec={openapi}
+                supportedSubmitMethods={[]}
+                defaultModelExpandDepth={5}
+                defaultModelsExpandDepth={4}
+              />
+            </React.Suspense>
+          </div>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId.tsx
@@ -133,7 +133,7 @@ export default function CasePage() {
   const language = useFormatLanguage();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between gap-8">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
@@ -148,129 +148,133 @@ export default function CasePage() {
       </Page.Header>
       <div className="flex size-full flex-row overflow-hidden">
         <div className="relative flex size-full flex-col overflow-hidden">
-          <Page.Content>
-            <div>
-              <CollapsibleV2.Provider
-                defaultOpen={caseDetail.decisions.length > 0}
-              >
-                <div className="group flex flex-1 items-center gap-2">
-                  <CollapsibleV2.Title className="hover:bg-purple-05 text-grey-100 group flex items-center rounded border border-transparent outline-none transition-colors focus-visible:border-purple-100">
-                    <Icon
-                      icon="arrow-2-up"
-                      aria-hidden
-                      className="size-6 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180 group-data-[initial]:rotate-180"
-                    />
-                    <span className="text-m mx-2 font-bold first-letter:capitalize">
-                      {t('cases:case.decisions')}
-                    </span>
-                  </CollapsibleV2.Title>
-                  <span className="text-grey-25 text-xs font-normal capitalize">
-                    {t('cases:case_detail.decisions_count', {
-                      count: caseDetail.decisions.length,
-                    })}
-                  </span>
-                </div>
-                <CollapsibleV2.Content>
-                  {caseDetail.decisions.length > 0 ? (
-                    <div className="mt-4">
-                      <CaseDecisions
-                        decisions={caseDetail.decisions}
-                        caseDecisionsPromise={caseDecisionsPromise}
+          <Page.Container>
+            <Page.Content>
+              <div>
+                <CollapsibleV2.Provider
+                  defaultOpen={caseDetail.decisions.length > 0}
+                >
+                  <div className="group flex flex-1 items-center gap-2">
+                    <CollapsibleV2.Title className="hover:bg-purple-05 text-grey-100 group flex items-center rounded border border-transparent outline-none transition-colors focus-visible:border-purple-100">
+                      <Icon
+                        icon="arrow-2-up"
+                        aria-hidden
+                        className="size-6 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180 group-data-[initial]:rotate-180"
                       />
-                    </div>
-                  ) : (
-                    <div className="px-2 pt-2">
-                      <span className="text-grey-50 text-s whitespace-pre">
-                        <Trans
-                          t={t}
-                          i18nKey="cases:case_detail.no_decisions"
-                          components={{
-                            Link: (
-                              <Link
-                                className="text-purple-50 hover:text-purple-100 hover:underline"
-                                to={getRoute('/decisions/')}
-                              />
-                            ),
-                          }}
-                        />
+                      <span className="text-m mx-2 font-bold first-letter:capitalize">
+                        {t('cases:case.decisions')}
                       </span>
-                    </div>
-                  )}
-                </CollapsibleV2.Content>
-              </CollapsibleV2.Provider>
-            </div>
-            <div>
-              <CollapsibleV2.Provider defaultOpen={caseDetail.files.length > 0}>
-                <div className="group flex flex-1 items-center gap-2">
-                  <CollapsibleV2.Title className="hover:bg-purple-05 text-grey-100 group flex items-center rounded border border-transparent outline-none transition-colors focus-visible:border-purple-100">
-                    <Icon
-                      icon="arrow-2-up"
-                      aria-hidden
-                      className="size-6 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180 group-data-[initial]:rotate-180"
-                    />
-                    <span className="text-m mx-2 font-bold capitalize">
-                      {t('cases:case.files')}
+                    </CollapsibleV2.Title>
+                    <span className="text-grey-25 text-xs font-normal capitalize">
+                      {t('cases:case_detail.decisions_count', {
+                        count: caseDetail.decisions.length,
+                      })}
                     </span>
-                  </CollapsibleV2.Title>
-                  <span className="text-grey-25 text-xs font-normal capitalize">
-                    {t('cases:case_detail.files_count', {
-                      count: caseDetail.files.length,
-                    })}
-                  </span>
-                </div>
-
-                <CollapsibleV2.Content>
-                  {caseDetail.files.length > 0 ? (
-                    <div className="mt-4">
-                      <FilesList files={caseDetail.files} />
-                    </div>
-                  ) : (
-                    <div className="px-2 pt-2">
-                      <span className="text-grey-50 text-s whitespace-pre">
-                        <Trans
-                          t={t}
-                          i18nKey="cases:case_detail.no_files"
-                          components={{
-                            Button: (
-                              <AddYourFirstFile caseDetail={caseDetail} />
-                            ),
-                          }}
-                        />
-                      </span>
-                    </div>
-                  )}
-                </CollapsibleV2.Content>
-              </CollapsibleV2.Provider>
-            </div>
-            <div>
-              <CollapsibleV2.Provider
-                defaultOpen={caseDetail.events.length > 0}
-              >
-                <div className="group flex flex-1 items-center gap-2">
-                  <CollapsibleV2.Title className="hover:bg-purple-05 text-grey-100 group flex items-center rounded border border-transparent outline-none transition-colors focus-visible:border-purple-100">
-                    <Icon
-                      icon="arrow-2-up"
-                      aria-hidden
-                      className="size-6 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180"
-                    />
-                    <span className="text-m mx-2 font-bold capitalize">
-                      {t('cases:case_detail.history')}
-                    </span>
-                  </CollapsibleV2.Title>
-                  <span className="text-grey-25 text-xs font-normal capitalize">
-                    {t('cases:case_detail.events_count', {
-                      count: caseDetail.events.length,
-                    })}
-                  </span>
-                </div>
-                <CollapsibleV2.Content>
-                  <div className="border-grey-10 bg-grey-00 mt-4 max-h-96 overflow-y-scroll rounded-lg border p-4">
-                    <CaseEvents events={caseDetail.events} />
                   </div>
-                </CollapsibleV2.Content>
-              </CollapsibleV2.Provider>
-            </div>
-          </Page.Content>
+                  <CollapsibleV2.Content>
+                    {caseDetail.decisions.length > 0 ? (
+                      <div className="mt-4">
+                        <CaseDecisions
+                          decisions={caseDetail.decisions}
+                          caseDecisionsPromise={caseDecisionsPromise}
+                        />
+                      </div>
+                    ) : (
+                      <div className="px-2 pt-2">
+                        <span className="text-grey-50 text-s whitespace-pre">
+                          <Trans
+                            t={t}
+                            i18nKey="cases:case_detail.no_decisions"
+                            components={{
+                              Link: (
+                                <Link
+                                  className="text-purple-50 hover:text-purple-100 hover:underline"
+                                  to={getRoute('/decisions/')}
+                                />
+                              ),
+                            }}
+                          />
+                        </span>
+                      </div>
+                    )}
+                  </CollapsibleV2.Content>
+                </CollapsibleV2.Provider>
+              </div>
+              <div>
+                <CollapsibleV2.Provider
+                  defaultOpen={caseDetail.files.length > 0}
+                >
+                  <div className="group flex flex-1 items-center gap-2">
+                    <CollapsibleV2.Title className="hover:bg-purple-05 text-grey-100 group flex items-center rounded border border-transparent outline-none transition-colors focus-visible:border-purple-100">
+                      <Icon
+                        icon="arrow-2-up"
+                        aria-hidden
+                        className="size-6 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180 group-data-[initial]:rotate-180"
+                      />
+                      <span className="text-m mx-2 font-bold capitalize">
+                        {t('cases:case.files')}
+                      </span>
+                    </CollapsibleV2.Title>
+                    <span className="text-grey-25 text-xs font-normal capitalize">
+                      {t('cases:case_detail.files_count', {
+                        count: caseDetail.files.length,
+                      })}
+                    </span>
+                  </div>
+
+                  <CollapsibleV2.Content>
+                    {caseDetail.files.length > 0 ? (
+                      <div className="mt-4">
+                        <FilesList files={caseDetail.files} />
+                      </div>
+                    ) : (
+                      <div className="px-2 pt-2">
+                        <span className="text-grey-50 text-s whitespace-pre">
+                          <Trans
+                            t={t}
+                            i18nKey="cases:case_detail.no_files"
+                            components={{
+                              Button: (
+                                <AddYourFirstFile caseDetail={caseDetail} />
+                              ),
+                            }}
+                          />
+                        </span>
+                      </div>
+                    )}
+                  </CollapsibleV2.Content>
+                </CollapsibleV2.Provider>
+              </div>
+              <div>
+                <CollapsibleV2.Provider
+                  defaultOpen={caseDetail.events.length > 0}
+                >
+                  <div className="group flex flex-1 items-center gap-2">
+                    <CollapsibleV2.Title className="hover:bg-purple-05 text-grey-100 group flex items-center rounded border border-transparent outline-none transition-colors focus-visible:border-purple-100">
+                      <Icon
+                        icon="arrow-2-up"
+                        aria-hidden
+                        className="size-6 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180"
+                      />
+                      <span className="text-m mx-2 font-bold capitalize">
+                        {t('cases:case_detail.history')}
+                      </span>
+                    </CollapsibleV2.Title>
+                    <span className="text-grey-25 text-xs font-normal capitalize">
+                      {t('cases:case_detail.events_count', {
+                        count: caseDetail.events.length,
+                      })}
+                    </span>
+                  </div>
+                  <CollapsibleV2.Content>
+                    <div className="border-grey-10 bg-grey-00 mt-4 max-h-96 overflow-y-scroll rounded-lg border p-4">
+                      <CaseEvents events={caseDetail.events} />
+                    </div>
+                  </CollapsibleV2.Content>
+                </CollapsibleV2.Provider>
+              </div>
+            </Page.Content>
+          </Page.Container>
           <div className="bg-grey-00 border-t-grey-10 flex shrink-0 flex-row items-center gap-4 border-t p-4">
             <AddComment caseId={caseDetail.id} />
             <UploadFile caseDetail={caseDetail}>
@@ -311,7 +315,7 @@ export default function CasePage() {
           </div>
         </div>
       </div>
-    </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/cases+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/_index.tsx
@@ -33,21 +33,23 @@ export default function Cases() {
   const { isCreateInboxAvailable } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="case-manager" className="mr-2 size-6" />
         {t('navigation:caseManager')}
       </Page.Header>
-      <Page.Content>
-        {isCreateInboxAvailable ? (
-          <div className="flex max-w-xl flex-col gap-4">
-            <p>{t('cases:inbox.need_first_inbox')}</p>
-            <CreateInbox redirectRoutePath="/cases/inboxes/:inboxId" />
-          </div>
-        ) : (
-          <p>{t('cases:inbox.need_inbox_contact_admin')}</p>
-        )}
-      </Page.Content>
-    </Page.Container>
+      <Page.Container>
+        <Page.Content>
+          {isCreateInboxAvailable ? (
+            <div className="flex max-w-xl flex-col gap-4">
+              <p>{t('cases:inbox.need_first_inbox')}</p>
+              <CreateInbox redirectRoutePath="/cases/inboxes/:inboxId" />
+            </div>
+          ) : (
+            <p>{t('cases:inbox.need_inbox_contact_admin')}</p>
+          )}
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -117,7 +117,7 @@ export default function Cases() {
 
   return (
     <CaseRightPanel.Root>
-      <div className="flex h-full flex-row">
+      <Page.Container>
         <Page.Content>
           <div className="flex flex-col gap-4">
             <CasesFiltersProvider
@@ -147,7 +147,7 @@ export default function Cases() {
             </CasesFiltersProvider>
           </div>
         </Page.Content>
-      </div>
+      </Page.Container>
     </CaseRightPanel.Root>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
@@ -9,7 +9,6 @@ import { NavLink, Outlet, useLoaderData } from '@remix-run/react';
 import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { ScrollAreaV2 } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 export const handle = {
@@ -35,18 +34,18 @@ export default function Cases() {
   const { inboxes, isCreateInboxAvailable } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="case-manager" className="mr-2 size-6" />
         {t('navigation:caseManager')}
       </Page.Header>
       <div className="flex h-full flex-row overflow-hidden">
-        <div className="border-r-grey-10 bg-grey-00 flex h-full w-fit min-w-[200px] max-w-[300px] shrink-0 flex-col border-r p-4">
+        <div className="border-r-grey-10 bg-grey-00 flex h-full w-fit min-w-[200px] max-w-[300px] shrink-0 flex-col overflow-y-auto border-r p-4">
           <div className="flex flex-row items-center gap-2">
             <Icon icon="inbox" className="size-5" />
             <p className="font-bold">{t('cases:case.inboxes')}</p>
           </div>
-          <ScrollAreaV2 className="-mx-4 mb-6 mt-4 max-h-[70dvh] px-4">
+          <div className="mb-6 mt-4">
             <nav>
               <ul className="flex flex-col gap-1">
                 {inboxes.map((inbox) => (
@@ -70,13 +69,13 @@ export default function Cases() {
                 ))}
               </ul>
             </nav>
-          </ScrollAreaV2>
+          </div>
           {isCreateInboxAvailable ? (
             <CreateInbox redirectRoutePath="/cases/inboxes/:inboxId" />
           ) : null}
         </div>
         <Outlet />
       </div>
-    </Page.Container>
+    </Page.Main>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/data+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/_layout.tsx
@@ -47,7 +47,7 @@ export default function Data() {
   const { dataModel, dataModelFeatureAccess } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center">
           <Icon icon="harddrive" className="mr-2 size-6" />
@@ -60,6 +60,6 @@ export default function Data() {
       >
         <Outlet />
       </DataModelContextProvider>
-    </Page.Container>
+    </Page.Main>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/data+/list.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/list.tsx
@@ -1,4 +1,4 @@
-import { Callout, Page, TabLink } from '@app-builder/components';
+import { Page, TabLink } from '@app-builder/components';
 import { dataI18n } from '@app-builder/components/Data/data-i18n';
 import { TableDetails } from '@app-builder/components/Data/TableDetails';
 import { CreateTable } from '@app-builder/routes/ressources+/data+/createTable';
@@ -22,43 +22,43 @@ export default function Data() {
   const { isCreateDataModelTableAvailable } = useDataModelFeatureAccess();
 
   return (
-    <Page.Content>
-      <nav className="border border-transparent">
-        <ul className="flex flex-row gap-2">
-          <li>
-            <TabLink
-              labelTKey="navigation:data.list"
-              to={getRoute('/data/list')}
-              Icon={(props) => <Icon {...props} icon="lists" />}
-            />
-          </li>
-          <li>
-            <TabLink
-              labelTKey="navigation:data.schema"
-              to={getRoute('/data/schema')}
-              Icon={(props) => <Icon {...props} icon="tree-schema" />}
-            />
-          </li>
-        </ul>
-      </nav>
-      <Callout className="whitespace-normal" variant="outlined">
-        {t('data:your_data_callout')}
-      </Callout>
-      {isCreateDataModelTableAvailable ? (
-        <CreateTable>
-          <Button className="w-fit">
-            <Icon icon="plus" className="size-6" />
-            {t('data:create_table.title')}
-          </Button>
-        </CreateTable>
-      ) : null}
-      {dataModel.map((table) => (
-        <TableDetails
-          key={table.name}
-          tableModel={table}
-          dataModel={dataModel}
-        />
-      ))}
-    </Page.Content>
+    <Page.Container>
+      <Page.Description>{t('data:your_data_callout')}</Page.Description>
+      <Page.Content>
+        <nav className="border border-transparent">
+          <ul className="flex flex-row gap-2">
+            <li>
+              <TabLink
+                labelTKey="navigation:data.list"
+                to={getRoute('/data/list')}
+                Icon={(props) => <Icon {...props} icon="lists" />}
+              />
+            </li>
+            <li>
+              <TabLink
+                labelTKey="navigation:data.schema"
+                to={getRoute('/data/schema')}
+                Icon={(props) => <Icon {...props} icon="tree-schema" />}
+              />
+            </li>
+          </ul>
+        </nav>
+        {isCreateDataModelTableAvailable ? (
+          <CreateTable>
+            <Button className="w-fit">
+              <Icon icon="plus" className="size-6" />
+              {t('data:create_table.title')}
+            </Button>
+          </CreateTable>
+        ) : null}
+        {dataModel.map((table) => (
+          <TableDetails
+            key={table.name}
+            tableModel={table}
+            dataModel={dataModel}
+          />
+        ))}
+      </Page.Content>
+    </Page.Container>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/data+/schema.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/schema.tsx
@@ -1,4 +1,4 @@
-import { TabLink } from '@app-builder/components';
+import { Page, TabLink } from '@app-builder/components';
 import { dataI18n } from '@app-builder/components/Data/data-i18n';
 import {
   DataModelFlow,
@@ -14,6 +14,7 @@ import {
 } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { Panel } from 'reactflow';
 import { Icon } from 'ui-icons';
 
@@ -37,10 +38,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function Data() {
   const dataModel = useDataModel();
+  const { t } = useTranslation(handle.i18n);
   const { pivots } = useLoaderData<typeof loader>();
 
   return (
     <div className="size-full">
+      <Page.Description>{t('data:your_data_callout')}</Page.Description>
       <DataModelFlow dataModel={dataModel} pivots={pivots}>
         <Panel position="top-left">
           <nav className="bg-grey-00 border-grey-10 w-fit rounded border p-px drop-shadow-md lg:p-[9px]">

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -124,7 +124,7 @@ export default function DecisionPage() {
 
   return (
     <DecisionRightPanel.Root>
-      <Page.Container>
+      <Page.Main>
         <Page.Header className="justify-between gap-8">
           <div className="flex flex-row items-center gap-4">
             <Page.BackButton />
@@ -139,30 +139,32 @@ export default function DecisionPage() {
           </div>
           {!decision.case ? <AddToCase decisionIds={[decision.id]} /> : null}
         </Page.Header>
-        <Page.Content>
-          <div className="grid grid-cols-[2fr_1fr] gap-4 lg:gap-6">
-            <div className="flex flex-col gap-4 lg:gap-6">
-              <DecisionDetail decision={decision} />
-              <PivotDetail
-                pivotValues={pivotValues}
-                existingPivotDefinition={existingPivotDefinition}
-              />
-              <RulesDetail
-                ruleExecutions={decision.rules}
-                triggerObjectType={decision.triggerObjectType}
-                astRuleData={astRuleData}
-              />
-            </div>
-            <div className="flex flex-col gap-4 lg:gap-6">
-              <div className="flex flex-col gap-4 lg:flex-row lg:gap-6">
-                <ScorePanel score={decision.score} />
-                <OutcomePanel outcome={decision.outcome} />
+        <Page.Container>
+          <Page.Content>
+            <div className="grid grid-cols-[2fr_1fr] gap-4 lg:gap-6">
+              <div className="flex flex-col gap-4 lg:gap-6">
+                <DecisionDetail decision={decision} />
+                <PivotDetail
+                  pivotValues={pivotValues}
+                  existingPivotDefinition={existingPivotDefinition}
+                />
+                <RulesDetail
+                  ruleExecutions={decision.rules}
+                  triggerObjectType={decision.triggerObjectType}
+                  astRuleData={astRuleData}
+                />
               </div>
-              <TriggerObjectDetail triggerObject={decision.triggerObject} />
+              <div className="flex flex-col gap-4 lg:gap-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:gap-6">
+                  <ScorePanel score={decision.score} />
+                  <OutcomePanel outcome={decision.outcome} />
+                </div>
+                <TriggerObjectDetail triggerObject={decision.triggerObject} />
+              </div>
             </div>
-          </div>
-        </Page.Content>
-      </Page.Container>
+          </Page.Content>
+        </Page.Container>
+      </Page.Main>
     </DecisionRightPanel.Root>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -143,54 +143,56 @@ export default function Decisions() {
 
   return (
     <DecisionRightPanel.Root>
-      <Page.Container>
+      <Page.Main>
         <Page.Header>
           <Icon icon="decision" className="mr-2 size-6" />
           {t('navigation:decisions')}
         </Page.Header>
 
-        <Page.Content>
-          <div className="flex flex-col gap-4">
-            <DecisionFiltersProvider
-              scenarios={scenarios}
-              submitDecisionFilters={navigateDecisionList}
-              filterValues={filters}
-              hasPivots={hasPivots}
-              inboxes={inboxes}
-            >
-              <div className="flex justify-between gap-4">
-                <SearchById />
-                <div className="flex gap-4">
-                  <DecisionFiltersMenu filterNames={decisionFilterNames}>
-                    <FiltersButton />
-                  </DecisionFiltersMenu>
-                  <AddToCase
-                    hasSelection={hasSelection}
-                    getSelectedDecisions={getSelectedDecisions}
-                  />
+        <Page.Container>
+          <Page.Content>
+            <div className="flex flex-col gap-4">
+              <DecisionFiltersProvider
+                scenarios={scenarios}
+                submitDecisionFilters={navigateDecisionList}
+                filterValues={filters}
+                hasPivots={hasPivots}
+                inboxes={inboxes}
+              >
+                <div className="flex justify-between gap-4">
+                  <SearchById />
+                  <div className="flex gap-4">
+                    <DecisionFiltersMenu filterNames={decisionFilterNames}>
+                      <FiltersButton />
+                    </DecisionFiltersMenu>
+                    <AddToCase
+                      hasSelection={hasSelection}
+                      getSelectedDecisions={getSelectedDecisions}
+                    />
+                  </div>
                 </div>
-              </div>
-              <DecisionFiltersBar />
-              <DecisionsList
-                className="max-h-[60dvh]"
-                decisions={decisions}
-                selectable
-                selectionProps={selectionProps}
-                columnVisibility={{
-                  pivot_value: false,
-                }}
-              />
-              <CursorPaginationButtons
-                items={decisions}
-                onPaginationChange={(paginationParams: PaginationParams) =>
-                  navigateDecisionList(filters, paginationParams)
-                }
-                {...pagination}
-              />
-            </DecisionFiltersProvider>
-          </div>
-        </Page.Content>
-      </Page.Container>
+                <DecisionFiltersBar />
+                <DecisionsList
+                  className="max-h-[60dvh]"
+                  decisions={decisions}
+                  selectable
+                  selectionProps={selectionProps}
+                  columnVisibility={{
+                    pivot_value: false,
+                  }}
+                />
+                <CursorPaginationButtons
+                  items={decisions}
+                  onPaginationChange={(paginationParams: PaginationParams) =>
+                    navigateDecisionList(filters, paginationParams)
+                  }
+                  {...pagination}
+                />
+              </DecisionFiltersProvider>
+            </div>
+          </Page.Content>
+        </Page.Container>
+      </Page.Main>
     </DecisionRightPanel.Root>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -1,4 +1,4 @@
-import { Callout, ErrorComponent, Page } from '@app-builder/components';
+import { ErrorComponent, Page } from '@app-builder/components';
 import { DeleteList } from '@app-builder/routes/ressources+/lists+/delete';
 import { EditList } from '@app-builder/routes/ressources+/lists+/edit';
 import { NewListValue } from '@app-builder/routes/ressources+/lists+/value_create';
@@ -113,13 +113,11 @@ export default function Lists() {
     getSortedRowModel: getSortedRowModel(),
   });
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
-        <div className="flex w-full flex-row items-center justify-between gap-4">
-          <div className="flex flex-row items-center gap-4">
-            <Page.BackButton />
-            <span className="line-clamp-2 text-left">{customList.name}</span>
-          </div>
+        <div className="flex w-full flex-row items-center gap-4">
+          <Page.BackButton />
+          <span className="line-clamp-2 text-left">{customList.name}</span>
           {listFeatureAccess.isEditListAvailable ? (
             <EditList
               listId={customList.id}
@@ -129,47 +127,47 @@ export default function Lists() {
           ) : null}
         </div>
       </Page.Header>
-      <Page.Content className="max-w-3xl">
-        <Callout className="w-full" variant="outlined">
-          {customList.description}
-        </Callout>
-        {/* <ScenariosList scenarios={scenarios} /> */}
-        <div className="flex flex-col gap-2 overflow-hidden lg:gap-4">
-          <div className="flex flex-row gap-2 lg:gap-4">
-            <form className="flex grow items-center">
-              <Input
-                className="w-full"
-                disabled={listValues.length === 0}
-                type="search"
-                aria-label={t('common:search')}
-                placeholder={t('common:search')}
-                startAdornment="search"
-                onChange={(event) => {
-                  virtualTable.table.setGlobalFilter(event.target.value);
-                }}
-              />
-            </form>
-            {listFeatureAccess.isCreateListValueAvailable ? (
-              <NewListValue listId={customList.id} />
-            ) : null}
-          </div>
-          {virtualTable.isEmpty ? (
-            <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
-              <p className="text-s font-medium">
-                {listValues.length > 0
-                  ? t('lists:empty_custom_list_matches')
-                  : t('lists:empty_custom_list_values_list')}
-              </p>
+      <Page.Container>
+        <Page.Description>{customList.description}</Page.Description>
+        <Page.Content className="max-w-screen-xl">
+          {/* <ScenariosList scenarios={scenarios} /> */}
+          <div className="flex flex-col gap-2 overflow-hidden lg:gap-4">
+            <div className="flex flex-row gap-2 lg:gap-4">
+              <form className="flex grow items-center">
+                <Input
+                  className="w-full"
+                  disabled={listValues.length === 0}
+                  type="search"
+                  aria-label={t('common:search')}
+                  placeholder={t('common:search')}
+                  startAdornment="search"
+                  onChange={(event) => {
+                    virtualTable.table.setGlobalFilter(event.target.value);
+                  }}
+                />
+              </form>
+              {listFeatureAccess.isCreateListValueAvailable ? (
+                <NewListValue listId={customList.id} />
+              ) : null}
             </div>
-          ) : (
-            <Table.Default {...virtualTable}></Table.Default>
-          )}
-        </div>
-        {listFeatureAccess.isDeleteListAvailable ? (
-          <DeleteList listId={customList.id} />
-        ) : null}
-      </Page.Content>
-    </Page.Container>
+            {virtualTable.isEmpty ? (
+              <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
+                <p className="text-s font-medium">
+                  {listValues.length > 0
+                    ? t('lists:empty_custom_list_matches')
+                    : t('lists:empty_custom_list_values_list')}
+                </p>
+              </div>
+            ) : (
+              <Table.Default {...virtualTable}></Table.Default>
+            )}
+          </div>
+          {listFeatureAccess.isDeleteListAvailable ? (
+            <DeleteList listId={customList.id} />
+          ) : null}
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 export function ErrorBoundary() {

--- a/packages/app-builder/src/routes/_builder+/lists+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/_index.tsx
@@ -74,49 +74,51 @@ export default function ListsPage() {
     });
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="lists" className="mr-2 size-6" />
         {t('navigation:lists')}
       </Page.Header>
-      <Page.Content>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-row justify-end">
-            {isCreateListAvailable ? <CreateList /> : null}
-          </div>
-          {isEmpty ? (
-            <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
-              <p className="text-s font-medium">
-                {t('lists:empty_custom_lists_list')}
-              </p>
+      <Page.Container>
+        <Page.Content className="max-w-screen-xl">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-row justify-end">
+              {isCreateListAvailable ? <CreateList /> : null}
             </div>
-          ) : (
-            <Table.Container
-              {...getContainerProps()}
-              className="bg-grey-00 max-h-[70dvh]"
-            >
-              <Table.Header headerGroups={table.getHeaderGroups()} />
-              <Table.Body {...getBodyProps()}>
-                {rows.map((row) => (
-                  <Table.Row
-                    key={row.id}
-                    className="hover:bg-purple-05 cursor-pointer"
-                    row={row}
-                    onClick={() => {
-                      navigate(
-                        getRoute('/lists/:listId', {
-                          listId: fromUUID(row.original.id),
-                        }),
-                      );
-                    }}
-                  />
-                ))}
-              </Table.Body>
-            </Table.Container>
-          )}
-        </div>
-      </Page.Content>
-    </Page.Container>
+            {isEmpty ? (
+              <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
+                <p className="text-s font-medium">
+                  {t('lists:empty_custom_lists_list')}
+                </p>
+              </div>
+            ) : (
+              <Table.Container
+                {...getContainerProps()}
+                className="bg-grey-00 max-h-[70dvh]"
+              >
+                <Table.Header headerGroups={table.getHeaderGroups()} />
+                <Table.Body {...getBodyProps()}>
+                  {rows.map((row) => (
+                    <Table.Row
+                      key={row.id}
+                      className="hover:bg-purple-05 cursor-pointer"
+                      row={row}
+                      onClick={() => {
+                        navigate(
+                          getRoute('/lists/:listId', {
+                            listId: fromUUID(row.original.id),
+                          }),
+                        );
+                      }}
+                    />
+                  ))}
+                </Table.Body>
+              </Table.Container>
+            )}
+          </div>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 export function ErrorBoundary() {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
@@ -101,7 +101,7 @@ export default function ScenarioEditLayout() {
     isCreateDraftAvailable && currentIteration.type !== 'draft';
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between gap-4">
         <div className="flex flex-row items-center gap-4">
           <Page.BackLink to={getRoute('/scenarios/')} />
@@ -159,56 +159,58 @@ export default function ScenarioEditLayout() {
           ) : null}
         </div>
       </Page.Header>
-      <Page.Content>
-        <nav>
-          <ul className="flex flex-row gap-2">
-            <li>
-              <TabLink
-                aria-invalid={hasTriggerErrors(scenarioValidation)}
-                labelTKey="navigation:scenario.trigger"
-                to="./trigger"
-                Icon={(props) => (
-                  <ScenariosLinkIcon
-                    {...props}
-                    icon="trigger"
-                    withPing={hasTriggerErrors(scenarioValidation)}
-                  />
-                )}
-              />
-            </li>
-            <li>
-              <TabLink
-                aria-invalid={hasRulesErrors(scenarioValidation)}
-                labelTKey="navigation:scenario.rules"
-                to="./rules"
-                Icon={(props) => (
-                  <ScenariosLinkIcon
-                    {...props}
-                    icon="rules"
-                    withPing={hasRulesErrors(scenarioValidation)}
-                  />
-                )}
-              />
-            </li>
-            <li>
-              <TabLink
-                aria-invalid={hasDecisionErrors(scenarioValidation)}
-                labelTKey="navigation:scenario.decision"
-                to="./decision"
-                Icon={(props) => (
-                  <ScenariosLinkIcon
-                    {...props}
-                    icon="decision"
-                    withPing={hasDecisionErrors(scenarioValidation)}
-                  />
-                )}
-              />
-            </li>
-          </ul>
-        </nav>
-        <Outlet />
-      </Page.Content>
-    </Page.Container>
+      <Page.Container>
+        <Page.Content>
+          <nav>
+            <ul className="flex flex-row gap-2">
+              <li>
+                <TabLink
+                  aria-invalid={hasTriggerErrors(scenarioValidation)}
+                  labelTKey="navigation:scenario.trigger"
+                  to="./trigger"
+                  Icon={(props) => (
+                    <ScenariosLinkIcon
+                      {...props}
+                      icon="trigger"
+                      withPing={hasTriggerErrors(scenarioValidation)}
+                    />
+                  )}
+                />
+              </li>
+              <li>
+                <TabLink
+                  aria-invalid={hasRulesErrors(scenarioValidation)}
+                  labelTKey="navigation:scenario.rules"
+                  to="./rules"
+                  Icon={(props) => (
+                    <ScenariosLinkIcon
+                      {...props}
+                      icon="rules"
+                      withPing={hasRulesErrors(scenarioValidation)}
+                    />
+                  )}
+                />
+              </li>
+              <li>
+                <TabLink
+                  aria-invalid={hasDecisionErrors(scenarioValidation)}
+                  labelTKey="navigation:scenario.decision"
+                  to="./decision"
+                  Icon={(props) => (
+                    <ScenariosLinkIcon
+                      {...props}
+                      icon="decision"
+                      withPing={hasDecisionErrors(scenarioValidation)}
+                    />
+                  )}
+                />
+              </li>
+            </ul>
+          </nav>
+          <Outlet />
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -226,7 +226,7 @@ export default function RuleDetail() {
   };
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
@@ -240,22 +240,23 @@ export default function RuleDetail() {
           ) : null}
         </div>
       </Page.Header>
-
-      {editorMode === 'view' ? (
-        <RuleViewContent
-          options={options}
-          astEditorStore={astEditorStore}
-          rule={rule}
-        />
-      ) : (
-        <RuleEditContent
-          options={options}
-          astEditorStore={astEditorStore}
-          rule={rule}
-          scenarioId={scenarioId}
-        />
-      )}
-    </Page.Container>
+      <Page.Container>
+        {editorMode === 'view' ? (
+          <RuleViewContent
+            options={options}
+            astEditorStore={astEditorStore}
+            rule={rule}
+          />
+        ) : (
+          <RuleEditContent
+            options={options}
+            astEditorStore={astEditorStore}
+            rule={rule}
+            scenarioId={scenarioId}
+          />
+        )}
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/scenarios+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/_index.tsx
@@ -31,58 +31,63 @@ export default function ScenariosPage() {
   const { scenarios } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="scenarios" className="mr-2 size-6" />
         {t('navigation:scenarios')}
       </Page.Header>
-      <Page.Content>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-row justify-end">
-            <CreateScenario>
-              <Button>
-                <Icon icon="plus" className="size-6" aria-hidden />
-                {t('scenarios:create_scenario.title')}
-              </Button>
-            </CreateScenario>
-          </div>
-          <div className="flex max-w-3xl flex-col gap-2 lg:gap-4">
-            {scenarios.length ? (
-              scenarios.map((scenario) => {
-                return (
-                  <Link
-                    key={scenario.id}
-                    to={getRoute('/scenarios/:scenarioId', {
-                      scenarioId: fromUUID(scenario.id),
-                    })}
-                  >
-                    <div className="bg-grey-00 border-grey-10 flex flex-col gap-1 rounded-lg border border-solid p-4 hover:shadow-md">
-                      <div className="text-m flex flex-row gap-2 font-bold">
-                        {scenario.name}
-                        {scenario.liveVersionId ? (
-                          <Tag color="purple" className="capitalize">
-                            {t('scenarios:live')}
-                          </Tag>
-                        ) : null}
+      <Page.Container>
+        <Page.Description>
+          {t('scenarios:scenarios.description')}
+        </Page.Description>
+        <Page.Content className="max-w-3xl">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-row justify-end">
+              <CreateScenario>
+                <Button>
+                  <Icon icon="plus" className="size-6" aria-hidden />
+                  {t('scenarios:create_scenario.title')}
+                </Button>
+              </CreateScenario>
+            </div>
+            <div className="flex flex-col gap-2 lg:gap-4">
+              {scenarios.length ? (
+                scenarios.map((scenario) => {
+                  return (
+                    <Link
+                      key={scenario.id}
+                      to={getRoute('/scenarios/:scenarioId', {
+                        scenarioId: fromUUID(scenario.id),
+                      })}
+                    >
+                      <div className="bg-grey-00 border-grey-10 flex flex-col gap-1 rounded-lg border border-solid p-4 hover:shadow-md">
+                        <div className="text-m flex flex-row gap-2 font-bold">
+                          {scenario.name}
+                          {scenario.liveVersionId ? (
+                            <Tag color="purple" className="capitalize">
+                              {t('scenarios:live')}
+                            </Tag>
+                          ) : null}
+                        </div>
+                        <p className="text-s line-clamp-2 font-medium">
+                          {scenario.description}
+                        </p>
                       </div>
-                      <p className="text-s line-clamp-2 font-medium">
-                        {scenario.description}
-                      </p>
-                    </div>
-                  </Link>
-                );
-              })
-            ) : (
-              <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
-                <p className="text-s font-medium">
-                  {t('scenarios:empty_scenario_list')}
-                </p>
-              </div>
-            )}
+                    </Link>
+                  );
+                })
+              ) : (
+                <div className="bg-grey-00 border-grey-10 flex h-28 max-w-3xl flex-col items-center justify-center rounded-lg border border-solid p-4">
+                  <p className="text-s font-medium">
+                    {t('scenarios:empty_scenario_list')}
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      </Page.Content>
-    </Page.Container>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/scheduled-executions.tsx
+++ b/packages/app-builder/src/routes/_builder+/scheduled-executions.tsx
@@ -35,16 +35,18 @@ export default function ScheduledExecutions() {
   const { scheduledExecutions } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="scheduled-execution" className="mr-2 size-6" />
         {t('navigation:scheduledExecutions')}
       </Page.Header>
 
-      <Page.Content>
-        <ScheduledExecutionsList scheduledExecutions={scheduledExecutions} />
-      </Page.Content>
-    </Page.Container>
+      <Page.Container>
+        <Page.Content>
+          <ScheduledExecutionsList scheduledExecutions={scheduledExecutions} />
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
@@ -80,53 +80,55 @@ export default function Settings() {
   const { sections } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="settings" className="mr-2 size-6" />
         {t('navigation:settings')}
       </Page.Header>
       <div className="flex size-full flex-row overflow-hidden">
-        <div className="border-r-grey-10 bg-grey-00 flex h-full w-fit min-w-[200px] flex-col border-r p-4">
-          {sections.map(([section, settings]) => {
-            if (settings.length === 0) return null;
+        <div className="border-r-grey-10 bg-grey-00 flex h-full w-fit min-w-[200px] flex-col overflow-y-auto border-r p-4">
+          <div className="flex flex-col">
+            {sections.map(([section, settings]) => {
+              if (settings.length === 0) return null;
 
-            const icon =
-              section === 'users'
-                ? 'users'
-                : section === 'case_manager'
-                  ? 'case-manager'
-                  : 'world';
+              const icon =
+                section === 'users'
+                  ? 'users'
+                  : section === 'case_manager'
+                    ? 'case-manager'
+                    : 'world';
 
-            return (
-              <nav key={section} className="flex flex-col gap-4">
-                <div className="flex flex-row items-center gap-2">
-                  <Icon icon={icon} className="size-5" />
-                  <p className="font-bold">{t(`settings:${section}`)}</p>
-                </div>
-                <ul className="flex flex-col gap-1 pb-6">
-                  {settings.map((setting) => (
-                    <NavLink
-                      key={setting.title}
-                      className={({ isActive }) =>
-                        clsx(
-                          'text-s flex w-full cursor-pointer flex-row rounded p-2 font-medium first-letter:capitalize',
-                          isActive
-                            ? 'bg-purple-10 text-purple-100'
-                            : 'bg-grey-00 text-grey-100 hover:bg-purple-10 hover:text-purple-100',
-                        )
-                      }
-                      to={setting.to}
-                    >
-                      {t(`settings:${setting.title}`)}
-                    </NavLink>
-                  ))}
-                </ul>
-              </nav>
-            );
-          })}
+              return (
+                <nav key={section} className="flex flex-col gap-4">
+                  <div className="flex flex-row items-center gap-2">
+                    <Icon icon={icon} className="size-5" />
+                    <p className="font-bold">{t(`settings:${section}`)}</p>
+                  </div>
+                  <ul className="flex flex-col gap-1 pb-6">
+                    {settings.map((setting) => (
+                      <NavLink
+                        key={setting.title}
+                        className={({ isActive }) =>
+                          clsx(
+                            'text-s flex w-full cursor-pointer flex-row rounded p-2 font-medium first-letter:capitalize',
+                            isActive
+                              ? 'bg-purple-10 text-purple-100'
+                              : 'bg-grey-00 text-grey-100 hover:bg-purple-10 hover:text-purple-100',
+                          )
+                        }
+                        to={setting.to}
+                      >
+                        {t(`settings:${setting.title}`)}
+                      </NavLink>
+                    ))}
+                  </ul>
+                </nav>
+              );
+            })}
+          </div>
         </div>
         <Outlet />
       </div>
-    </Page.Container>
+    </Page.Main>
   );
 }

--- a/packages/app-builder/src/routes/_builder+/settings+/api-keys.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/api-keys.tsx
@@ -13,7 +13,6 @@ import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Table, useTable } from 'ui-design-system';
@@ -113,7 +112,7 @@ export default function ApiKeys() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         {createdApiKey ? <CreatedAPIKey createdApiKey={createdApiKey} /> : null}
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
@@ -129,7 +128,7 @@ export default function ApiKeys() {
                     <Table.Row
                       key={row.id}
                       tabIndex={0}
-                      className={clsx('hover:bg-purple-05 group')}
+                      className="hover:bg-purple-05 group"
                       row={row}
                     />
                   );

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
@@ -16,7 +16,6 @@ import {
   getCoreRowModel,
   getSortedRowModel,
 } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import { type InboxUserDto } from 'marble-api';
 import { useMemo } from 'react';
@@ -139,7 +138,7 @@ export default function Inbox() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
             <span className="flex-1">
@@ -189,9 +188,7 @@ export default function Inbox() {
                     <Table.Row
                       key={row.id}
                       tabIndex={0}
-                      className={clsx(
-                        'hover:bg-purple-05 group cursor-pointer',
-                      )}
+                      className="hover:bg-purple-05 group cursor-pointer"
                       row={row}
                     />
                   );

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
@@ -10,7 +10,6 @@ import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData, useNavigate } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
@@ -85,7 +84,7 @@ export default function Inboxes() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
             <span className="flex-1">{t('settings:inboxes')}</span>
@@ -102,7 +101,7 @@ export default function Inboxes() {
                     <Table.Row
                       key={row.id}
                       tabIndex={0}
-                      className={clsx('hover:bg-purple-05 cursor-pointer')}
+                      className="hover:bg-purple-05 cursor-pointer"
                       row={row}
                       onClick={() => {
                         navigate(

--- a/packages/app-builder/src/routes/_builder+/settings+/tags.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/tags.tsx
@@ -7,7 +7,6 @@ import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { type Tag } from 'marble-api';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -99,7 +98,7 @@ export default function Tags() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
             <span className="flex-1">{t('settings:tags')}</span>
@@ -114,7 +113,7 @@ export default function Tags() {
                     <Table.Row
                       key={row.id}
                       tabIndex={0}
-                      className={clsx('hover:bg-purple-05 group')}
+                      className="hover:bg-purple-05 group"
                       row={row}
                     />
                   );

--- a/packages/app-builder/src/routes/_builder+/settings+/users.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/users.tsx
@@ -9,7 +9,6 @@ import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
@@ -152,7 +151,7 @@ export default function Users() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
             <span className="flex-1">{t('settings:users')}</span>
@@ -169,7 +168,7 @@ export default function Users() {
                     <Table.Row
                       key={row.id}
                       tabIndex={0}
-                      className={clsx('hover:bg-purple-05 group')}
+                      className="hover:bg-purple-05 group"
                       row={row}
                     />
                   );

--- a/packages/app-builder/src/routes/_builder+/settings+/webhooks.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/webhooks.tsx
@@ -9,7 +9,6 @@ import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -101,7 +100,7 @@ export default function Webhooks() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
             <span className="flex-1">{t('settings:webhooks')}</span>
@@ -139,7 +138,7 @@ export default function Webhooks() {
                     <Table.Row
                       key={row.id}
                       tabIndex={0}
-                      className={clsx('hover:bg-purple-05 cursor-pointer')}
+                      className="hover:bg-purple-05 cursor-pointer"
                       row={row}
                     />
                   );

--- a/packages/app-builder/src/routes/_builder+/settings+/webhooks_.$webhookId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/webhooks_.$webhookId.tsx
@@ -14,7 +14,6 @@ import {
   getCoreRowModel,
   getSortedRowModel,
 } from '@tanstack/react-table';
-import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -62,7 +61,7 @@ export default function WebhookDetail() {
 
   return (
     <Page.Container>
-      <Page.Content>
+      <Page.Content className="max-w-screen-xl">
         <CollapsiblePaper.Container>
           <CollapsiblePaper.Title>
             <span className="flex-1">{t('settings:webhook_details')}</span>
@@ -221,7 +220,7 @@ function WebhookSecrets({ secrets }: { secrets: WebhookSecret[] }) {
             <Table.Row
               key={row.id}
               tabIndex={0}
-              className={clsx('relative')}
+              className="relative"
               row={row}
             />
           );

--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -1,4 +1,4 @@
-import { Callout, Page, Paper } from '@app-builder/components';
+import { Page, Paper } from '@app-builder/components';
 import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { type TableModel } from '@app-builder/models';
 import { useBackendInfo } from '@app-builder/services/auth/auth.client';
@@ -387,50 +387,54 @@ export default function Upload() {
   const { objectType, table, uploadLogs } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="upload" className="mr-2 size-6" />
         {t('upload:upload_cta', { replace: { objectType } })}
       </Page.Header>
-      <Page.Content>
-        <Callout className="whitespace-normal" variant="outlined">
-          <div className="leading-8">
-            <p className="whitespace-pre text-wrap">
-              <Trans
-                t={t}
-                i18nKey="upload:upload_callout_1"
-                components={{
-                  DocLink: <ExternalLink href={ingestingDataByCsvDocHref} />,
-                }}
-                values={{ objectType }}
-              />
-            </p>
-            <p>{t('upload:upload_callout_2')}</p>
+      <Page.Container>
+        <Page.Description>
+          <p className="whitespace-pre text-wrap">
+            <Trans
+              t={t}
+              i18nKey="upload:upload_callout_1"
+              components={{
+                DocLink: <ExternalLink href={ingestingDataByCsvDocHref} />,
+              }}
+              values={{ objectType }}
+            />
+            <br />
+            {t('upload:upload_callout_2')}
+          </p>
+        </Page.Description>
+
+        <Page.Content>
+          <div className="flex">
+            <ClientOnly fallback={<LoadingButton />}>
+              {() => (
+                <a
+                  href={generateCsvTemplateLink(table)}
+                  download={`${objectType}_template.csv`}
+                  className={clsx(
+                    'text-s flex flex-row items-center justify-center gap-1 rounded border border-solid px-4 py-2 font-semibold outline-none',
+                    'hover:bg-grey-05 active:bg-grey-10 bg-grey-00 border-grey-10 text-grey-100 disabled:text-grey-50 disabled:border-grey-05 disabled:bg-grey-05 focus:border-purple-100',
+                  )}
+                >
+                  <Icon icon="download" className="mr-2 size-6" />
+                  {t('upload:download_template_cta')}
+                </a>
+              )}
+            </ClientOnly>
           </div>
-        </Callout>
-        <div className="flex">
-          <ClientOnly fallback={<LoadingButton />}>
-            {() => (
-              <a
-                href={generateCsvTemplateLink(table)}
-                download={`${objectType}_template.csv`}
-                className={clsx(
-                  'text-s flex flex-row items-center justify-center gap-1 rounded border border-solid px-4 py-2 font-semibold outline-none',
-                  'hover:bg-grey-05 active:bg-grey-10 bg-grey-00 border-grey-10 text-grey-100 disabled:text-grey-50 disabled:border-grey-05 disabled:bg-grey-05 focus:border-purple-100',
-                )}
-              >
-                <Icon icon="download" className="mr-2 size-6" />
-                {t('upload:download_template_cta')}
-              </a>
-            )}
+          <ClientOnly fallback={<Loading />}>
+            {() => <UploadForm objectType={objectType} />}
           </ClientOnly>
-        </div>
-        <ClientOnly fallback={<Loading />}>
-          {() => <UploadForm objectType={objectType} />}
-        </ClientOnly>
-        {uploadLogs.length > 0 ? <PastUploads uploadLogs={uploadLogs} /> : null}
-      </Page.Content>
-    </Page.Container>
+          {uploadLogs.length > 0 ? (
+            <PastUploads uploadLogs={uploadLogs} />
+          ) : null}
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/workflows+/$scenarioId.tsx
+++ b/packages/app-builder/src/routes/_builder+/workflows+/$scenarioId.tsx
@@ -137,7 +137,7 @@ export default function Workflow() {
   };
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
@@ -159,7 +159,7 @@ export default function Workflow() {
           <DetailPanel onDelete={deleteWorkflow} onSave={saveWorkflow} />
         </div>
       </WorkflowProvider>
-    </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/_builder+/workflows+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/workflows+/_index.tsx
@@ -1,6 +1,5 @@
 import {
   adaptOffsetPaginationButtonsProps,
-  Callout,
   ErrorComponent,
   OffsetPaginationButtons,
   Page,
@@ -162,13 +161,13 @@ export default function WorkflowsPage() {
   });
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="rule-settings" className="mr-2 size-6" />
         {t('navigation:workflows')}
       </Page.Header>
-      <Page.Content className="max-w-screen-lg">
-        <Callout className="w-full" variant="outlined">
+      <Page.Container>
+        <Page.Description>
           <p className="whitespace-pre text-wrap">
             <Trans
               t={t}
@@ -178,61 +177,63 @@ export default function WorkflowsPage() {
               }}
             />
           </p>
-        </Callout>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2 lg:gap-4">
-            <div className="flex flex-row gap-2 lg:gap-4">
-              <form className="flex grow items-center">
-                <Input
-                  className="w-full max-w-md"
-                  disabled={scenarios.length === 0}
-                  type="search"
-                  aria-label={t('common:search')}
-                  placeholder={t('common:search')}
-                  startAdornment="search"
-                  onChange={(event) => {
-                    table.setGlobalFilter(event.target.value);
-                  }}
-                />
-              </form>
-            </div>
-            {rows.length === 0 ? (
-              <div className="bg-grey-00 border-grey-10 flex h-28 flex-col items-center justify-center rounded-lg border border-solid p-4">
-                <p className="text-s font-medium">
-                  {scenarios.length === 0
-                    ? t('workflows:no_scenarios')
-                    : t('workflows:no_matching_scenarios')}
-                </p>
+        </Page.Description>
+        <Page.Content className="max-w-screen-xl">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2 lg:gap-4">
+              <div className="flex flex-row gap-2 lg:gap-4">
+                <form className="flex grow items-center">
+                  <Input
+                    className="w-full max-w-md"
+                    disabled={scenarios.length === 0}
+                    type="search"
+                    aria-label={t('common:search')}
+                    placeholder={t('common:search')}
+                    startAdornment="search"
+                    onChange={(event) => {
+                      table.setGlobalFilter(event.target.value);
+                    }}
+                  />
+                </form>
               </div>
-            ) : (
-              <>
-                <Table.Container
-                  {...getContainerProps()}
-                  className="bg-grey-00"
-                >
-                  <Table.Header headerGroups={table.getHeaderGroups()} />
-                  <Table.Body {...getBodyProps()}>
-                    {rows.map((row) => {
-                      return (
-                        <Table.Row
-                          key={row.id}
-                          tabIndex={0}
-                          className="hover:bg-purple-05 cursor-pointer"
-                          row={row}
-                        />
-                      );
-                    })}
-                  </Table.Body>
-                </Table.Container>
-                <OffsetPaginationButtons
-                  {...adaptOffsetPaginationButtonsProps(table)}
-                />
-              </>
-            )}
+              {rows.length === 0 ? (
+                <div className="bg-grey-00 border-grey-10 flex h-28 flex-col items-center justify-center rounded-lg border border-solid p-4">
+                  <p className="text-s font-medium">
+                    {scenarios.length === 0
+                      ? t('workflows:no_scenarios')
+                      : t('workflows:no_matching_scenarios')}
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <Table.Container
+                    {...getContainerProps()}
+                    className="bg-grey-00"
+                  >
+                    <Table.Header headerGroups={table.getHeaderGroups()} />
+                    <Table.Body {...getBodyProps()}>
+                      {rows.map((row) => {
+                        return (
+                          <Table.Row
+                            key={row.id}
+                            tabIndex={0}
+                            className="hover:bg-purple-05 cursor-pointer"
+                            row={row}
+                          />
+                        );
+                      })}
+                    </Table.Body>
+                  </Table.Container>
+                  <OffsetPaginationButtons
+                    {...adaptOffsetPaginationButtonsProps(table)}
+                  />
+                </>
+              )}
+            </div>
           </div>
-        </div>
-      </Page.Content>
-    </Page.Container>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/transfercheck+/_layout.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/_layout.tsx
@@ -9,9 +9,9 @@ import {
   useTransfercheckResources,
 } from '@app-builder/components/HelpCenter';
 import {
-  Header,
-  ToggleHeader,
-} from '@app-builder/components/Layout/MainLayout';
+  LeftSidebar,
+  ToggleSidebar,
+} from '@app-builder/components/Layout/LeftSidebar';
 import { UserInfo } from '@app-builder/components/UserInfo';
 import { isMarbleAdmin, isTransferCheckUser } from '@app-builder/models';
 import { useRefreshToken } from '@app-builder/routes/ressources+/auth+/refresh';
@@ -86,7 +86,7 @@ export default function Builder() {
 
   return (
     <div className="flex h-full flex-1 flex-row overflow-hidden">
-      <Header>
+      <LeftSidebar>
         <div className="h-24 px-2 pt-3">
           <UserInfo
             email={user.actorIdentity.email}
@@ -158,11 +158,11 @@ export default function Builder() {
               </ChatlioProvider>
             </li>
             <li>
-              <ToggleHeader />
+              <ToggleSidebar />
             </li>
           </ul>
         </nav>
-      </Header>
+      </LeftSidebar>
 
       <Outlet />
     </div>

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/_.received.$alertId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/_.received.$alertId.tsx
@@ -62,7 +62,7 @@ export default function ReceivedAlertDetailPage() {
   const { alert } = useLoaderData<typeof loader>();
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
@@ -78,8 +78,8 @@ export default function ReceivedAlertDetailPage() {
         </div>
       </Page.Header>
 
-      <Page.Content>
-        <div className="flex max-w-3xl flex-col gap-4 lg:gap-6">
+      <Page.Container>
+        <Page.Content className="max-w-3xl">
           <Collapsible.Container className="bg-grey-00 w-full">
             <Collapsible.Title>
               {t('transfercheck:alert_detail.alert_data.title')}
@@ -88,9 +88,9 @@ export default function ReceivedAlertDetailPage() {
               <AlertData alert={alert} />
             </Collapsible.Content>
           </Collapsible.Container>
-        </div>
-      </Page.Content>
-    </Page.Container>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/_.sent.$alertId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/_.sent.$alertId.tsx
@@ -69,7 +69,7 @@ export default function SentAlertDetailPage() {
   const { color, tKey } = alertStatusMapping[alert.status];
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
@@ -89,8 +89,8 @@ export default function SentAlertDetailPage() {
         </div>
       </Page.Header>
 
-      <Page.Content>
-        <div className="flex max-w-3xl flex-col gap-4 lg:gap-6">
+      <Page.Container>
+        <Page.Content className="max-w-3xl">
           <Collapsible.Container className="bg-grey-00 w-full">
             <Collapsible.Title>
               {t('transfercheck:alert_detail.alert_data.title')}
@@ -117,9 +117,9 @@ export default function SentAlertDetailPage() {
               </div>
             </Collapsible.Content>
           </Collapsible.Container>
-        </div>
-      </Page.Content>
-    </Page.Container>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/_layout.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/_layout.tsx
@@ -14,33 +14,35 @@ export default function AlertsPage() {
   const { t } = useTranslation(handle.i18n);
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="notifications" className="mr-2 size-6" />
         {t('navigation:transfercheck.alerts')}
       </Page.Header>
 
-      <Page.Content className="max-w-3xl">
-        <nav className="bg-grey-00 border-grey-10 w-fit rounded border p-1">
-          <ul className="flex flex-row gap-2">
-            <li>
-              <TabLink
-                labelTKey="navigation:transfercheck.alerts.received"
-                to={getRoute('/transfercheck/alerts/received')}
-                Icon={(props) => <Icon {...props} icon="inbox" />}
-              />
-            </li>
-            <li>
-              <TabLink
-                labelTKey="navigation:transfercheck.alerts.sent"
-                to={getRoute('/transfercheck/alerts/sent')}
-                Icon={(props) => <Icon {...props} icon="send" />}
-              />
-            </li>
-          </ul>
-        </nav>
-        <Outlet />
-      </Page.Content>
-    </Page.Container>
+      <Page.Container>
+        <Page.Content className="max-w-3xl">
+          <nav className="bg-grey-00 border-grey-10 w-fit rounded border p-1">
+            <ul className="flex flex-row gap-2">
+              <li>
+                <TabLink
+                  labelTKey="navigation:transfercheck.alerts.received"
+                  to={getRoute('/transfercheck/alerts/received')}
+                  Icon={(props) => <Icon {...props} icon="inbox" />}
+                />
+              </li>
+              <li>
+                <TabLink
+                  labelTKey="navigation:transfercheck.alerts.sent"
+                  to={getRoute('/transfercheck/alerts/sent')}
+                  Icon={(props) => <Icon {...props} icon="send" />}
+                />
+              </li>
+            </ul>
+          </nav>
+          <Outlet />
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }

--- a/packages/app-builder/src/routes/transfercheck+/transfers+/$transferId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/transfers+/$transferId.tsx
@@ -125,7 +125,7 @@ export default function TransferDetailPage() {
   });
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header className="justify-between">
         <div className="flex flex-row items-center gap-4">
           <Page.BackButton />
@@ -139,9 +139,8 @@ export default function TransferDetailPage() {
           </CopyToClipboardButton>
         </div>
       </Page.Header>
-
-      <Page.Content>
-        <div className="flex max-w-3xl flex-col gap-4 lg:gap-6">
+      <Page.Container>
+        <Page.Content className="max-w-3xl">
           <Collapsible.Container className="bg-grey-00 w-full">
             <Collapsible.Title>
               {t('transfercheck:transfer_detail.transfer_status.title')}
@@ -185,9 +184,9 @@ export default function TransferDetailPage() {
               <TransferData {...transfer.data} />
             </Collapsible.Content>
           </Collapsible.Container>
-        </div>
-      </Page.Content>
-    </Page.Container>
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }
 

--- a/packages/app-builder/src/routes/transfercheck+/transfers+/_index.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/transfers+/_index.tsx
@@ -62,34 +62,35 @@ export default function TransfersPage() {
   const [query, setQuery] = React.useState(transferId || '');
 
   return (
-    <Page.Container>
+    <Page.Main>
       <Page.Header>
         <Icon icon="arrows-right-left" className="mr-2 size-6" />
         {t('navigation:transfercheck.transfers')}
       </Page.Header>
-
-      <Page.Content className="max-w-3xl">
-        <Form
-          id="search-form"
-          onChange={(event) => submit(event.currentTarget, { replace: true })}
-          role="search"
-        >
-          <div className="flex flex-row items-center gap-2">
-            <Input
-              className="w-full max-w-lg"
-              type="search"
-              aria-label={t('transfercheck:transfer.search.placeholder')}
-              placeholder={t('transfercheck:transfer.search.placeholder')}
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              startAdornment="search"
-              name="transferId"
-            />
-            <Spinner className={clsx('size-6', !isLoading && 'hidden')} />
-          </div>
-        </Form>
-        <TransfersList transfers={transfers} />
-      </Page.Content>
-    </Page.Container>
+      <Page.Container>
+        <Page.Content className="max-w-3xl">
+          <Form
+            id="search-form"
+            onChange={(event) => submit(event.currentTarget, { replace: true })}
+            role="search"
+          >
+            <div className="flex flex-row items-center gap-2">
+              <Input
+                className="w-full max-w-lg"
+                type="search"
+                aria-label={t('transfercheck:transfer.search.placeholder')}
+                placeholder={t('transfercheck:transfer.search.placeholder')}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                startAdornment="search"
+                name="transferId"
+              />
+              <Spinner className={clsx('size-6', !isLoading && 'hidden')} />
+            </div>
+          </Form>
+          <TransfersList transfers={transfers} />
+        </Page.Content>
+      </Page.Container>
+    </Page.Main>
   );
 }


### PR DESCRIPTION
Boring but necessary refacto, to prepare for the new design layout (= with description just under the header)

NB: I tested every single screen to ensure no regression (and discovered some weird types on Transfercheck, due to the new table rows with alterne bg color)

<img width="1216" alt="Screenshot 2024-10-29 at 17 53 52" src="https://github.com/user-attachments/assets/4501e93e-8b5c-48bc-9615-a54637454e67">

Now, I do not use specific bg color for archived rows, I just filtered out those rows by default