### PR TITLE
fix: fix sanctions checks bugs

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseDecisions.tsx
+++ b/packages/app-builder/src/components/Cases/CaseDecisions.tsx
@@ -387,19 +387,23 @@ function DecisionDetail({
               </span>
               <div className="inline-flex items-center gap-2">
                 <SanctionState sanctionCheck={sanctionCheck} />
-                {sanctionCheck.status === 'in_review' ? (
-                  <Link
-                    to={getRoute('/cases/:caseId/sanctions/:decisionId', {
-                      caseId: fromUUID(caseId),
-                      decisionId: fromUUID(decision.id),
-                    })}
-                  >
-                    <Button>
-                      <Icon icon="case-manager" className="size-5" />
-                      {t('sanctions:start_reviewing')}
-                    </Button>
-                  </Link>
-                ) : null}
+                <Link
+                  to={getRoute('/cases/:caseId/sanctions/:decisionId', {
+                    caseId: fromUUID(caseId),
+                    decisionId: fromUUID(decision.id),
+                  })}
+                >
+                  <Button>
+                    {sanctionCheck.status === 'in_review' ? (
+                      <>
+                        <Icon icon="case-manager" className="size-5" />
+                        {t('sanctions:start_reviewing')}
+                      </>
+                    ) : (
+                      t('sanctions:see_details')
+                    )}
+                  </Button>
+                </Link>
               </div>
             </div>
           </>

--- a/packages/app-builder/src/components/Decisions/SanctionCheckDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/SanctionCheckDetail.tsx
@@ -1,9 +1,12 @@
 import { decisionsI18n } from '@app-builder/components';
 import { type SanctionCheck } from '@app-builder/models/sanction-check';
 import { useTranslation } from 'react-i18next';
+import * as R from 'remeda';
 import { Collapsible } from 'ui-design-system';
+import { Icon } from 'ui-icons';
 
 import { MatchCard } from '../Sanctions/MatchCard';
+import { SanctionStatusTag } from '../Sanctions/SanctionStatusTag';
 
 export function SanctionCheckDetail({
   sanctionCheck,
@@ -11,14 +14,40 @@ export function SanctionCheckDetail({
   sanctionCheck: SanctionCheck;
 }) {
   const { t } = useTranslation(decisionsI18n);
+  const searchInputs = R.pipe(
+    R.values(sanctionCheck.request.queries),
+    R.flatMap((query) => R.values(query.properties)),
+    R.flat(),
+  );
 
   return (
     <Collapsible.Container className="bg-grey-100">
       <Collapsible.Title>
-        {t('decisions:sanction_check.title')}
+        <div className="flex grow items-center justify-between">
+          <span>{t('decisions:sanction_check.title')}</span>
+          <SanctionStatusTag
+            status={sanctionCheck.status}
+            border="square"
+            className="h-8"
+          />
+        </div>
       </Collapsible.Title>
       <Collapsible.Content>
         <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <span>{t('sanctions:search_input')}</span>
+            {searchInputs.map((input, i) => (
+              <div
+                key={i}
+                className="border-grey-90 flex items-center gap-2 rounded border p-2"
+              >
+                <span className="bg-grey-95 size-6 rounded-sm p-1">
+                  <Icon icon="string" className="size-4" />
+                </span>
+                {input}
+              </div>
+            ))}
+          </div>
           {sanctionCheck.matches.map((match) => (
             <MatchCard readonly key={match.id} match={match} />
           ))}

--- a/packages/app-builder/src/components/Decisions/decisions-i18n.ts
+++ b/packages/app-builder/src/components/Decisions/decisions-i18n.ts
@@ -7,5 +7,6 @@ export const decisionsI18n = [
   'common',
   'scenarios',
   'cases',
+  'sanctions',
   ...filtersI18n,
 ] satisfies Namespace;

--- a/packages/app-builder/src/locales/ar/sanctions.json
+++ b/packages/app-builder/src/locales/ar/sanctions.json
@@ -111,5 +111,6 @@
   "refine_modal.schema.legalentity": "الكيان القانوني",
   "match.status.skipped": "تخطي",
   "match.unique_counterparty_identifier": "معرف فريد للطرف المقابل",
-  "sanction_check": "فحص العقوبة"
+  "sanction_check": "فحص العقوبة",
+  "see_details": "انظر التفاصيل"
 }

--- a/packages/app-builder/src/locales/en/sanctions.json
+++ b/packages/app-builder/src/locales/en/sanctions.json
@@ -23,6 +23,7 @@
   "review_modal.status_label": "Choose a status",
   "review_modal.title": "Change match status",
   "review_modal.whitelist_label": "Do not alert again if this profile is associated with:",
+  "see_details": "See details",
   "start_reviewing": "Start reviewing",
   "search_input": "Search input",
   "status.in_review": "Hits to review",

--- a/packages/app-builder/src/locales/fr/sanctions.json
+++ b/packages/app-builder/src/locales/fr/sanctions.json
@@ -97,19 +97,20 @@
   "status.error": "Erreur",
   "status.in_review": "Hits à réviser",
   "status.no_hit": "Pas de correspondance",
-  "review_modal.callout_confirmed_hit": "En choisissant de confirmer cette correspondance, l'état de ce contrôle de sanction sera automatiquement modifié pour Confirmation de correspondance",
+  "review_modal.callout_confirmed_hit": "En choisissant de confirmer cette correspondance, l'état de ce filtrage de sanction sera automatiquement modifié pour Confirmation de correspondance",
   "review_modal.comment_label": "Ajouter un commentaire",
   "review_modal.status_label": "Choisissez un statut",
   "review_modal.title": "Modifier l'état de la correspondance",
   "review_modal.whitelist_label": "Ne plus alerter si ce profil est associé à:",
   "callout.needs_review": "{{toreview}} / {{totalmatches}} à examiner",
   "entity.schema.vehicle": "Véhicule",
-  "refine_modal.no_match_callout": "En appliquant cette recherche, le contrôle de sanction sera défini comme suit: <Statut />",
+  "refine_modal.no_match_callout": "En appliquant cette recherche, le filtrage de sanction sera défini comme suit: <Statut />",
   "refine_modal.no_match_label": "Aucune correspondance possible n'a été trouvée avec votre recherche.",
   "refine_modal.schema.vehicle": "Véhicule",
   "entity.schema.airplane": "Avion",
   "entity.schema.vessel": "Navire",
   "match.status.skipped": "Sauté",
   "match.unique_counterparty_identifier": "Identifiant unique de contrepartie",
-  "sanction_check": "Filtrage des sanction"
+  "sanction_check": "Filtrage des sanction",
+  "see_details": "Voir les détails"
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_layout.tsx
@@ -172,7 +172,12 @@ export default function CaseSanctionReviewPage() {
   return (
     <Page.Main>
       <Page.Header className="justify-between gap-8">
-        <BreadCrumbs />
+        <div className="flex gap-4">
+          <Page.BackLink
+            to={getRoute('/cases/:caseId', { caseId: fromUUID(caseDetail.id) })}
+          />
+          <BreadCrumbs />
+        </div>
       </Page.Header>
       <div className="flex size-full flex-col overflow-hidden">
         <div className="flex flex-1 flex-row overflow-hidden">

--- a/packages/app-builder/src/routes/ressources+/cases+/review-decision.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/review-decision.tsx
@@ -173,7 +173,7 @@ function ReviewDecisionContent({
             >
               {nonPendingReviewStatuses.map((reviewStatus) => {
                 const disabled =
-                  sanctionCheck && sanctionCheck.status === 'in_review';
+                  sanctionCheck && sanctionCheck.status !== 'no_hit';
 
                 return disabled && reviewStatus === 'approve' ? (
                   <div className="flex flex-col items-start gap-2 p-1">


### PR DESCRIPTION
- Add information from sanction check in decision detail
- Keep button to sanction check on case when it's reviewed, changed the wording accordingly
- Add back button before breadcrumb leading to case page on sanction pages
- Make the decision able to be approved only if the sanction check (if there's one) has the status "no_hit"