### PR TITLE
refactor: lift up error boundary to app-router

### DIFF
--- a/packages/app-builder/src/routes/app-router.tsx
+++ b/packages/app-builder/src/routes/app-router.tsx
@@ -1,9 +1,17 @@
+import { ErrorComponent } from '@app-builder/components';
 import { authI18n } from '@app-builder/components/Auth/auth-i18n';
 import { isMarbleCoreUser, isTransferCheckUser } from '@app-builder/models';
 import { serverServices } from '@app-builder/services/init.server';
+import { segment } from '@app-builder/services/segment';
 import { forbidden } from '@app-builder/utils/http/http-responses';
+import { FORBIDDEN } from '@app-builder/utils/http/http-status-codes';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
+import { Form, isRouteErrorResponse, useRouteError } from '@remix-run/react';
+import { captureRemixErrorBoundaryError } from '@sentry/remix';
+import { useTranslation } from 'react-i18next';
+import { Button } from 'ui-design-system';
+import { Icon } from 'ui-icons';
 
 export const handle = {
   i18n: authI18n,
@@ -32,5 +40,50 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return forbidden(
     'You are not allowed to access any page on this application.',
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const { t } = useTranslation(handle.i18n);
+
+  let errorComponent;
+  // Handle Marble Admins, do not capture error in Sentry
+  if (isRouteErrorResponse(error) && error.status === FORBIDDEN) {
+    errorComponent = (
+      <div className="m-auto flex flex-col items-center gap-4">
+        <h1 className="text-l text-purple-110 font-semibold">
+          {t('common:error_boundary.marble_admin.title')}
+        </h1>
+        <p className="text-s mb-6">
+          {t('common:error_boundary.marble_admin.subtitle')}
+        </p>
+        <div className="mb-1">
+          <Form action={getRoute('/ressources/auth/logout')} method="post">
+            <Button
+              type="submit"
+              onClick={() => {
+                void segment.reset();
+              }}
+            >
+              <Icon icon="logout" className="size-5" />
+              {t('common:auth.logout')}
+            </Button>
+          </Form>
+        </div>
+      </div>
+    );
+  } else {
+    captureRemixErrorBoundaryError(error);
+
+    errorComponent = <ErrorComponent error={error} />;
+  }
+
+  return (
+    <div className="bg-purple-05 flex size-full items-center justify-center">
+      <div className="bg-grey-00 flex max-w-md rounded-2xl p-10 shadow-md">
+        {errorComponent}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Move the error component to handle Marble admin (and allow logout without clearing the cookies).

**Context:**
Historically, I added a special handler to handle Marble admin that try to log into the marble core app (ex: people that alternate between backoffice and marble app). Since this is not possible, the user is blocked on an error page, without the possibility to logout: he must clear auth cookies from the browser...

By adding TC, I added a `/app-router` responsible to redirect the user on the correct app. I forggot to move the error handler for Marble admin.