### PR TITLE
WIP: isEmpty operator

### DIFF
--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AstBuilderNode.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AstBuilderNode.tsx
@@ -37,7 +37,6 @@ export function AstBuilderNode({
   onSave,
   root = false,
 }: AstBuilderNodeProps) {
-  console.log(astNode);
   if (isMainAstBinaryNode(astNode)) {
     return (
       <div className="flex w-full flex-col gap-2">

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AstBuilderNode.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/AstBuilderNode.tsx
@@ -1,4 +1,8 @@
-import { type AstNode, isTwoLineOperandAstNode } from '@app-builder/models';
+import {
+  type AstNode,
+  isMainAstBinaryNode,
+  isMainAstUnaryNode,
+} from '@app-builder/models';
 import {
   useEnumValuesFromNeighbour,
   useEvaluation,
@@ -12,8 +16,11 @@ import {
 import { useFormatReturnValue } from '@app-builder/services/editor/return-value';
 import * as React from 'react';
 
+import {
+  MainAstBinaryOperatorLine,
+  MainAstUnaryOperatorLine,
+} from './MainAstLine';
 import { Operand } from './Operand';
-import { TwoOperandsLine } from './TwoOperandsLine';
 
 interface AstBuilderNodeProps {
   treePath: string;
@@ -30,12 +37,26 @@ export function AstBuilderNode({
   onSave,
   root = false,
 }: AstBuilderNodeProps) {
-  if (isTwoLineOperandAstNode(astNode)) {
+  console.log(astNode);
+  if (isMainAstBinaryNode(astNode)) {
     return (
       <div className="flex w-full flex-col gap-2">
-        <TwoOperandsLine
+        <MainAstBinaryOperatorLine
           treePath={treePath}
-          twoLineOperandAstNode={astNode}
+          mainAstNode={astNode}
+          viewOnly={viewOnly}
+          root={root}
+        />
+      </div>
+    );
+  }
+
+  if (isMainAstUnaryNode(astNode)) {
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <MainAstUnaryOperatorLine
+          treePath={treePath}
+          mainAstNode={astNode}
           viewOnly={viewOnly}
           root={root}
         />

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/MainAstLine.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/MainAstLine.tsx
@@ -7,10 +7,6 @@ import {
   NewUndefinedAstNode,
 } from '@app-builder/models';
 import {
-  isBinaryMainAstOperatorFunction,
-  isUnaryMainAstOperatorFunction,
-} from '@app-builder/models/editable-operators';
-import {
   useAstNodeEditorActions,
   useEvaluationErrors,
 } from '@app-builder/services/editor/ast-editor';
@@ -39,8 +35,7 @@ export function MainAstBinaryOperatorLine({
   viewOnly?: boolean;
   root?: boolean;
 }) {
-  const { setAstNodeAtPath, setOperatorAtPath, remove } =
-    useAstNodeEditorActions();
+  const { setAstNodeAtPath, setOperatorAtPath } = useAstNodeEditorActions();
 
   function addNestedChild(stringPath: string, child: AstNode) {
     setAstNodeAtPath(stringPath, NewNestedChild(child));
@@ -79,9 +74,6 @@ export function MainAstBinaryOperatorLine({
           value={mainAstNode.name}
           setValue={(operator: (typeof operators)[number]) => {
             setOperatorAtPath(treePath, operator);
-            if (isUnaryMainAstOperatorFunction(operator)) {
-              remove(rightPath);
-            }
           }}
           validationStatus={evaluationErrors.length > 0 ? 'error' : 'valid'}
           viewOnly={viewOnly}
@@ -121,8 +113,7 @@ export function MainAstUnaryOperatorLine({
   viewOnly?: boolean;
   root?: boolean;
 }) {
-  const { setAstNodeAtPath, setOperatorAtPath, appendChild } =
-    useAstNodeEditorActions();
+  const { setAstNodeAtPath, setOperatorAtPath } = useAstNodeEditorActions();
 
   const operators = useMainAstOperatorFunctions();
 
@@ -147,9 +138,6 @@ export function MainAstUnaryOperatorLine({
           value={mainAstNode.name}
           setValue={(operator: (typeof operators)[number]) => {
             setOperatorAtPath(treePath, operator);
-            if (isBinaryMainAstOperatorFunction(operator)) {
-              appendChild(treePath, NewUndefinedAstNode());
-            }
           }}
           validationStatus={evaluationErrors.length > 0 ? 'error' : 'valid'}
           viewOnly={viewOnly}

--- a/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/MainAstLine.tsx
+++ b/packages/app-builder/src/components/Scenario/AstBuilder/AstBuilderNode/MainAstLine.tsx
@@ -1,6 +1,7 @@
 import {
   type AstNode,
-  isMainAstNode,
+  isMainAstBinaryNode,
+  isMainAstUnaryNode,
   type MainAstBinaryNode,
   type MainAstUnaryNode,
   NewUndefinedAstNode,
@@ -26,8 +27,6 @@ function NewNestedChild(node: AstNode) {
     children: [node, NewUndefinedAstNode()],
   });
 }
-
-// add a similar component for unary operator below
 
 export function MainAstBinaryOperatorLine({
   treePath,
@@ -60,7 +59,7 @@ export function MainAstBinaryOperatorLine({
   const right = mainAstNode.children[1];
   const rightPath = `${treePath}.children.1`;
 
-  const isNestedRight = isMainAstNode(right); // and operator is not unary
+  const isNestedRight = isMainAstUnaryNode(right) || isMainAstBinaryNode(right);
 
   const evaluationErrors = useEvaluationErrors(treePath);
 
@@ -80,9 +79,8 @@ export function MainAstBinaryOperatorLine({
           value={mainAstNode.name}
           setValue={(operator: (typeof operators)[number]) => {
             setOperatorAtPath(treePath, operator);
-            // here, set right operator to undefined if operator changes to a unary operator, or vice versa
             if (isUnaryMainAstOperatorFunction(operator)) {
-              remove(`${treePath}.children.1`);
+              remove(rightPath);
             }
           }}
           validationStatus={evaluationErrors.length > 0 ? 'error' : 'valid'}
@@ -99,7 +97,7 @@ export function MainAstBinaryOperatorLine({
         />
         {!root ? <span className="text-grey-25">)</span> : null}
       </div>
-      {root && !viewOnly ? ( // also, only display the option if the operator is not a unary operator
+      {root && !viewOnly ? (
         <NestSwitch
           checked={isNestedRight}
           onCheckedChange={(checked) => {
@@ -149,9 +147,8 @@ export function MainAstUnaryOperatorLine({
           value={mainAstNode.name}
           setValue={(operator: (typeof operators)[number]) => {
             setOperatorAtPath(treePath, operator);
-            // here, set right operator to undefined if operator changes to a unary operator, or vice versa
             if (isBinaryMainAstOperatorFunction(operator)) {
-              appendChild(`${treePath}`, NewUndefinedAstNode());
+              appendChild(treePath, NewUndefinedAstNode());
             }
           }}
           validationStatus={evaluationErrors.length > 0 ? 'error' : 'valid'}

--- a/packages/app-builder/src/locales/ar/scenarios.json
+++ b/packages/app-builder/src/locales/ar/scenarios.json
@@ -41,6 +41,8 @@
   "operator.does_not_contain": "لا يحتوي على",
   "operator.contains_any_of": "يحتوي على أي من",
   "operator.contains_none_of": "لا يحتوي على أي من",
+  "operator.is_empty": "فارغ",
+  "operator.is_not_empty": "غير فارغ",
   "rules.function.title": "دالة",
   "deployment_modal.commit.button": "حفظ",
   "deployment_modal.commit.title": "حفظ الإصدار",

--- a/packages/app-builder/src/locales/en/scenarios.json
+++ b/packages/app-builder/src/locales/en/scenarios.json
@@ -74,6 +74,8 @@
   "operator.does_not_contain": "does not contain",
   "operator.contains_any_of": "contains any of",
   "operator.contains_none_of": "does not contain any of",
+  "operator.is_empty": "is empty",
+  "operator.is_not_empty": "is not empty",
   "rules.function.title": "function",
   "deployment_modal.commit.button": "Commit",
   "deployment_modal.commit.title": "Commit version",

--- a/packages/app-builder/src/locales/fr/scenarios.json
+++ b/packages/app-builder/src/locales/fr/scenarios.json
@@ -26,6 +26,8 @@
   "logical_operator.or": "ou",
   "logical_operator.where": "où",
   "operator.is_in": "est dans",
+  "operator.is_empty": "est vide",
+  "operator.is_not_empty": "n'est pas vide",
   "rules.consequence.score_modifier": "Modification du score : <Score>{{score}}</Score>",
   "rules.decision": "Décision",
   "rules.description": "Description",

--- a/packages/app-builder/src/models/ast-node.ts
+++ b/packages/app-builder/src/models/ast-node.ts
@@ -3,7 +3,9 @@ import * as R from 'remeda';
 
 import {
   type BinaryMainAstOperatorFunction,
+  isBinaryMainAstOperatorFunction,
   isMainAstOperatorFunction,
+  isUnaryMainAstOperatorFunction,
   type MainAstOperatorFunction,
   type UnaryMainAstOperatorFunction,
   undefinedAstNodeName,
@@ -550,11 +552,16 @@ export interface MainAstUnaryNode {
 }
 
 export function isMainAstNode(astNode: AstNode): astNode is MainAstNode {
-  if (isLeafOperandAstNode(astNode)) return false;
-
-  if (Object.keys(astNode.namedChildren).length > 0) return false;
-  if (astNode.name == null || !isMainAstOperatorFunction(astNode.name))
+  if (isLeafOperandAstNode(astNode)) {
     return false;
+  }
+
+  if (Object.keys(astNode.namedChildren).length > 0) {
+    return false;
+  }
+  if (astNode.name == null || !isMainAstOperatorFunction(astNode.name)) {
+    return false;
+  }
 
   return true;
 }
@@ -564,7 +571,10 @@ export function isMainAstUnaryNode(
 ): astNode is MainAstUnaryNode {
   if (!isMainAstNode(astNode)) return false;
 
-  return astNode.children.length === 1;
+  return (
+    astNode.children.length === 1 &&
+    isUnaryMainAstOperatorFunction(astNode.name)
+  );
 }
 
 export function isMainAstBinaryNode(
@@ -572,5 +582,8 @@ export function isMainAstBinaryNode(
 ): astNode is MainAstBinaryNode {
   if (!isMainAstNode(astNode)) return false;
 
-  return astNode.children.length === 2;
+  return (
+    astNode.children.length === 2 &&
+    isBinaryMainAstOperatorFunction(astNode.name)
+  );
 }

--- a/packages/app-builder/src/models/editable-operators.ts
+++ b/packages/app-builder/src/models/editable-operators.ts
@@ -4,7 +4,7 @@ import { assertNever } from 'typescript-utils';
 export const undefinedAstNodeName = 'Undefined';
 
 // order is important for sorting
-const mainAstOperatorFunctions = [
+const orderedMainAstOperatorFunctions = [
   '=',
   '≠',
   '<',
@@ -25,7 +25,6 @@ const mainAstOperatorFunctions = [
   'IsNotEmpty',
   undefinedAstNodeName,
 ] as const;
-export type MainAstOperatorFunction = (typeof mainAstOperatorFunctions)[number];
 
 // define a subset of MainAstOperatorFunction with only unary operators
 const unaryMainAstOperatorFunctions = ['IsEmpty', 'IsNotEmpty'] as const;
@@ -74,15 +73,21 @@ export function isBinaryMainAstOperatorFunction(
 export function isMainAstOperatorFunction(
   value: string,
 ): value is MainAstOperatorFunction {
-  return (mainAstOperatorFunctions as ReadonlyArray<string>).includes(value);
+  return (
+    isBinaryMainAstOperatorFunction(value) ||
+    isUnaryMainAstOperatorFunction(value)
+  );
 }
+export type MainAstOperatorFunction =
+  | BinaryMainAstOperatorFunction
+  | UnaryMainAstOperatorFunction;
 
 export function sortMainAstOperatorFunctions(
   lhs: MainAstOperatorFunction,
   rhs: MainAstOperatorFunction,
 ) {
-  const lhsIndex = mainAstOperatorFunctions.indexOf(lhs);
-  const rhsIndex = mainAstOperatorFunctions.indexOf(rhs);
+  const lhsIndex = orderedMainAstOperatorFunctions.indexOf(lhs);
+  const rhsIndex = orderedMainAstOperatorFunctions.indexOf(rhs);
   return lhsIndex - rhsIndex;
 }
 
@@ -169,9 +174,9 @@ export function getOperatorName(
       case 'IsInList':
         return t('scenarios:operator.is_in');
       case 'IsEmpty':
-        return 'IsEmpty'; // TODO add trad
+        return t('scenarios:operator.is_empty');
       case 'IsNotEmpty':
-        return 'IsNotEmpty'; // TODO add trad
+        return t('scenarios:operator.is_not_empty');
       case 'IsNotInList':
         return t('scenarios:operator.is_not_in');
       case 'StringContains':

--- a/packages/app-builder/src/models/editable-operators.ts
+++ b/packages/app-builder/src/models/editable-operators.ts
@@ -4,7 +4,44 @@ import { assertNever } from 'typescript-utils';
 export const undefinedAstNodeName = 'Undefined';
 
 // order is important for sorting
-const twoLineOperandOperatorFunctions = [
+const mainAstOperatorFunctions = [
+  '=',
+  '≠',
+  '<',
+  '<=',
+  '>',
+  '>=',
+  '+',
+  '-',
+  '*',
+  '/',
+  'IsInList',
+  'IsNotInList',
+  'StringContains',
+  'StringNotContain',
+  'ContainsAnyOf',
+  'ContainsNoneOf',
+  'IsEmpty',
+  'IsNotEmpty',
+  undefinedAstNodeName,
+] as const;
+export type MainAstOperatorFunction = (typeof mainAstOperatorFunctions)[number];
+
+// define a subset of MainAstOperatorFunction with only unary operators
+const unaryMainAstOperatorFunctions = ['IsEmpty', 'IsNotEmpty'] as const;
+export type UnaryMainAstOperatorFunction =
+  (typeof unaryMainAstOperatorFunctions)[number];
+
+export function isUnaryMainAstOperatorFunction(
+  value: string,
+): value is UnaryMainAstOperatorFunction {
+  return (unaryMainAstOperatorFunctions as ReadonlyArray<string>).includes(
+    value,
+  );
+}
+
+// define a subset of MainAstOperatorFunction with only binary operators
+const binaryMainAstOperatorFunctions = [
   '=',
   '≠',
   '<',
@@ -23,23 +60,29 @@ const twoLineOperandOperatorFunctions = [
   'ContainsNoneOf',
   undefinedAstNodeName,
 ] as const;
-export type TwoLineOperandOperatorFunction =
-  (typeof twoLineOperandOperatorFunctions)[number];
+export type BinaryMainAstOperatorFunction =
+  (typeof binaryMainAstOperatorFunctions)[number];
 
-export function isTwoLineOperandOperatorFunction(
+export function isBinaryMainAstOperatorFunction(
   value: string,
-): value is TwoLineOperandOperatorFunction {
-  return (twoLineOperandOperatorFunctions as ReadonlyArray<string>).includes(
+): value is BinaryMainAstOperatorFunction {
+  return (binaryMainAstOperatorFunctions as ReadonlyArray<string>).includes(
     value,
   );
 }
 
-export function sortTwoLineOperandOperatorFunctions(
-  lhs: TwoLineOperandOperatorFunction,
-  rhs: TwoLineOperandOperatorFunction,
+export function isMainAstOperatorFunction(
+  value: string,
+): value is MainAstOperatorFunction {
+  return (mainAstOperatorFunctions as ReadonlyArray<string>).includes(value);
+}
+
+export function sortMainAstOperatorFunctions(
+  lhs: MainAstOperatorFunction,
+  rhs: MainAstOperatorFunction,
 ) {
-  const lhsIndex = twoLineOperandOperatorFunctions.indexOf(lhs);
-  const rhsIndex = twoLineOperandOperatorFunctions.indexOf(rhs);
+  const lhsIndex = mainAstOperatorFunctions.indexOf(lhs);
+  const rhsIndex = mainAstOperatorFunctions.indexOf(rhs);
   return lhsIndex - rhsIndex;
 }
 
@@ -83,13 +126,13 @@ export function isAggregatorOperator(
 }
 
 export type OperatorFunction =
-  | TwoLineOperandOperatorFunction
+  | MainAstOperatorFunction
   | FilterOperator
   | TimeAddOperator
   | AggregatorOperator;
 export function isOperatorFunction(value: string): value is OperatorFunction {
   return (
-    isTwoLineOperandOperatorFunction(value) ||
+    isMainAstOperatorFunction(value) ||
     isFilterOperator(value) ||
     isTimeAddOperator(value) ||
     isAggregatorOperator(value)
@@ -125,6 +168,10 @@ export function getOperatorName(
         return '÷';
       case 'IsInList':
         return t('scenarios:operator.is_in');
+      case 'IsEmpty':
+        return 'IsEmpty'; // TODO add trad
+      case 'IsNotEmpty':
+        return 'IsNotEmpty'; // TODO add trad
       case 'IsNotInList':
         return t('scenarios:operator.is_not_in');
       case 'StringContains':

--- a/packages/app-builder/src/services/editor/ast-editor.tsx
+++ b/packages/app-builder/src/services/editor/ast-editor.tsx
@@ -1,4 +1,8 @@
-import { type AstNode } from '@app-builder/models';
+import { type AstNode, NewUndefinedAstNode } from '@app-builder/models';
+import {
+  isBinaryMainAstOperatorFunction,
+  isUnaryMainAstOperatorFunction,
+} from '@app-builder/models/editable-operators';
 import {
   NewNodeEvaluation,
   type NodeEvaluation,
@@ -82,11 +86,18 @@ export function useAstNodeEditor({
             // No node at this path
             return;
           }
+          const newNode = {
+            ...currentNode,
+            name,
+          };
+          if (isUnaryMainAstOperatorFunction(name)) {
+            const children = newNode.children.slice(0, 1);
+            newNode.children = children;
+          } else if (isBinaryMainAstOperatorFunction(name)) {
+            newNode.children.push(NewUndefinedAstNode());
+          }
           set({
-            rootAstNode: setAtPath(rootAstNode, path, {
-              ...currentNode,
-              name,
-            }),
+            rootAstNode: setAtPath(rootAstNode, path, newNode),
           });
         },
         appendChild: (stringPath, childAst) => {

--- a/packages/app-builder/src/services/editor/options.tsx
+++ b/packages/app-builder/src/services/editor/options.tsx
@@ -22,9 +22,9 @@ import {
 } from '@app-builder/models/data-model';
 import {
   aggregatorOperators,
-  isTwoLineOperandOperatorFunction,
+  isMainAstOperatorFunction,
   type OperatorFunction,
-  sortTwoLineOperandOperatorFunctions,
+  sortMainAstOperatorFunctions,
 } from '@app-builder/models/editable-operators';
 import { type OperandType } from '@app-builder/models/operand-type';
 import { createSimpleContext } from '@app-builder/utils/create-context';
@@ -252,13 +252,13 @@ export function useOperandOptions(enumValues?: EnumValue[]) {
   ]);
 }
 
-export function useTwoLineOperandOperatorFunctions() {
+export function useMainAstOperatorFunctions() {
   const operators = useOperatorFunctions();
   return React.useMemo(
     () =>
       operators
-        .filter(isTwoLineOperandOperatorFunction)
-        .sort(sortTwoLineOperandOperatorFunctions),
+        .filter(isMainAstOperatorFunction)
+        .sort(sortMainAstOperatorFunctions),
     [operators],
   );
 }

--- a/packages/app-builder/src/services/validation/ast-node-validation.ts
+++ b/packages/app-builder/src/services/validation/ast-node-validation.ts
@@ -91,7 +91,7 @@ function hasNestedErrors(astNodeErrors: AstNodeErrors, root = true): boolean {
   return false;
 }
 
-// TODO: should be removed. Depending on the use case, we should use computeLineErrors or alike function (ex: when we have a "TwoLineOperandAstNode" like comp in a modal)
+// TODO: should be removed. Depending on the use case, we should use computeLineErrors or alike function (ex: when we have a "MainAstNode" like comp in a modal)
 // Ex: if you nest variables, this function is "wrong" because it doesn't separate children errors like computeLineErrors
 export function computeValidationForNamedChildren(
   astNode: AstNode,

--- a/packages/app-builder/src/utils/array.ts
+++ b/packages/app-builder/src/utils/array.ts
@@ -1,3 +1,0 @@
-export function hasExactlyTwoElements<T>(data: T[]): data is [T, T] {
-  return data.length === 2;
-}

--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -5012,12 +5012,9 @@ components:
       type: object
       required:
         - name
-        - number_of_arguments
       properties:
         name:
           type: string
-        number_of_arguments:
-          type: number
         named_arguments:
           type: array
           items:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -620,7 +620,6 @@ export type UpdateOrganizationBodyDto = {
 };
 export type FuncAttributes = {
     name: string;
-    number_of_arguments: number;
     named_arguments?: string[];
 };
 export type InboxUserDto = {


### PR DESCRIPTION
Goes with PR https://github.com/checkmarble/marble-backend/pull/743 on the backend.
Implements the IsEmpty and IsNotEmpty operators, but only on the main AST (not for aggregator filters).
The operator returns true if the value is NULL or empty string, else false.

### Illustration
Starting from a binary operator
<img width="827" alt="Capture d’écran 2024-11-20 à 22 25 54" src="https://github.com/user-attachments/assets/cf3e91de-f641-4d6e-a6e5-b55dd2b4b168">

I can remove the right leg by setting the operator to "is empty"
<img width="823" alt="Capture d’écran 2024-11-20 à 22 26 01" src="https://github.com/user-attachments/assets/702249aa-5904-4f7a-b563-1a52c99fb6cb">

and back again
<img width="824" alt="Capture d’écran 2024-11-20 à 22 26 10" src="https://github.com/user-attachments/assets/297dd49e-06d7-44f7-92f7-b9a6531419b9">

it also works with nesting
<img width="813" alt="Capture d’écran 2024-11-20 à 22 26 25" src="https://github.com/user-attachments/assets/6fc0330e-f259-4b8d-95ea-16ed1f9ab69e">

Decision view display does basically what we can expect it to do
<img width="975" alt="Capture d’écran 2024-11-20 à 22 27 43" src="https://github.com/user-attachments/assets/555ee113-6147-43b5-80fa-7cc66a8a2ccb">
