### PR TITLE
fix: LoM on sanction check page

### DIFF
--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -205,10 +205,12 @@ export default function SanctionDetail() {
     useLoaderData<typeof loader>();
   const editor = useEditorMode();
   const { submit, data } = useFetcher<typeof action>();
-  const lastData = data as {
-    status: 'error' | 'success';
-    errors?: z.typeToFlattenedError<EditSanctionForm>;
-  };
+  const lastData = data as
+    | {
+        status: 'error' | 'success';
+        errors?: z.typeToFlattenedError<EditSanctionForm>;
+      }
+    | undefined;
   const scenario = useCurrentScenario();
   const ruleGroups = useRuleGroups();
   const { id: iterationId, sanctionCheckConfig } = useCurrentScenarioIteration();
@@ -254,7 +256,7 @@ export default function SanctionDetail() {
     triggerObjectType: scenario.triggerObjectType,
   };
 
-  if (!form.state.isTouched && lastData.status === 'error' && lastData.errors) {
+  if (!form.state.isTouched && lastData?.status === 'error' && lastData?.errors) {
     Dict.entries(lastData.errors.fieldErrors).forEach(([field, errors]) =>
       form.setFieldMeta(field, (prev) => ({
         ...prev,


### PR DESCRIPTION
Fix casting of `lastData` as it can be undefined on first page load