### PR TITLE
Improve documentation of the env file example 

### DIFF
--- a/packages/app-builder/.env.example
+++ b/packages/app-builder/.env.example
@@ -4,32 +4,44 @@
 # .env is only used in development, and ignored in production.
 # More information about environment variables can be found at: https://remix.run/docs/en/main/guides/envvars
 
-ENV=development
-NODE_ENV=development
+#
+# REQUIRED SETTINGS
+#
 
-SESSION_SECRET=SESSION_SECRET
-LICENSE_KEY=LICENSE_KEY
+ENV=development # Set to "production" when not testing. Note that it will require HTTPS
+NODE_ENV=development # Set to "production" if deploying instead of developing
+
+# In production, generate a new random secret to sign your user's sessions. You can use this command to do so:
+#  - openssl rand -base64 128 | tr -d "\n"
+SESSION_SECRET=
 SESSION_MAX_AGE=43200
 
+# Set the different URLs used to access your Marble platform, where:
+#  - MARBLE_API_DOMAIN_CLIENT is the URL your user's browser will use to reach the API.
+#  - MARBLE_API_DOMAIN_SERVER is the URL your frontend process can use to reach the API (this can be a private URL).
+#  - MARBLE_APP_DOMAIN is the URL your user's will type in their browser to access the application.
 MARBLE_API_DOMAIN_CLIENT=http://localhost:8080
 MARBLE_API_DOMAIN_SERVER=http://localhost:8080
 MARBLE_APP_DOMAIN=http://localhost:3000
 
-# coment out to use the real firebase
-FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+# Configure your Firebase project to allow username and password authentication.
+FIREBASE_PROJECT_ID=
+FIREBASE_API_KEY=
 
-# if you make use of the auth emulator, you can enter dummy values
-FIREBASE_API_KEY=dummy
-FIREBASE_AUTH_DOMAIN=dummy
-FIREBASE_PROJECT_ID=dummy
-FIREBASE_STORAGE_BUCKET=dummy
-FIREBASE_MESSAGING_SENDER_ID=dummy
-FIREBASE_APP_ID=dummy
+#
+# OPTIONAL SETTINGS
+#
 
+# If you need to support federated authentication through Firebase, you will need to configure the following settings:
+# To retrieve those value, go into the settings of your Firebase project, and register a new app from the 'General' tab.
+# The two information below will be provided to you after that. 
+# FIREBASE_APP_ID=
+# FIREBASE_AUTH_DOMAIN=
 
-# we use it for analytics
+# Uncomment this line if you are using the Firebase emulator for testing.
+# FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
+
+# Configure various external integrations.
 SEGMENT_WRITE_KEY=AnqbZOIJ8TvCbQUhXLqin1tXXnxHX0CE
-
-# we use it for error tracking
-# SENTRY_DSN= 
-# SENTRY_ENVIRONMENT= 
+SENTRY_DSN= 
+SENTRY_ENVIRONMENT= 

--- a/packages/app-builder/src/utils/environment.ts
+++ b/packages/app-builder/src/utils/environment.ts
@@ -27,11 +27,11 @@ const PublicEnvVarsSchema = z.object({
 
   FIREBASE_AUTH_EMULATOR_HOST: z.string().optional(),
   FIREBASE_API_KEY: z.string(),
-  FIREBASE_APP_ID: z.string(),
-  FIREBASE_AUTH_DOMAIN: z.string(),
-  FIREBASE_MESSAGING_SENDER_ID: z.string(),
+  FIREBASE_APP_ID: z.string().optional(),
+  FIREBASE_AUTH_DOMAIN: z.string().optional(),
+  FIREBASE_MESSAGING_SENDER_ID: z.string().optional(),
   FIREBASE_PROJECT_ID: z.string(),
-  FIREBASE_STORAGE_BUCKET: z.string(),
+  FIREBASE_STORAGE_BUCKET: z.string().optional(),
 
   SENTRY_DSN: z.string().optional(),
   SENTRY_ENVIRONMENT: z.string().optional(),

--- a/packages/app-builder/src/utils/environment.ts
+++ b/packages/app-builder/src/utils/environment.ts
@@ -29,9 +29,7 @@ const PublicEnvVarsSchema = z.object({
   FIREBASE_API_KEY: z.string(),
   FIREBASE_APP_ID: z.string().optional(),
   FIREBASE_AUTH_DOMAIN: z.string().optional(),
-  FIREBASE_MESSAGING_SENDER_ID: z.string().optional(),
   FIREBASE_PROJECT_ID: z.string(),
-  FIREBASE_STORAGE_BUCKET: z.string().optional(),
 
   SENTRY_DSN: z.string().optional(),
   SENTRY_ENVIRONMENT: z.string().optional(),
@@ -152,8 +150,6 @@ function parseFirebaseConfigFromEnv(): FirebaseConfig {
     apiKey: getEnv('FIREBASE_API_KEY'),
     authDomain: getEnv('FIREBASE_AUTH_DOMAIN'),
     projectId: getEnv('FIREBASE_PROJECT_ID'),
-    storageBucket: getEnv('FIREBASE_STORAGE_BUCKET'),
-    messagingSenderId: getEnv('FIREBASE_MESSAGING_SENDER_ID'),
     appId: getEnv('FIREBASE_APP_ID'),
   };
 


### PR DESCRIPTION
Same rationale as the backend one.

Big difference, though: this actually changes some code to mark some variables as optional. I do not think we use them for anything, from what I can see in the code and the Firebase project, so having them in the configuration file might clutter it for nothing.