### PR TITLE
fix: break all spaces on sanction check matches

### DIFF
--- a/packages/app-builder/src/components/Sanctions/MatchDetails.tsx
+++ b/packages/app-builder/src/components/Sanctions/MatchDetails.tsx
@@ -53,7 +53,7 @@ export function MatchDetails({ entity }: MatchDetailsProps) {
         return (
           <Fragment key={property}>
             <span className="font-bold">{t(`sanctions:entity.property.${property}`)}</span>
-            <span className="flex flex-wrap gap-1">
+            <span className="flex flex-wrap gap-1 break-all">
               {values.map((v, i) => (
                 <Fragment key={i}>
                   <TransformProperty property={property} value={v} />


### PR DESCRIPTION
Text was overflowing from its container:
<img width="802" alt="image" src="https://github.com/user-attachments/assets/d71ccefd-d8a0-4534-be0f-7f67f30cddb7" />

Text is not overflowing anymore:
<img width="802" alt="image" src="https://github.com/user-attachments/assets/8f409dec-9107-49cb-9a1f-b81c5efa5935" />
