### PR TITLE
feat: display wikidata Id as a link

### DIFF
--- a/packages/app-builder/src/components/ExternalLink.tsx
+++ b/packages/app-builder/src/components/ExternalLink.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
 import { forwardRef } from 'react';
+import { cn } from 'ui-design-system';
 
 export const linkClasses =
   'hover:text-purple-60 focus:text-purple-60 font-semibold lowercase text-purple-65 hover:underline focus:underline';
@@ -9,7 +9,7 @@ export const ExternalLink = forwardRef<HTMLAnchorElement, React.ComponentPropsWi
     return (
       <a
         ref={ref}
-        className={clsx(linkClasses, className)}
+        className={cn(linkClasses, className)}
         target="_blank"
         rel="noopener noreferrer"
         {...otherProps}

--- a/packages/app-builder/src/constants/sanction-check-entity.tsx
+++ b/packages/app-builder/src/constants/sanction-check-entity.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { type SanctionCheckEntitySchema } from '@app-builder/models/sanction-check';
 
-export type PropertyDataType = 'string' | 'country' | 'url' | 'date';
+export type PropertyDataType = 'string' | 'country' | 'url' | 'date' | 'wikidataId';
 export type PropertyForSchema<
   Schema extends SanctionCheckEntitySchema,
   _R = never,
@@ -169,7 +169,7 @@ const propertyMetadata = {
   weakAlias: { type: 'string' },
   website: { type: 'url' },
   weight: { type: 'string' },
-  wikidataId: { type: 'string' },
+  wikidataId: { type: 'wikidataId' },
 } satisfies Record<SanctionCheckEntityProperty, { type: PropertyDataType }>;
 
 export function getSanctionEntityProperties(schema: SanctionCheckEntitySchema) {
@@ -212,6 +212,12 @@ export function createPropertyTransformer(ctx: { language: string; formatLanguag
         }
       case 'date':
         return <time dateTime={value}>{intlDate.format(new Date(value))}</time>;
+      case 'wikidataId':
+        return (
+          <ExternalLink href={`https://wikidata.org/wiki/${value}`} className="normal-case">
+            {value}
+          </ExternalLink>
+        );
     }
   };
 }


### PR DESCRIPTION
Display wikidata ID as a link in sanction check match:
<img width="244" alt="image" src="https://github.com/user-attachments/assets/b41403e1-5b03-4353-88e0-c9fda8684071" />
