### PR TITLE
Handling last remark for sanction check config

### DIFF
--- a/packages/app-builder/src/components/Breadcrumbs.tsx
+++ b/packages/app-builder/src/components/Breadcrumbs.tsx
@@ -36,7 +36,7 @@ export const BreadCrumbLink = ({
   </Link>
 );
 
-export const BreadCrumbs = () => {
+export const BreadCrumbs = ({ back }: { back?: string }) => {
   const matches = useMatches();
 
   const links = useMemo(
@@ -57,7 +57,11 @@ export const BreadCrumbs = () => {
 
   return (
     <div className="flex flex-row items-center gap-4">
-      {links.length > 1 ? <Page.BackLink to={links.at(-2)!.pathname} /> : null}
+      {back ? (
+        <Page.BackLink to={back} />
+      ) : links.length > 1 ? (
+        <Page.BackLink to={links.at(-2)!.pathname} />
+      ) : null}
       {links.map(({ Elements, pathname, data }, linkIndex) => {
         const isLastLink = linkIndex === links.length - 1;
 

--- a/packages/app-builder/src/components/Scenario/Sanction/FieldNode.tsx
+++ b/packages/app-builder/src/components/Scenario/Sanction/FieldNode.tsx
@@ -1,4 +1,5 @@
 import { type AstNode, NewUndefinedAstNode } from '@app-builder/models';
+import { hasSubObject } from 'remeda';
 
 import { MatchOperand } from './MatchOperand';
 
@@ -10,7 +11,7 @@ export const FieldNode = ({
   onBlur,
 }: {
   value?: AstNode;
-  onChange?: (value: AstNode) => void;
+  onChange?: (value?: AstNode) => void;
   onBlur?: () => void;
   placeholder?: string;
   viewOnly?: boolean;
@@ -21,7 +22,11 @@ export const FieldNode = ({
       node={value ?? NewUndefinedAstNode()}
       placeholder={placeholder}
       onSave={(node) => {
-        onChange?.(node);
+        onChange?.(
+          hasSubObject(NewUndefinedAstNode() as AstNode, node)
+            ? undefined
+            : node,
+        );
       }}
     />
   </div>

--- a/packages/app-builder/src/components/Scenario/Sanction/FieldNode.tsx
+++ b/packages/app-builder/src/components/Scenario/Sanction/FieldNode.tsx
@@ -11,7 +11,7 @@ export const FieldNode = ({
   onBlur,
 }: {
   value?: AstNode;
-  onChange?: (value?: AstNode) => void;
+  onChange?: (value: AstNode | null) => void;
   onBlur?: () => void;
   placeholder?: string;
   viewOnly?: boolean;
@@ -19,13 +19,11 @@ export const FieldNode = ({
   <div onBlur={onBlur}>
     <MatchOperand
       viewOnly={viewOnly}
-      node={value ?? NewUndefinedAstNode()}
+      node={value}
       placeholder={placeholder}
       onSave={(node) => {
         onChange?.(
-          hasSubObject(NewUndefinedAstNode() as AstNode, node)
-            ? undefined
-            : node,
+          hasSubObject(NewUndefinedAstNode() as AstNode, node) ? null : node,
         );
       }}
     />

--- a/packages/app-builder/src/components/Scenario/Sanction/FieldNodeConcat.tsx
+++ b/packages/app-builder/src/components/Scenario/Sanction/FieldNodeConcat.tsx
@@ -9,7 +9,7 @@ import {
 import { nanoid } from 'nanoid';
 import { replace } from 'radash';
 import { useEffect, useState } from 'react';
-import { omit, splice } from 'remeda';
+import { hasSubObject, omit, splice } from 'remeda';
 import { Button } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
@@ -37,7 +37,7 @@ export function FieldNodeConcat({
   value?: AstNode;
   limit?: number;
   placeholder?: string;
-  onChange?: (node: AstNode) => void;
+  onChange?: (node?: AstNode) => void;
   onBlur?: () => void;
   viewOnly?: boolean;
 }) {
@@ -48,12 +48,20 @@ export function FieldNodeConcat({
   );
 
   useEffect(() => {
-    if (nodes.length !== 0) {
-      onChange?.(
-        NewStringConcatAstNode(nodes.map(omit(['id'])), {
-          withSeparator: true,
-        }),
+    if (nodes.length) {
+      const finalNodes = nodes.filter(
+        (n) => !hasSubObject(NewUndefinedAstNode() as AstNode, omit(n, ['id'])),
       );
+
+      onChange?.(
+        finalNodes.length !== 0
+          ? NewStringConcatAstNode(finalNodes.map(omit(['id'])), {
+              withSeparator: true,
+            })
+          : undefined,
+      );
+    } else {
+      onChange?.(undefined);
     }
   }, [nodes, onChange]);
 

--- a/packages/app-builder/src/components/Scenario/Sanction/FieldNodeConcat.tsx
+++ b/packages/app-builder/src/components/Scenario/Sanction/FieldNodeConcat.tsx
@@ -37,7 +37,7 @@ export function FieldNodeConcat({
   value?: AstNode;
   limit?: number;
   placeholder?: string;
-  onChange?: (node?: AstNode) => void;
+  onChange?: (node: AstNode | null) => void;
   onBlur?: () => void;
   viewOnly?: boolean;
 }) {
@@ -48,21 +48,18 @@ export function FieldNodeConcat({
   );
 
   useEffect(() => {
-    if (nodes.length) {
-      const finalNodes = nodes.filter(
-        (n) => !hasSubObject(NewUndefinedAstNode() as AstNode, omit(n, ['id'])),
-      );
+    const finalNodes = nodes.filter(
+      (n) => !hasSubObject(NewUndefinedAstNode() as AstNode, omit(n, ['id'])),
+    );
 
-      onChange?.(
-        finalNodes.length !== 0
-          ? NewStringConcatAstNode(finalNodes.map(omit(['id'])), {
-              withSeparator: true,
-            })
-          : undefined,
-      );
-    } else {
-      onChange?.(undefined);
-    }
+    const result =
+      finalNodes.length !== 0
+        ? NewStringConcatAstNode(finalNodes.map(omit(['id'])), {
+            withSeparator: true,
+          })
+        : null;
+
+    onChange?.(result);
   }, [nodes, onChange]);
 
   const onDragEnd: OnDragEndResponder<string> = (result): void => {
@@ -107,27 +104,23 @@ export function FieldNodeConcat({
                     >
                       {!viewOnly ? (
                         <div className="flex flex-row">
+                          <div
+                            key={node.id}
+                            className="hover:bg-grey-95 flex size-6 items-center justify-center rounded"
+                            {...dragProvided.dragHandleProps}
+                          >
+                            <Icon icon="drag" className="text-grey-80 size-3" />
+                          </div>
                           {nodes.length > 1 ? (
-                            <>
-                              <div
-                                className="hover:bg-grey-95 flex size-6 items-center justify-center rounded"
-                                {...dragProvided.dragHandleProps}
-                              >
-                                <Icon
-                                  icon="drag"
-                                  className="text-grey-80 size-3"
-                                />
-                              </div>
-                              <Button
-                                size="icon"
-                                variant="tertiary"
-                                onClick={() =>
-                                  setNodes((prev) => splice(prev, index, 1, []))
-                                }
-                              >
-                                <Icon icon="cross" className="size-4" />
-                              </Button>
-                            </>
+                            <Button
+                              size="icon"
+                              variant="tertiary"
+                              onClick={() =>
+                                setNodes((prev) => splice(prev, index, 1, []))
+                              }
+                            >
+                              <Icon icon="cross" className="size-4" />
+                            </Button>
                           ) : null}
                           {!limit || nodes.length < limit ? (
                             <Button

--- a/packages/app-builder/src/components/Scenario/Sanction/FieldTrigger.tsx
+++ b/packages/app-builder/src/components/Scenario/Sanction/FieldTrigger.tsx
@@ -6,6 +6,7 @@ import {
   useValidateAstNode,
 } from '@app-builder/services/editor/ast-editor';
 import { useEffect } from 'react';
+import { hasSubObject } from 'remeda';
 import { useStore } from 'zustand';
 
 import { AstBuilder, type AstBuilderProps } from '../AstBuilder';
@@ -19,7 +20,7 @@ export const FieldTrigger = ({
   onBlur,
 }: {
   trigger?: AstNode;
-  onChange?: (node: AstNode | undefined) => void;
+  onChange?: (node?: AstNode) => void;
   onBlur?: () => void;
   scenarioId: string;
   iterationId: string;
@@ -41,7 +42,9 @@ export const FieldTrigger = ({
   useValidateAstNode(astEditorStore, validate, validation);
 
   useEffect(() => {
-    onChange?.(astNode);
+    onChange?.(
+      hasSubObject(NewEmptyTriggerAstNode(), astNode) ? undefined : astNode,
+    );
   }, [astNode, onChange]);
 
   return (

--- a/packages/app-builder/src/components/Scenario/Sanction/MatchOperand.tsx
+++ b/packages/app-builder/src/components/Scenario/Sanction/MatchOperand.tsx
@@ -1,4 +1,4 @@
-import { type AstNode } from '@app-builder/models';
+import { type AstNode, NewUndefinedAstNode } from '@app-builder/models';
 import {
   useGetAstNodeOperandProps,
   useOperandOptions,
@@ -13,7 +13,7 @@ export const MatchOperand = memo(function MatchOperand({
   placeholder,
   viewOnly,
 }: {
-  node: AstNode;
+  node?: AstNode;
   onSave?: (astNode: AstNode) => void;
   placeholder?: string;
   viewOnly?: boolean;
@@ -23,7 +23,7 @@ export const MatchOperand = memo(function MatchOperand({
 
   return (
     <Operand
-      {...getOperandAstNodeOperandProps(node)}
+      {...getOperandAstNodeOperandProps(node ?? NewUndefinedAstNode())}
       placeholder={placeholder}
       options={options.filter((o) => o.dataType === 'String')}
       validationStatus="valid"

--- a/packages/app-builder/src/locales/ar/scenarios.json
+++ b/packages/app-builder/src/locales/ar/scenarios.json
@@ -423,5 +423,6 @@
   "edit_aggregation.filters_in": "المرشحات في <strong>{{tableName}}</strong>",
   "sanction_counterparty_id.tooltip": "اختر قيمة معرف فريدة من نوعها (مثل IBAN ، رقم الهاتف) ، والتي يمكن أن تكون قائمة بيضاء في حالة وجود تطابق كاذب.",
   "sanction_counterparty_name.tooltip": "حدد الاسم الأول الاسم الأخير أو الاسم الكامل.",
-  "sanction_counterparty_id_placeholder": "حدد معرف طرف مقابل فريد"
+  "sanction_counterparty_id_placeholder": "حدد معرف طرف مقابل فريد",
+  "sanction.match_settings.no_empty": "تحتاج إلى تحديد اسم أو تسمية واحدة على الأقل"
 }

--- a/packages/app-builder/src/locales/en/scenarios.json
+++ b/packages/app-builder/src/locales/en/scenarios.json
@@ -196,6 +196,7 @@
   "sanction.nudge": "Improve your rules with a sanction check based on OpenSanction API",
   "sanction.match_settings.title": "Matching settings",
   "sanction.match_settings.callout": "Choose information that should be checked.",
+  "sanction.match_settings.no_empty": "You need to select at least one name or label",
   "sanction.lists.title": "Sanction lists",
   "sanction.lists.callout": "Select lists that are relevant to your business",
   "sanction.lists.nb_selected_one": "({{count}} selected)",

--- a/packages/app-builder/src/locales/fr/scenarios.json
+++ b/packages/app-builder/src/locales/fr/scenarios.json
@@ -423,5 +423,6 @@
   "edit_aggregation.filter_field_label": "Où",
   "sanction_counterparty_id.tooltip": "Choisissez une valeur d'identifiant unique (comme Iban, numéro de téléphone), qui peut être liste blanche en cas de faux match.",
   "sanction_counterparty_name.tooltip": "Sélectionnez le nom de famille du prénom ou le nom complet.",
-  "sanction_counterparty_id_placeholder": "Sélectionnez un identifiant de contrepartie unique"
+  "sanction_counterparty_id_placeholder": "Sélectionnez un identifiant de contrepartie unique",
+  "sanction.match_settings.no_empty": "Vous devez sélectionner au moins un nom ou un étiquette"
 }

--- a/packages/app-builder/src/models/sanction-check-config.ts
+++ b/packages/app-builder/src/models/sanction-check-config.ts
@@ -9,7 +9,6 @@ export type SanctionCheckConfig = {
   ruleGroup?: string;
   datasets?: string[];
   forceOutcome?: Outcome;
-  scoreModifier?: number;
   triggerRule?: AstNode;
   query: {
     name: AstNode;
@@ -27,7 +26,6 @@ export function adaptSanctionCheckConfig(
     ruleGroup: dto.rule_group,
     datasets: dto.datasets,
     forceOutcome: dto.force_outcome,
-    scoreModifier: dto.score_modifier,
     triggerRule: dto.trigger_rule ? adaptAstNode(dto.trigger_rule) : undefined,
     query: {
       name: adaptAstNode(dto.query.name),
@@ -48,7 +46,6 @@ export function adaptSanctionCheckConfigDto(
     rule_group: config.ruleGroup,
     datasets: config.datasets,
     force_outcome: config.forceOutcome,
-    score_modifier: config.scoreModifier,
     trigger_rule: config.triggerRule
       ? adaptNodeDto(config.triggerRule)
       : undefined,

--- a/packages/app-builder/src/models/sanction-check-config.ts
+++ b/packages/app-builder/src/models/sanction-check-config.ts
@@ -3,19 +3,19 @@ import { type SanctionCheckConfigDto } from 'marble-api';
 import { adaptAstNode, adaptNodeDto, type AstNode } from './astNode/ast-node';
 import { type Outcome } from './outcome';
 
-export type SanctionCheckConfig = {
-  name?: string;
-  description?: string;
-  ruleGroup?: string;
-  datasets?: string[];
-  forceOutcome?: Outcome;
-  triggerRule?: AstNode;
-  query: {
+export type SanctionCheckConfig = Partial<{
+  name: string;
+  description: string;
+  ruleGroup: string;
+  datasets: string[];
+  forcedOutcome: Outcome;
+  triggerRule: AstNode;
+  query: Partial<{
     name: AstNode;
-    label?: AstNode;
-  };
-  counterPartyId?: AstNode;
-};
+    label: AstNode;
+  }>;
+  counterPartyId: AstNode;
+}>;
 
 export function adaptSanctionCheckConfig(
   dto: SanctionCheckConfigDto,
@@ -25,10 +25,10 @@ export function adaptSanctionCheckConfig(
     description: dto.description,
     ruleGroup: dto.rule_group,
     datasets: dto.datasets,
-    forceOutcome: dto.force_outcome,
+    forcedOutcome: dto.forced_outcome,
     triggerRule: dto.trigger_rule ? adaptAstNode(dto.trigger_rule) : undefined,
     query: {
-      name: adaptAstNode(dto.query.name),
+      name: dto.query?.name ? adaptAstNode(dto.query.name) : undefined,
       label: dto.query?.label ? adaptAstNode(dto.query.label) : undefined,
     },
     counterPartyId: dto.counterparty_id_expression
@@ -45,12 +45,12 @@ export function adaptSanctionCheckConfigDto(
     description: config.description,
     rule_group: config.ruleGroup,
     datasets: config.datasets,
-    force_outcome: config.forceOutcome,
+    forced_outcome: config.forcedOutcome,
     trigger_rule: config.triggerRule
       ? adaptNodeDto(config.triggerRule)
       : undefined,
     query: {
-      name: adaptNodeDto(config.query.name),
+      name: config.query?.name ? adaptNodeDto(config.query.name) : undefined,
       label: config.query?.label ? adaptNodeDto(config.query.label) : undefined,
     },
     counterparty_id_expression: config.counterPartyId

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
@@ -235,7 +235,7 @@ export default function Rules() {
         },
       ),
       columnHelper.accessor(
-        (row) => (row.type === 'sanction' ? row.forceOutcome : undefined),
+        (row) => (row.type === 'sanction' ? row.forcedOutcome : undefined),
         {
           id: 'outcome',
           cell: ({ getValue }) => {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
@@ -212,25 +212,28 @@ export default function Rules() {
           return <Tag>{value}</Tag>;
         },
       }),
-      columnHelper.accessor((row) => row.scoreModifier, {
-        id: 'score',
-        cell: ({ getValue }) => {
-          const scoreModifier = getValue();
-          if (!scoreModifier) return '';
-          return (
-            <span
-              className={scoreModifier < 0 ? 'text-green-38' : 'text-red-47'}
-            >
-              {formatNumber(scoreModifier, {
-                language,
-                signDisplay: 'exceptZero',
-              })}
-            </span>
-          );
+      columnHelper.accessor(
+        (row) => (row.type === 'rule' ? row.scoreModifier : undefined),
+        {
+          id: 'score',
+          cell: ({ getValue }) => {
+            const scoreModifier = getValue();
+            if (!scoreModifier) return '';
+            return (
+              <span
+                className={scoreModifier < 0 ? 'text-green-38' : 'text-red-47'}
+              >
+                {formatNumber(scoreModifier, {
+                  language,
+                  signDisplay: 'exceptZero',
+                })}
+              </span>
+            );
+          },
+          header: t('scenarios:rules.score'),
+          size: 100,
         },
-        header: t('scenarios:rules.score'),
-        size: 100,
-      }),
+      ),
       columnHelper.accessor(
         (row) => (row.type === 'sanction' ? row.forceOutcome : undefined),
         {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout.tsx
@@ -33,7 +33,7 @@ import {
   useRouteLoaderData,
 } from '@remix-run/react';
 import { type Namespace } from 'i18next';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import invariant from 'tiny-invariant';
@@ -154,17 +154,21 @@ export function useCurrentScenarioIterationRule() {
 }
 
 export const useRuleGroups = () => {
-  const { rules } = useCurrentScenarioIteration();
+  const { rules, sanctionCheckConfig } = useCurrentScenarioIteration();
 
-  return React.useMemo(
+  return useMemo(
     () =>
       R.pipe(
-        rules,
-        R.map((rule) => rule.ruleGroup),
+        [
+          ...rules.map((r) => r.ruleGroup),
+          ...(sanctionCheckConfig?.ruleGroup
+            ? [sanctionCheckConfig.ruleGroup]
+            : []),
+        ],
         R.filter((val) => !R.isEmpty(val)),
         R.unique(),
       ),
-    [rules],
+    [rules, sanctionCheckConfig],
   );
 };
 

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -265,7 +265,12 @@ export default function SanctionDetail() {
   return (
     <Page.Main>
       <Page.Header className="justify-between">
-        <BreadCrumbs />
+        <BreadCrumbs
+          back={getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
+            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUID(scenario.id),
+          })}
+        />
       </Page.Header>
       <Page.Container>
         <Page.Content>

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -38,7 +38,6 @@ import { useForm } from '@tanstack/react-form';
 import { decode as formDataToObject } from 'decode-formdata';
 import { type Namespace } from 'i18next';
 import { serialize as objectToFormData } from 'object-to-formdata';
-import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { difference } from 'remeda';
 import { Button, Collapsible, Tag } from 'ui-design-system';
@@ -218,14 +217,9 @@ export default function SanctionDetail() {
   const editor = useEditorMode();
   const fetcher = useFetcher<typeof action>();
   const scenario = useCurrentScenario();
-  const defaultRuleGroups = useRuleGroups();
+  const ruleGroups = useRuleGroups();
   const { id: iterationId, sanctionCheckConfig } =
     useCurrentScenarioIteration();
-
-  const ruleGroups = useMemo(
-    () => [...defaultRuleGroups, 'Sanction check'],
-    [defaultRuleGroups],
-  );
 
   const form = useForm<EditSanctionForm>({
     onSubmit: ({ value, formApi }) => {
@@ -246,10 +240,11 @@ export default function SanctionDetail() {
     defaultValues: {
       name: sanctionCheckConfig?.name ?? 'Sanction Check',
       description: sanctionCheckConfig?.description ?? '',
-      ruleGroup: sanctionCheckConfig?.ruleGroup ?? 'Sanction check',
+      ruleGroup: sanctionCheckConfig?.ruleGroup ?? 'Sanction Check',
       datasets: sanctionCheckConfig?.datasets ?? [],
       forcedOutcome:
-        (sanctionCheckConfig?.forcedOutcome as SanctionOutcome) ?? 'decline',
+        (sanctionCheckConfig?.forcedOutcome as SanctionOutcome) ??
+        'block_and_review',
       triggerRule: sanctionCheckConfig?.triggerRule,
       query: {
         name: sanctionCheckConfig?.query?.name,
@@ -359,7 +354,6 @@ export default function SanctionDetail() {
                           {t('scenarios:rules.rule_group')}
                         </FormLabel>
                         <FieldRuleGroup
-                          disabled
                           name={field.name}
                           onChange={field.handleChange}
                           onBlur={field.handleBlur}

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -128,7 +128,7 @@ const editSanctionFormSchema = z.object({
   name: z.string().nonempty(),
   description: z.string().optional(),
   ruleGroup: z.string().nonempty(),
-  forceOutcome: z.union([
+  forcedOutcome: z.union([
     z.literal('review'),
     z.literal('decline'),
     z.literal('block_and_review'),
@@ -248,8 +248,8 @@ export default function SanctionDetail() {
       description: sanctionCheckConfig?.description ?? '',
       ruleGroup: sanctionCheckConfig?.ruleGroup ?? 'Sanction check',
       datasets: sanctionCheckConfig?.datasets ?? [],
-      forceOutcome:
-        (sanctionCheckConfig?.forceOutcome as SanctionOutcome) ?? 'decline',
+      forcedOutcome:
+        (sanctionCheckConfig?.forcedOutcome as SanctionOutcome) ?? 'decline',
       triggerRule: sanctionCheckConfig?.triggerRule,
       query: {
         name: sanctionCheckConfig?.query?.name,
@@ -372,7 +372,7 @@ export default function SanctionDetail() {
                       </div>
                     )}
                   </form.Field>
-                  <form.Field name="forceOutcome">
+                  <form.Field name="forcedOutcome">
                     {(field) => (
                       <div className="flex flex-col gap-2">
                         <FormLabel

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -127,7 +127,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 const editSanctionFormSchema = z.object({
   name: z.string().nonempty(),
   description: z.string().optional(),
-  scoreModifier: z.coerce.number(),
   ruleGroup: z.string().nonempty(),
   forceOutcome: z.union([
     z.literal('review'),
@@ -251,7 +250,6 @@ export default function SanctionDetail() {
       datasets: sanctionCheckConfig?.datasets ?? [],
       forceOutcome:
         (sanctionCheckConfig?.forceOutcome as SanctionOutcome) ?? 'decline',
-      scoreModifier: sanctionCheckConfig?.scoreModifier ?? 0,
       triggerRule: sanctionCheckConfig?.triggerRule,
       query: {
         name: sanctionCheckConfig?.query?.name,
@@ -341,36 +339,6 @@ export default function SanctionDetail() {
                           }
                           placeholder={t(
                             'scenarios:edit_rule.description_placeholder',
-                          )}
-                          valid={field.state.meta.errors.length === 0}
-                        />
-                        <FormErrorOrDescription
-                          errors={field.state.meta.errors}
-                        />
-                      </div>
-                    )}
-                  </form.Field>
-                  <form.Field name="scoreModifier">
-                    {(field) => (
-                      <div className="flex flex-col gap-2">
-                        <FormLabel
-                          name={field.name}
-                          className="text-m"
-                          valid={field.state.meta.errors.length === 0}
-                        >
-                          {t('scenarios:edit_rule.score')}
-                        </FormLabel>
-                        <FormInput
-                          disabled={editor === 'view'}
-                          defaultValue={field.state.value}
-                          type="number"
-                          name={field.name}
-                          onBlur={field.handleBlur}
-                          onChange={(e) =>
-                            field.handleChange(+e.currentTarget.value)
-                          }
-                          placeholder={t(
-                            'scenarios:edit_rule.score_placeholder',
                           )}
                           valid={field.state.meta.errors.length === 0}
                         />

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
@@ -1,12 +1,53 @@
 import { Nudge } from '@app-builder/components/Nudge';
+import { serverServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
-import { Link } from '@remix-run/react';
+import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
+import { useFetcher } from '@remix-run/react';
 import clsx from 'clsx';
+import { type Namespace } from 'i18next';
 import { type FeatureAccessDto } from 'marble-api/generated/license-api';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'ui-design-system';
 import { Icon } from 'ui-icons';
+
+export const handle = {
+  i18n: ['scenarios'] satisfies Namespace,
+};
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const { authService } = serverServices;
+  const { scenarioIterationSanctionRepository } =
+    await authService.isAuthenticated(request, {
+      failureRedirect: getRoute('/sign-in'),
+    });
+  const scenarioId = fromParams(params, 'scenarioId');
+  const iterationId = fromParams(params, 'iterationId');
+
+  try {
+    await scenarioIterationSanctionRepository.upsertSanctionCheckConfig({
+      iterationId,
+      changes: {
+        name: 'Sanction Check',
+        ruleGroup: 'Sanction Check',
+        forcedOutcome: 'decline',
+      },
+    });
+
+    return redirect(
+      getRoute('/scenarios/:scenarioId/i/:iterationId/sanction', {
+        scenarioId: fromUUID(scenarioId),
+        iterationId: fromUUID(iterationId),
+      }),
+    );
+  } catch (error) {
+    console.log('Error', error);
+    return json({
+      success: false as const,
+      error: error,
+    });
+  }
+}
 
 export function CreateSanction({
   scenarioId,
@@ -20,15 +61,21 @@ export function CreateSanction({
   hasAlreadyASanction: boolean;
 }) {
   const { t } = useTranslation(['scenarios']);
+  const fetcher = useFetcher<typeof action>();
 
   return (
-    <Link
-      to={getRoute('/scenarios/:scenarioId/i/:iterationId/sanction', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
-      })}
+    <fetcher.Form
+      method="POST"
+      action={getRoute(
+        '/ressources/scenarios/:scenarioId/:iterationId/sanctions/create',
+        {
+          scenarioId: fromUUID(scenarioId),
+          iterationId: fromUUID(iterationId),
+        },
+      )}
     >
       <Button
+        type="submit"
         variant="dropdown"
         size="dropdown"
         disabled={hasAlreadyASanction || isSanctionAvailable === 'restricted'}
@@ -60,6 +107,6 @@ export function CreateSanction({
           />
         ) : null}
       </Button>
-    </Link>
+    </fetcher.Form>
   );
 }

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
@@ -30,7 +30,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       changes: {
         name: 'Sanction Check',
         ruleGroup: 'Sanction Check',
-        forcedOutcome: 'decline',
+        forcedOutcome: 'block_and_review',
       },
     });
 

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete.tsx
@@ -1,40 +1,30 @@
 import { serverServices } from '@app-builder/services/init.server';
-import { parseFormSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
-import { Button, HiddenInputs, ModalV2 } from 'ui-design-system';
+import { Button, ModalV2 } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { z } from 'zod';
 
 export const handle = {
   i18n: ['scenarios', 'navigation', 'common'] satisfies Namespace,
 };
 
-const deleteSanctionFormSchema = z.object({
-  scenarioId: z.string().uuid(),
-  iterationId: z.string().uuid(),
-});
-
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ request, params }: ActionFunctionArgs) {
   const { authService } = serverServices;
+  const iterationId = fromParams(params, 'iterationId');
+  const scenarioId = fromParams(params, 'scenarioId');
   const { scenarioIterationSanctionRepository } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),
     });
 
-  const parsedForm = await parseFormSafe(request, deleteSanctionFormSchema);
-  if (!parsedForm.success) {
-    // TODO check error
-    return null;
-  }
-  const { scenarioId, iterationId } = parsedForm.data;
   await scenarioIterationSanctionRepository.deleteSanctioncheckConfig({
     iterationId,
   });
+
   return redirect(
     getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
       scenarioId: fromUUID(scenarioId),
@@ -59,48 +49,48 @@ export function DeleteSanction({
     <ModalV2.Root>
       <ModalV2.Trigger render={children} />
       <ModalV2.Content>
-        <fetcher.Form
-          method="DELETE"
-          action={getRoute(
-            `/ressources/scenarios/:scenarioId/:iterationId/sanctions/delete`,
-            {
-              scenarioId: fromUUID(scenarioId),
-              iterationId: fromUUID(iterationId),
-            },
-          )}
-        >
-          <HiddenInputs scenarioId={scenarioId} iterationId={iterationId} />
-          <div className="flex flex-col gap-6 p-6">
-            <div className="flex flex-1 flex-col items-center justify-center gap-2">
-              <div className="bg-red-95 mb-6 box-border rounded-[90px] p-4">
-                <Icon icon="delete" className="text-red-47 size-16" />
-              </div>
-              <h1 className="text-l font-semibold">
-                {t('scenarios:delete_sanction.title')}
-              </h1>
-              <p className="text-center">
-                {t('scenarios:delete_sanction.content')}
-              </p>
+        <div className="flex flex-col gap-6 p-6">
+          <div className="flex flex-1 flex-col items-center justify-center gap-2">
+            <div className="bg-red-95 mb-6 box-border rounded-[90px] p-4">
+              <Icon icon="delete" className="text-red-47 size-16" />
             </div>
-            <div className="flex flex-1 flex-row gap-2">
-              <ModalV2.Close
-                render={<Button className="flex-1" variant="secondary" />}
-              >
-                {t('common:cancel')}
-              </ModalV2.Close>
-              <Button
-                color="red"
-                className="flex-1"
-                variant="primary"
-                type="submit"
-                name="delete"
-              >
-                <Icon icon="delete" className="size-6" />
-                {t('common:delete')}
-              </Button>
-            </div>
+            <h1 className="text-l font-semibold">
+              {t('scenarios:delete_sanction.title')}
+            </h1>
+            <p className="text-center">
+              {t('scenarios:delete_sanction.content')}
+            </p>
           </div>
-        </fetcher.Form>
+          <div className="flex flex-1 flex-row gap-2">
+            <ModalV2.Close
+              render={<Button className="flex-1" variant="secondary" />}
+            >
+              {t('common:cancel')}
+            </ModalV2.Close>
+            <Button
+              color="red"
+              className="flex-1"
+              variant="primary"
+              type="button"
+              name="delete"
+              onClick={() =>
+                fetcher.submit(new FormData(), {
+                  method: 'DELETE',
+                  action: getRoute(
+                    `/ressources/scenarios/:scenarioId/:iterationId/sanctions/delete`,
+                    {
+                      scenarioId: fromUUID(scenarioId),
+                      iterationId: fromUUID(iterationId),
+                    },
+                  ),
+                })
+              }
+            >
+              <Icon icon="delete" className="size-6" />
+              {t('common:delete')}
+            </Button>
+          </div>
+        </div>
       </ModalV2.Content>
     </ModalV2.Root>
   );

--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -5060,8 +5060,6 @@ components:
             $ref: '#/components/schemas/OpenSanctionsCatalogSection'
     SanctionCheckConfigDto:
       type: object
-      required:
-        - query
       properties:
         name:
           type: string
@@ -5073,16 +5071,12 @@ components:
           type: array
           items:
             type: string
-        force_outcome:
+        forced_outcome:
           $ref: '#/components/schemas/OutcomeDto'
-        score_modifier:
-          type: number
         trigger_rule:
           $ref: '#/components/schemas/NodeDto'
         query:
           type: object
-          required:
-            - name
           properties:
             name:
               $ref: '#/components/schemas/NodeDto'

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -387,11 +387,10 @@ export type SanctionCheckConfigDto = {
     description?: string;
     rule_group?: string;
     datasets?: string[];
-    force_outcome?: OutcomeDto;
-    score_modifier?: number;
+    forced_outcome?: OutcomeDto;
     trigger_rule?: NodeDto;
-    query: {
-        name: NodeDto;
+    query?: {
+        name?: NodeDto;
         label?: NodeDto;
     };
     counterparty_id_expression?: NodeDto;


### PR DESCRIPTION
- [X] Removing Score Modifier from Sanction check Config
- [X] Save empty sanction when creating new sanction check config
- [X] Prevent double submit when deleting Sanction Check Config
- [X] Set `block_and_review` as default choice for `forced_outcome`
- [X] Enable `rule_group` selector in the sanction check config form
- [X] Back Button on Sanction Check Config redirect to rules page
- [x] Return `undefined` if node is of type `UndefinedNode`
- [x] Clear from `CounterPartyName` nodes which are `UndefinedNode`
- [x] Add zod Validation if we don't have at least `name` or `label` in the query
- [x] Branch Validation for sanction check config