### PR TITLE
Better error messages in aggregation modale

### DIFF
--- a/packages/app-builder/src/locales/ar/scenarios.json
+++ b/packages/app-builder/src/locales/ar/scenarios.json
@@ -152,6 +152,8 @@
   "validation.evaluation_error.division_by_zero_other": "{{count}} قسمة على صفر.",
   "validation.evaluation_error.payload_field_not_found_one": "لم يتم العثور على حقل الحمولة",
   "validation.evaluation_error.payload_field_not_found_other": "{{count}} payload fields not found",
+  "validation.evaluation_error.aggregation_field_incompatible_with_aggregator": "نوع حقل التجميع غير متوافق مع وظيفة التجميع",
+  "validation.evaluation_error.aggregation_field_not_chosen": "يجب اختيار مجال التجميع",
   "edit_aggregation.title": "إنشاء متغير",
   "edit_aggregation.subtitle": "من قاعدة بيانات Marble",
   "edit_aggregation.description": "يتم حساب التجميعات على البيانات التي تم استيرادها. (<DocLink>لمعرفة المزيد</DocLink>)",

--- a/packages/app-builder/src/locales/en/scenarios.json
+++ b/packages/app-builder/src/locales/en/scenarios.json
@@ -303,6 +303,8 @@
   "validation.evaluation_error.payload_field_not_found_one": "payload field not found",
   "validation.evaluation_error.payload_field_not_found_other": "{{count}} payload fields not found",
   "validation.evaluation_error.filters_table_not_match": "filter must be applied on the same table than aggregate",
+  "validation.evaluation_error.aggregation_field_not_chosen": "You must select a field and entity to compute the aggregate on",
+  "validation.evaluation_error.aggregation_field_incompatible_with_aggregator": "This aggregation function is incompatible with the data type of the field you selected",
   "edit_aggregation.title": "Create a variable",
   "edit_aggregation.subtitle": "From Marble database",
   "edit_aggregation.description": "Computes aggregates on your ingested data (<DocLink>learn more</DocLink>)",

--- a/packages/app-builder/src/locales/fr/scenarios.json
+++ b/packages/app-builder/src/locales/fr/scenarios.json
@@ -258,6 +258,8 @@
   "validation.evaluation_error.undefined_function_one": "requis",
   "validation.evaluation_error.undefined_function_other": "{{count}} requis",
   "validation.evaluation_error.wrong_number_of_arguments": "mauvais nombre d'arguments",
+  "validation.evaluation_error.aggregation_field_not_chosen": "Vous devez sélectionner un champ et une entité sur lequel l'agrégation sera effectuée",
+  "validation.evaluation_error.aggregation_field_incompatible_with_aggregator": "Cette fonction d'agrégation est incompatible avec le champ que vous avez sélectionné",
   "custom_list.unknown": "Liste inconnue",
   "scenarios.description": "Un scénario permet de détecter un certain type de risque, selon des règles métier spécifiques, pour un événement déclencheur spécifique.",
   "trigger_object.description": "L'objet central qui initie le processus de prise de décision. Il est accessible lors de l'exécution du scénario.",

--- a/packages/app-builder/src/services/validation/scenario-validation-error-messages.ts
+++ b/packages/app-builder/src/services/validation/scenario-validation-error-messages.ts
@@ -37,7 +37,11 @@ export type EvaluationErrorViewModel =
       count: number;
     }
   | {
-      error: 'WRONG_NUMBER_OF_ARGUMENTS' | 'FILTERS_TABLE_NOT_MATCH';
+      error:
+        | 'WRONG_NUMBER_OF_ARGUMENTS'
+        | 'FILTERS_TABLE_NOT_MATCH'
+        | 'AGGREGATION_FIELD_NOT_CHOSEN'
+        | 'AGGREGATION_FIELD_INCOMPATIBLE_WITH_AGGREGATOR';
     };
 
 export function adaptEvaluationErrorViewModels(
@@ -144,6 +148,12 @@ const commonErrorMessages =
         return t('scenarios:validation.evaluation_error.wrong_number_of_arguments');
       case 'FILTERS_TABLE_NOT_MATCH':
         return t('scenarios:validation.evaluation_error.filters_table_not_match');
+      case 'AGGREGATION_FIELD_NOT_CHOSEN':
+        return t('scenarios:validation.evaluation_error.aggregation_field_not_chosen');
+      case 'AGGREGATION_FIELD_INCOMPATIBLE_WITH_AGGREGATOR':
+        return t(
+          'scenarios:validation.evaluation_error.aggregation_field_incompatible_with_aggregator',
+        );
       case 'MISSING_NAMED_ARGUMENT':
         return t('scenarios:validation.evaluation_error.missing_named_argument', {
           count: evaluationError.count,


### PR DESCRIPTION
## Prerequisites
See https://github.com/checkmarble/marble-backend/pull/889 for error codes definition.

## Content 

Display a "pretty" error message below the field selector in the aggregation modale when the state of the node is not completely set, or inconsistent choices are made.

## Screenshots

No field chosen:
<img width="600" alt="Capture d’écran 2025-03-05 à 23 35 35" src="https://github.com/user-attachments/assets/7d47cdd1-0c93-495d-be01-aa72c3a2fc2c" />

Field chosen has a type that is not compatible with this aggregation function:
<img width="600" alt="Capture d’écran 2025-03-05 à 23 35 45" src="https://github.com/user-attachments/assets/653c4a07-4fba-42c3-965e-c2bdd74d904d" />



