### PR TITLE
feat(custom-list): allow to manage list values as CSV

### DIFF
--- a/packages/app-builder/eslint.config.mjs
+++ b/packages/app-builder/eslint.config.mjs
@@ -9,4 +9,5 @@ export default [
   ...reactConfig,
   ...tailwindcssConfig(tailwindConfigPath),
   ...vitestConfig,
+  { ignores: ['build'] },
 ];

--- a/packages/app-builder/src/locales/ar/lists.json
+++ b/packages/app-builder/src/locales/ar/lists.json
@@ -23,5 +23,18 @@
   "delete_value.title": "حذف هذه القيمة",
   "delete_value.value_content": "أنت على وشك حذف القيمة.",
   "delete_value.no_return": "هذه العملية غير قابلة للتراجع، هل ترغب في المتابعة؟",
-  "empty_custom_list_matches": "لا توجد قيمة تطابق بحثك."
+  "empty_custom_list_matches": "لا توجد قيمة تطابق بحثك.",
+  "download_values_as_csv": "قم بتنزيل القيم بتنسيق CSV",
+  "drop_csv_here": "قم بإسقاط ملف CSV الخاص بك هنا",
+  "errors.failure_message": "فشل التحميل بسبب الخطأ التالي: {{errorMessage}}",
+  "errors.request_timeout": "انتهت مهلة الطلب. \nيرجى المحاولة مرة أخرى.",
+  "pick_csv": "اختر ملف CSV",
+  "upload_csv.results": "نتائج",
+  "upload_csv.success": "تم التحميل بنجاح :",
+  "upload_csv.success.created_one": "تم إنشاء {{count}} قيمة جديدة",
+  "upload_csv.success.created_other": "تم إنشاء {{count}} قيم جديدة",
+  "upload_csv.success.deleted_one": "تم حذف {{count}} القيمة القديمة",
+  "upload_csv.success.deleted_other": "تم حذف {{count}} من القيم القديمة",
+  "upload_csv.success.existing_one": "{{count}} القيمة الحالية",
+  "upload_csv.success.existing_other": "{{count}} القيم الموجودة"
 }

--- a/packages/app-builder/src/locales/en/lists.json
+++ b/packages/app-builder/src/locales/en/lists.json
@@ -23,5 +23,18 @@
   "delete_list.content": "You are about to delete this list. This action is irreversible, do you want to proceed ?",
   "delete_value.title": "Delete this value",
   "delete_value.value_content": "You are about to delete the value",
-  "delete_value.no_return": "This action is irreversible, do you want to proceed ?"
+  "delete_value.no_return": "This action is irreversible, do you want to proceed ?",
+  "download_values_as_csv": "Download values as CSV",
+  "drop_csv_here": "Drop your CSV file here",
+  "pick_csv": "Pick a CSV file",
+  "upload_csv.results": "Results",
+  "upload_csv.success": "The upload is successful :",
+  "upload_csv.success.deleted_one": "{{count}} old value deleted",
+  "upload_csv.success.deleted_other": "{{count}} old values deleted",
+  "upload_csv.success.created_one": "{{count}} new value created",
+  "upload_csv.success.created_other": "{{count}} new values created",
+  "upload_csv.success.existing_one": "{{count}} existing value",
+  "upload_csv.success.existing_other": "{{count}} existing values",
+  "errors.request_timeout": "The request timed out. Please try again.",
+  "errors.failure_message": "Upload failed with the following error: {{errorMessage}}"
 }

--- a/packages/app-builder/src/locales/fr/lists.json
+++ b/packages/app-builder/src/locales/fr/lists.json
@@ -23,5 +23,18 @@
   "create_list.title": "Nouvelle liste",
   "create_list.name_placeholder": "Ajouter un nom à cette liste",
   "create_list.description_placeholder": "Ajouter une description",
-  "empty_custom_list_matches": "Aucune valeur ne correspond à votre recherche."
+  "empty_custom_list_matches": "Aucune valeur ne correspond à votre recherche.",
+  "download_values_as_csv": "Télécharger les valeurs au format CSV",
+  "drop_csv_here": "Déposez votre fichier CSV ici",
+  "errors.failure_message": "Le téléchargement a échoué avec l'erreur suivante : {{errorMessage}}",
+  "errors.request_timeout": "La requète a expiré. \nVeuillez réessayer.",
+  "pick_csv": "Choisissez un fichier CSV",
+  "upload_csv.results": "Résultats",
+  "upload_csv.success": "Le téléchargement a réussi :",
+  "upload_csv.success.created_one": "{{count}} nouvelle valeur créée",
+  "upload_csv.success.created_other": "{{count}} nouvelles valeurs créées",
+  "upload_csv.success.deleted_one": "{{count}} ancienne valeur supprimée",
+  "upload_csv.success.deleted_other": "{{count}} anciennes valeurs supprimées",
+  "upload_csv.success.existing_one": "{{count}} valeur existante",
+  "upload_csv.success.existing_other": "{{count}} valeurs existantes"
 }

--- a/packages/app-builder/src/routes/_builder+/api.tsx
+++ b/packages/app-builder/src/routes/_builder+/api.tsx
@@ -1,6 +1,6 @@
 import { Page } from '@app-builder/components';
 import { serverServices } from '@app-builder/services/init.server';
-import { downloadBlob } from '@app-builder/utils/download-blob';
+import { downloadFile } from '@app-builder/utils/download-file';
 import { getRoute } from '@app-builder/utils/routes';
 import {
   json,
@@ -10,6 +10,7 @@ import {
 import { useLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import * as React from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import swaggercss from 'swagger-ui-react/swagger-ui.css?url';
 import { Button } from 'ui-design-system';
@@ -56,10 +57,15 @@ export default function Api() {
             <Button
               variant="secondary"
               onClick={() => {
-                const blob = new Blob([JSON.stringify(openapi)], {
-                  type: 'application/json;charset=utf-8,',
-                });
-                void downloadBlob(blob, 'openapi.json');
+                try {
+                  const blob = new Blob([JSON.stringify(openapi)], {
+                    type: 'application/json;charset=utf-8,',
+                  });
+                  const url = URL.createObjectURL(blob);
+                  void downloadFile(url, 'openapi.json');
+                } catch (error) {
+                  toast.error(t('common:errors.unknown'));
+                }
               }}
             >
               <Icon icon="download" className="me-2 size-6" />

--- a/packages/app-builder/src/services/DownloadCaseFilesService.ts
+++ b/packages/app-builder/src/services/DownloadCaseFilesService.ts
@@ -1,4 +1,4 @@
-import { DownloadError } from '@app-builder/utils/download-blob';
+import { DownloadError, downloadFile } from '@app-builder/utils/download-file';
 import { UnknownError } from '@app-builder/utils/unknown-error';
 import { useState } from 'react';
 import { z } from 'zod';
@@ -59,7 +59,7 @@ export function useDownloadCaseFiles(
         );
       }
       const { url } = fileDownloadUrlSchema.parse(await response.json());
-      await openFileLink(url);
+      await downloadFile(url);
     } catch (error) {
       if (
         error instanceof AlreadyDownloadingError ||
@@ -80,28 +80,4 @@ export function useDownloadCaseFiles(
     downloadCaseFile,
     downloadingCaseFile: downloading,
   };
-}
-
-const TIME_TO_OPEN_DOWNLOAD_MODALE = 150;
-
-async function openFileLink(url: string) {
-  return new Promise<void>((resolve, reject) => {
-    try {
-      const a = document.createElement('a');
-      a.href = url;
-      a.target = '_blank';
-
-      const clickHandler = () => {
-        setTimeout(() => {
-          removeEventListener('click', clickHandler);
-          resolve();
-        }, TIME_TO_OPEN_DOWNLOAD_MODALE);
-      };
-
-      a.addEventListener('click', clickHandler);
-      a.click();
-    } catch (error) {
-      reject(new DownloadError(error));
-    }
-  });
 }

--- a/packages/app-builder/src/utils/download-file.ts
+++ b/packages/app-builder/src/utils/download-file.ts
@@ -1,15 +1,13 @@
 // This is an empirical value to wait for the download modal to open (in ms)
-// Usefull to await for downloadBlob and display a loading indicator
+// Usefull to await for downloadFile and display a loading indicator
 const TIME_TO_OPEN_DOWNLOAD_MODALE = 150;
 
 /**
- * Utility function to download a blob as a file in the browser
+ * Utility function to download a file in the browser
  */
-export async function downloadBlob(blob: Blob, filename?: string) {
+export async function downloadFile(url: string, filename?: string) {
   return new Promise<void>((resolve, reject) => {
     try {
-      const url = URL.createObjectURL(blob);
-
       const a = document.createElement('a');
       a.href = url;
       a.download = filename || 'download';
@@ -35,7 +33,7 @@ export async function downloadBlob(blob: Blob, filename?: string) {
 export class DownloadError extends Error {
   constructor(error: unknown) {
     super(
-      `Internal error: Failed to download decisions: ${
+      `Internal error: ${
         error instanceof Error ? error.message : 'unknown error'
       }`,
     );


### PR DESCRIPTION
In this PR :
- download custom list values as CSV (single column list of values)
- upload custom list values as CSV (single column list of values)
  - display usefull error messages (if any)
  - display some ingestion statistics (if succeed)

![image](https://github.com/user-attachments/assets/05ce19f1-1a80-4a84-8534-7196b5d71c37)
![image](https://github.com/user-attachments/assets/8a294ccf-3b09-4e6d-8815-9b3fc4364df4)
