### PR TITLE
fix: remove user and entitlements from auth session cookie

### DIFF
--- a/packages/app-builder/src/models/marble-session.ts
+++ b/packages/app-builder/src/models/marble-session.ts
@@ -3,13 +3,9 @@ import { type Token } from 'marble-api';
 
 import { type CreatedApiKey } from './api-keys';
 import { type AuthErrors } from './auth-errors';
-import { type LicenseEntitlements } from './license';
-import { type CurrentUser } from './user';
 
 export type AuthData = {
   authToken: Token;
-  user: CurrentUser;
-  entitlements: LicenseEntitlements;
 };
 export type AuthFlashData = {
   authError: { message: AuthErrors };


### PR DESCRIPTION
Too much information was stored in auth session cookie, namely "user" and "entitlements" taking too much space in the cookie (which are limited to 4KB in size in total for a domain) nearing the maximum size they can take.
They were only used in the `isAuthenticated` auth service function.

What we did is remove `user` and `entitlements` from the cookie and instead of reading them from the cookie in the `isAuthenticated` auth service function, we now call the call the dedicated services.