### PR TITLE
Try and extract error message from ingestion error.

### DIFF
--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -214,6 +214,20 @@ const ResultModal = ({
   const { t } = useTranslation(handle.i18n);
   const icon = modalContent.success ? 'tick' : 'cross';
 
+  const errorMessage = (errorString?: string): string | undefined => {
+    if (errorString) {
+      try {
+        const error = JSON.parse(errorString);
+
+        if ('message' in error) return error.message;
+      } catch (error) {
+        return errorString;
+      }
+    }
+
+    return errorString;
+  };
+
   return (
     <Modal.Root open={isOpen} onOpenChange={onOpenChange}>
       <Modal.Content>
@@ -232,7 +246,7 @@ const ResultModal = ({
             <p>{modalContent.message}</p>
             {!modalContent.success ? (
               <>
-                <p>{modalContent.error}</p>
+                <p className="first-letter:capitalize">{errorMessage(modalContent.error)}</p>
                 <p className="mt-6">
                   {t('upload:failure_additional_message', {
                     replace: { objectType },


### PR DESCRIPTION
This PR touches the error message displayed to the user when an issue happens with CSV parsing. We used to display the raw JSON returned by the backend, this parses the JSON to only display the message.

![image](https://github.com/user-attachments/assets/3980b512-af35-44f6-ae38-6c616d37b916)

Do not hesitate to edit this PR if you want to improve either how it is displayed, or how I implemented it.