### PR TITLE
table,field,link name match ^[a-z]+[a-z0-9_]+

### DIFF
--- a/packages/app-builder/src/routes/ressources+/data+/createField.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/createField.tsx
@@ -39,7 +39,9 @@ const createFieldFormSchema = z.object({
   name: z
     .string()
     .min(1)
-    .regex(/^[a-zA-Z0-9_]+$/, { message: 'Only alphanumeric and _' })
+    .regex(/^[a-z]+[a-z0-9_]+$/, {
+      message: 'Only lower case alphanumeric and _, must start with a letter',
+    })
     .refine((value) => value !== 'id', {
       message: 'The name "id" is reserved',
     }),

--- a/packages/app-builder/src/routes/ressources+/data+/createLink.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/createLink.tsx
@@ -28,14 +28,14 @@ export const handle = {
 const createLinkFormSchema = z.object({
   name: z
     .string()
-    .nonempty()
-    .regex(/^[a-zA-Z0-9_]+$/, {
-      message: 'Only alphanumeric and _',
+    .min(1)
+    .regex(/^[a-z]+[a-z0-9_]+$/, {
+      message: 'Only lower case alphanumeric and _, must start with a letter',
     }),
-  parentTableId: z.string().nonempty().uuid(),
-  parentFieldId: z.string().nonempty().uuid(),
-  childTableId: z.string().nonempty().uuid(),
-  childFieldId: z.string().nonempty().uuid(),
+  parentTableId: z.string().min(1).uuid(),
+  parentFieldId: z.string().min(1).uuid(),
+  childTableId: z.string().min(1).uuid(),
+  childFieldId: z.string().min(1).uuid(),
 });
 
 export async function action({ request }: ActionFunctionArgs) {

--- a/packages/app-builder/src/routes/ressources+/data+/createTable.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/createTable.tsx
@@ -27,8 +27,10 @@ export const handle = {
 const createTableFormSchema = z.object({
   name: z
     .string()
-    .nonempty()
-    .regex(/^[a-zA-Z0-9_]+$/, { message: 'Only alphanumeric and _' }),
+    .min(1)
+    .regex(/^[a-z]+[a-z0-9_]+$/, {
+      message: 'Only lower case alphanumeric and _, must start with a letter',
+    }),
   description: z.string(),
 });
 


### PR DESCRIPTION
TBH I'm voluntarily not adding translations for the error message for now - I have a shitload of things to finish, and I'm keeping this for later maybe.
See also https://github.com/checkmarble/marble-backend/pull/752 for backend enforcing