### PR TITLE
OpenAPI: add the match enrichment API.

### DIFF
--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -149,6 +149,8 @@ paths:
     $ref: ./marblecore-api/sanction-checks.yml#/~1sanction-checks~1{sanctionCheckId}~1files
   /sanction-checks/matches/{matchId}:
     $ref: ./marblecore-api/sanction-checks.yml#/~1sanction-checks~1matches~1{matchId}
+  /sanction-checks/matches/{matchId}/enrich:
+    $ref: ./marblecore-api/sanction-checks.yml#/~1sanction-checks~1matches~1{matchId}~1enrich
   /sanction-checks/search:
     $ref: ./marblecore-api/sanction-checks.yml#/~1sanction-checks~1search
   /sanction-checks/refine:

--- a/packages/marble-api/openapis/marblecore-api/sanction-checks.yml
+++ b/packages/marble-api/openapis/marblecore-api/sanction-checks.yml
@@ -85,6 +85,31 @@
           application/json:
             schema:
               $ref: '#/components/schemas/SanctionCheckMatchDto'
+/sanction-checks/matches/{matchId}/enrich:
+  post:
+    tags:
+      - Sanction Check
+    summary: Enrich the match payload with complete data
+    operationId: enrichSanctionCheckMatch
+    parameters:
+      - name: matchId
+        description: ID of the match to update
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '200':
+        description: The match returned ?
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SanctionCheckMatchDto'
+      '404':
+        $ref: 'components.yml#/responses/404'
+      '409':
+        $ref: 'components.yml#/responses/409'
 /sanction-checks/search:
   post:
     tags:
@@ -308,6 +333,7 @@ components:
         - status
         - datasets
         - payload
+        - enriched
         - comments
       properties:
         id:
@@ -327,6 +353,8 @@ components:
           type: string
         payload:
           $ref: '#/components/schemas/SanctionCheckMatchPayloadDto'
+        enriched:
+          type: boolean
         comments:
           type: array
           items:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -510,6 +510,7 @@ export type SanctionCheckMatchDto = {
     datasets: any;
     unique_counterparty_identifier?: string;
     payload: SanctionCheckMatchPayloadDto;
+    enriched: boolean;
     comments: {
         id: string;
         author_id: string;
@@ -1948,6 +1949,24 @@ export function updateSanctionCheckMatch(matchId: string, updateSanctionCheckMat
         method: "PATCH",
         body: updateSanctionCheckMatchDto
     })));
+}
+/**
+ * Enrich the match payload with complete data
+ */
+export function enrichSanctionCheckMatch(matchId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: SanctionCheckMatchDto;
+    } | {
+        status: 404;
+        data: string;
+    } | {
+        status: 409;
+        data: string;
+    }>(`/sanction-checks/matches/${encodeURIComponent(matchId)}/enrich`, {
+        ...opts,
+        method: "POST"
+    }));
 }
 /**
  * Search possible matches


### PR DESCRIPTION
The backend adds a new API to instruct it to enrich a match payload with additional data not present in the initial search.