### PR TITLE
feat: forward trace headers to backend queries MAR-671

### DIFF
--- a/packages/app-builder/src/entry.server.tsx
+++ b/packages/app-builder/src/entry.server.tsx
@@ -10,7 +10,7 @@ import { renderToPipeableStream } from 'react-dom/server';
 import { I18nextProvider } from 'react-i18next';
 import { PassThrough } from 'stream';
 
-import { serverServices } from './services/init.server';
+import { initServerServices } from './services/init.server';
 import { captureUnexpectedRemixError } from './services/monitoring';
 import { getServerEnv } from './utils/environment';
 
@@ -22,7 +22,7 @@ export default async function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext,
 ) {
-  const { i18nextService } = serverServices;
+  const { i18nextService } = initServerServices(request);
   const i18n = await i18nextService.getI18nextServerInstance(request, remixContext);
 
   const App = (

--- a/packages/app-builder/src/infra/marblecore-api.ts
+++ b/packages/app-builder/src/infra/marblecore-api.ts
@@ -1,4 +1,9 @@
-import { fetchWithAuthMiddleware, marblecoreApi, type TokenService } from 'marble-api';
+import {
+  createBasicFetch,
+  createFetchWithAuthMiddleware,
+  marblecoreApi,
+  type TokenService,
+} from 'marble-api';
 import * as R from 'remeda';
 import { type FunctionKeys } from 'typescript-utils';
 
@@ -7,21 +12,24 @@ export type MarbleCoreApi = {
 };
 
 function getMarbleCoreAPIClient({
+  request,
   tokenService,
   baseUrl,
 }: {
+  request: Request;
   baseUrl: string;
   tokenService?: TokenService<string>;
 }): MarbleCoreApi {
   const fetch = tokenService
-    ? fetchWithAuthMiddleware({
+    ? createFetchWithAuthMiddleware({
+        request,
         tokenService,
         getAuthorizationHeader: (token) => ({
           name: 'Authorization',
           value: `Bearer ${token}`,
         }),
       })
-    : undefined;
+    : createBasicFetch({ request });
 
   const { defaults, servers, ...api } = marblecoreApi;
 
@@ -35,13 +43,19 @@ function getMarbleCoreAPIClient({
 
 export type GetMarbleCoreAPIClientWithAuth = (tokenService: TokenService<string>) => MarbleCoreApi;
 
-export function initializeMarbleCoreAPIClient({ baseUrl }: { baseUrl: string }): {
+export function initializeMarbleCoreAPIClient({
+  request,
+  baseUrl,
+}: {
+  request: Request;
+  baseUrl: string;
+}): {
   marbleCoreApiClient: MarbleCoreApi;
   getMarbleCoreAPIClientWithAuth: GetMarbleCoreAPIClientWithAuth;
 } {
   return {
-    marbleCoreApiClient: getMarbleCoreAPIClient({ baseUrl }),
+    marbleCoreApiClient: getMarbleCoreAPIClient({ request, baseUrl }),
     getMarbleCoreAPIClientWithAuth: (tokenService: TokenService<string>) =>
-      getMarbleCoreAPIClient({ tokenService, baseUrl }),
+      getMarbleCoreAPIClient({ request, tokenService, baseUrl }),
   };
 }

--- a/packages/app-builder/src/infra/transfercheck-api.ts
+++ b/packages/app-builder/src/infra/transfercheck-api.ts
@@ -1,4 +1,9 @@
-import { fetchWithAuthMiddleware, type TokenService, transfercheckApi } from 'marble-api';
+import {
+  createBasicFetch,
+  createFetchWithAuthMiddleware,
+  type TokenService,
+  transfercheckApi,
+} from 'marble-api';
 import * as R from 'remeda';
 import { type FunctionKeys } from 'typescript-utils';
 
@@ -7,21 +12,24 @@ export type TransfercheckApi = {
 };
 
 function getTransfercheckAPIClient({
+  request,
   tokenService,
   baseUrl,
 }: {
+  request: Request;
   baseUrl: string;
   tokenService?: TokenService<string>;
 }): TransfercheckApi {
   const fetch = tokenService
-    ? fetchWithAuthMiddleware({
+    ? createFetchWithAuthMiddleware({
+        request,
         tokenService,
         getAuthorizationHeader: (token) => ({
           name: 'Authorization',
           value: `Bearer ${token}`,
         }),
       })
-    : undefined;
+    : createBasicFetch({ request });
 
   const { defaults, servers, ...api } = transfercheckApi;
 
@@ -37,13 +45,19 @@ export type GetTransfercheckAPIClientWithAuth = (
   tokenService: TokenService<string>,
 ) => TransfercheckApi;
 
-export function initializeTransfercheckAPIClient({ baseUrl }: { baseUrl: string }): {
+export function initializeTransfercheckAPIClient({
+  request,
+  baseUrl,
+}: {
+  request: Request;
+  baseUrl: string;
+}): {
   transfercheckApi: TransfercheckApi;
   getTransfercheckAPIClientWithAuth: GetTransfercheckAPIClientWithAuth;
 } {
   return {
-    transfercheckApi: getTransfercheckAPIClient({ baseUrl }),
+    transfercheckApi: getTransfercheckAPIClient({ request, baseUrl }),
     getTransfercheckAPIClientWithAuth: (tokenService: TokenService<string>) =>
-      getTransfercheckAPIClient({ tokenService, baseUrl }),
+      getTransfercheckAPIClient({ request, tokenService, baseUrl }),
   };
 }

--- a/packages/app-builder/src/root.tsx
+++ b/packages/app-builder/src/root.tsx
@@ -30,7 +30,7 @@ import { iconsSVGSpriteHref, Logo, logosSVGSpriteHref } from 'ui-icons';
 
 import { ErrorComponent } from './components/ErrorComponent';
 import { getToastMessage, MarbleToaster } from './components/MarbleToaster';
-import { serverServices } from './services/init.server';
+import { initServerServices } from './services/init.server';
 import { useSegmentPageTracking } from './services/segment';
 import { getSegmentScript } from './services/segment/segment.server';
 import { SegmentScript } from './services/segment/SegmentScript';
@@ -65,7 +65,7 @@ export const links: LinksFunction = () => [
 ];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { i18nextService, toastSessionService, csrfService } = serverServices;
+  const { i18nextService, toastSessionService, csrfService } = initServerServices(request);
   const locale = await i18nextService.getLocale(request);
 
   const [toastSession, [csrfToken, csrfCookieHeader]] = await Promise.all([

--- a/packages/app-builder/src/routes/$.tsx
+++ b/packages/app-builder/src/routes/$.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   await authService.isAuthenticated(request, {
     successRedirect: getRoute('/app-router'),
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_auth+/email-verification.tsx
+++ b/packages/app-builder/src/routes/_auth+/email-verification.tsx
@@ -3,7 +3,7 @@ import {
   SendEmailVerification,
   SendEmailVerificationDescription,
 } from '@app-builder/components/Auth/SendEmailVerification';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { Link } from '@remix-run/react';
@@ -14,7 +14,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   await authService.isAuthenticated(request, {
     successRedirect: getRoute('/app-router'),
   });

--- a/packages/app-builder/src/routes/_auth+/sign-in.tsx
+++ b/packages/app-builder/src/routes/_auth+/sign-in.tsx
@@ -7,7 +7,7 @@ import {
 import { SignInWithGoogle } from '@app-builder/components/Auth/SignInWithGoogle';
 import { SignInWithMicrosoft } from '@app-builder/components/Auth/SignInWithMicrosoft';
 import { type AuthPayload } from '@app-builder/services/auth/auth.server';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useFetcher, useLoaderData, useSearchParams } from '@remix-run/react';
@@ -21,7 +21,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService, authSessionService, licenseService } = serverServices;
+  const { authService, authSessionService, licenseService } = initServerServices(request);
   await authService.isAuthenticated(request, {
     successRedirect: getRoute('/app-router'),
   });
@@ -35,7 +35,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const { searchParams } = new URL(request.url);
   const redirectTo = searchParams.get('redirectTo');

--- a/packages/app-builder/src/routes/_auth+/sign-up.tsx
+++ b/packages/app-builder/src/routes/_auth+/sign-up.tsx
@@ -5,7 +5,7 @@ import {
   SignUpWithEmailAndPassword,
   StaticSignUpWithEmailAndPassword,
 } from '@app-builder/components/Auth/SignUpWithEmailAndPassword';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useLoaderData, useNavigate } from '@remix-run/react';
@@ -20,7 +20,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const {
     authService,
     authSessionService: { getSession },
-  } = serverServices;
+  } = initServerServices(request);
   await authService.isAuthenticated(request, {
     successRedirect: getRoute('/app-router'),
   });

--- a/packages/app-builder/src/routes/_builder+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/_layout.tsx
@@ -9,7 +9,7 @@ import { type SanctionCheckRepository } from '@app-builder/repositories/Sanction
 import { type ScenarioRepository } from '@app-builder/repositories/ScenarioRepository';
 import { useRefreshToken } from '@app-builder/routes/ressources+/auth+/refresh';
 import { isAnalyticsAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { OrganizationDetailsContextProvider } from '@app-builder/services/organization/organization-detail';
 import { OrganizationTagsContextProvider } from '@app-builder/services/organization/organization-tags';
 import { OrganizationUsersContextProvider } from '@app-builder/services/organization/organization-users';
@@ -59,7 +59,7 @@ async function getDatasetFreshnessInfo(
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService, versionRepository } = serverServices;
+  const { authService, versionRepository } = initServerServices(request);
   const { user, organization, entitlements, sanctionCheck, scenario } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/analytics.tsx
+++ b/packages/app-builder/src/routes/_builder+/analytics.tsx
@@ -5,7 +5,7 @@ import {
   BreadCrumbs,
 } from '@app-builder/components/Breadcrumbs';
 import { isAnalyticsAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { notFound } from '@app-builder/utils/http/http-responses';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -32,7 +32,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, analytics, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/api.tsx
+++ b/packages/app-builder/src/routes/_builder+/api.tsx
@@ -4,7 +4,7 @@ import {
   type BreadCrumbProps,
   BreadCrumbs,
 } from '@app-builder/components/Breadcrumbs';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { downloadFile } from '@app-builder/utils/download-file';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LinksFunction, type LoaderFunctionArgs } from '@remix-run/node';
@@ -40,7 +40,7 @@ export const links: LinksFunction = () =>
   swaggercss ? [{ rel: 'stylesheet', href: swaggercss }] : [];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { dataModelRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId._index.tsx
@@ -1,10 +1,10 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const caseId = fromParams(params, 'caseId');
   if (!caseId) {

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId._layout.tsx
@@ -28,7 +28,7 @@ import {
   isCreateSnoozeAvailable,
   isReadSnoozeAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getCaseFileUploadEndpoint } from '@app-builder/utils/files';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
@@ -98,7 +98,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const {
     user,
     entitlements,

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId.information.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId.information.tsx
@@ -1,6 +1,6 @@
 import { casesI18n } from '@app-builder/components/Cases';
 import { EditCase } from '@app-builder/routes/ressources+/cases+/edit';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -13,7 +13,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_index.tsx
@@ -1,10 +1,10 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const caseId = fromParams(params, 'caseId');
   const decisionId = fromParams(params, 'decisionId');

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_layout.tsx
@@ -16,7 +16,7 @@ import {
 import { SanctionStatusTag } from '@app-builder/components/Sanctions/SanctionStatusTag';
 import { isForbiddenHttpError, isNotFoundHttpError } from '@app-builder/models';
 import { UploadFile } from '@app-builder/routes/ressources+/files+/upload-file';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getSanctionCheckFileUploadEndpoint } from '@app-builder/utils/files';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -105,7 +105,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const {
     user,
     entitlements,

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/files.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/files.tsx
@@ -1,5 +1,5 @@
 import { FilesList } from '@app-builder/components/Files/FilesList';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import {
   getSanctionCheckFileDownloadEndpoint,
   getSanctionCheckFileUploadEndpoint,
@@ -11,7 +11,7 @@ import { type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { sanctionCheck: sanctionCheckRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/cases+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/_index.tsx
@@ -1,7 +1,7 @@
 import { Page } from '@app-builder/components';
 import { CreateInbox } from '@app-builder/routes/ressources+/settings+/inboxes+/create';
 import { isCreateInboxAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -11,7 +11,7 @@ import * as R from 'remeda';
 import { Icon } from 'ui-icons';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -15,7 +15,7 @@ import { isForbiddenHttpError, isNotFoundHttpError } from '@app-builder/models';
 import { type Case } from '@app-builder/models/cases';
 import { type PaginatedResponse, type PaginationParams } from '@app-builder/models/pagination';
 import { type CaseFilters } from '@app-builder/repositories/CaseRepository';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseQuerySafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
@@ -59,7 +59,7 @@ export const buildQueryParams = (
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { cases } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
@@ -7,7 +7,7 @@ import {
 import { casesI18n } from '@app-builder/components/Cases';
 import { CreateInbox } from '@app-builder/routes/ressources+/settings+/inboxes+/create';
 import { isCreateInboxAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
@@ -34,7 +34,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/data+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/_index.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   return authService.isAuthenticated(request, {
     successRedirect: getRoute('/data/list'),

--- a/packages/app-builder/src/routes/_builder+/data+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/_layout.tsx
@@ -14,7 +14,7 @@ import {
   isEditDataModelInfoAvailable,
   isIngestDataAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet, useLoaderData } from '@remix-run/react';
@@ -39,7 +39,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, dataModelRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/data+/schema.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/schema.tsx
@@ -2,7 +2,7 @@ import { TabLink } from '@app-builder/components';
 import { dataI18n } from '@app-builder/components/Data/data-i18n';
 import { DataModelFlow, dataModelFlowStyles } from '@app-builder/components/Data/DataModelFlow';
 import { useDataModel } from '@app-builder/services/data/data-model';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LinksFunction, type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -16,7 +16,7 @@ export const handle = {
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: dataModelFlowStyles }];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { dataModelRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/data+/view.$tableName.$objectId.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/view.$tableName.$objectId.tsx
@@ -1,7 +1,7 @@
 import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
 import { IngestedObjectDetail } from '@app-builder/components/Data/IngestedObjectDetail';
 import { useDataModel } from '@app-builder/services/data/data-model';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { HttpError } from '@oazapfts/runtime';
 import { type LoaderFunctionArgs } from '@remix-run/node';
@@ -30,7 +30,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { dataModelRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -19,7 +19,7 @@ import { SanctionCheckDetail } from '@app-builder/components/Decisions/SanctionC
 import { ScorePanel } from '@app-builder/components/Decisions/Score';
 import { DecisionDetailTriggerObject } from '@app-builder/components/Decisions/TriggerObjectDetail';
 import { isNotFoundHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { handleParseParamError } from '@app-builder/utils/http/handle-errors';
 import { notFound } from '@app-builder/utils/http/http-responses';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
@@ -65,7 +65,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { decision, editor, customListsRepository, scenario, dataModelRepository, sanctionCheck } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -20,7 +20,7 @@ import { FiltersButton } from '@app-builder/components/Filters';
 import { useCursorPaginatedFetcher } from '@app-builder/hooks/useCursorPaginatedFetcher';
 import { type Decision } from '@app-builder/models/decision';
 import { type PaginatedResponse, type PaginationParams } from '@app-builder/models/pagination';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseQuerySafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -65,7 +65,7 @@ export const buildQueryParams = (filters: DecisionFilters, offsetId: string | nu
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { decision, scenario, dataModelRepository, inbox } = await authService.isAuthenticated(
     request,
     {

--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -17,7 +17,7 @@ import {
   isEditListAvailable,
 } from '@app-builder/services/feature-access';
 import { clientServices } from '@app-builder/services/init.client';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { downloadFile } from '@app-builder/utils/download-file';
 import useAsync from '@app-builder/utils/hooks/use-async';
 import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
@@ -44,7 +44,7 @@ import { Icon } from 'ui-icons';
 import * as z from 'zod';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, customListsRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/lists+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/_index.tsx
@@ -3,7 +3,7 @@ import { BreadCrumbs } from '@app-builder/components/Breadcrumbs';
 import { type CustomList } from '@app-builder/models/custom-list';
 import { CreateList } from '@app-builder/routes/ressources+/lists+/create';
 import { isCreateListAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { Table, useVirtualTable } from 'ui-design-system';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, customListsRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_index.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { type Namespace } from 'i18next';
@@ -8,7 +8,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenarioId } = params;
   if (!scenarioId) {
     return {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_layout.tsx
@@ -2,7 +2,7 @@ import { ErrorComponent } from '@app-builder/components';
 import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
 import { TriggerObjectTag } from '@app-builder/components/Scenario/TriggerObjectTag';
 import { adaptScenarioIterationWithType } from '@app-builder/models/scenario-iteration';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs, type SerializeFrom } from '@remix-run/node';
@@ -34,7 +34,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/home.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/home.tsx
@@ -23,7 +23,7 @@ import {
   isEditScenarioAvailable,
   isManualTriggerScenarioAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { formatDateRelative, formatSchedule, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -49,7 +49,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const {
     user,
     entitlements,
@@ -88,7 +88,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, data, { scenario }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_index.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenarioId, iterationId } = params;
   if (!scenarioId || !iterationId) {
     return {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/_layout.tsx
@@ -15,7 +15,7 @@ import {
   isCreateDraftAvailable,
   isDeploymentActionsAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import {
   hasDecisionErrors,
   hasRulesErrors,
@@ -39,7 +39,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenario, user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/decision.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/decision.tsx
@@ -8,7 +8,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { EvaluationErrors } from '@app-builder/components/Scenario/ScenarioValidationError';
 import { scenarioDecisionDocHref } from '@app-builder/services/documentation-href';
 import { useEditorMode } from '@app-builder/services/editor/editor-mode';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useGetScenarioErrorMessage } from '@app-builder/services/validation';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
@@ -118,7 +118,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, data, t, { scenario }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
@@ -15,7 +15,7 @@ import { type ScenarioIterationRule } from '@app-builder/models/scenario-iterati
 import { CreateRule } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/create';
 import { CreateSanction } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create';
 import { useEditorMode } from '@app-builder/services/editor/editor-mode';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import {
   findRuleValidation,
   hasRuleErrors,
@@ -49,7 +49,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenarioIterationRuleRepository, entitlements, scenario } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/trigger.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/trigger.tsx
@@ -17,7 +17,7 @@ import {
   executeAScenarioDocHref,
 } from '@app-builder/services/documentation-href';
 import { useEditorMode } from '@app-builder/services/editor/editor-mode';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useGetScenarioErrorMessage } from '@app-builder/services/validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams } from '@app-builder/utils/short-uuid';
@@ -36,7 +36,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { customListsRepository, editor, dataModelRepository, scenario } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),
@@ -63,7 +63,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
   const session = await getSession(request);
   const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout.tsx
@@ -10,7 +10,7 @@ import {
   EditorModeContextProvider,
 } from '@app-builder/services/editor/editor-mode';
 import { isEditScenarioAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { findRuleValidation } from '@app-builder/services/validation';
 import { formatDateRelative, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
@@ -74,7 +74,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -15,7 +15,7 @@ import { useCurrentScenario } from '@app-builder/routes/_builder+/scenarios+/$sc
 import { DeleteRule } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/delete';
 import { DuplicateRule } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/duplicate';
 import { useEditorMode } from '@app-builder/services/editor/editor-mode';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
@@ -83,7 +83,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { customListsRepository, editor, dataModelRepository } = await authService.isAuthenticated(
     request,
     {
@@ -119,7 +119,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, data, { scenarioIterationRuleRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -23,7 +23,7 @@ import { knownOutcomes, type SanctionOutcome } from '@app-builder/models/outcome
 import { DeleteSanction } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete';
 import { type BuilderOptionsResource } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/builder-options';
 import { useEditorMode } from '@app-builder/services/editor/editor-mode';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
@@ -92,7 +92,7 @@ export const handle = {
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const scenarioId = fromParams(params, 'scenarioId');
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { customListsRepository, editor, dataModelRepository, sanctionCheck } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),
@@ -152,7 +152,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, raw, { scenarioIterationSanctionRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/scheduled-executions.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/scheduled-executions.tsx
@@ -5,7 +5,7 @@ import {
   BreadCrumbs,
 } from '@app-builder/components/Breadcrumbs';
 import { ScheduledExecutionsList } from '@app-builder/components/Scenario/ScheduledExecutionsList';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
@@ -38,7 +38,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { decision } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/$testRunId+/index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/$testRunId+/index.tsx
@@ -12,7 +12,7 @@ import { FilterTransactionByDecisionSkeleton } from '@app-builder/components/Sce
 import { TestRunDetails } from '@app-builder/components/Scenario/TestRun/TestRunDetails';
 import { adaptScenarioIterationWithType } from '@app-builder/models/scenario-iteration';
 import { CancelTestRun } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/testrun+/$testRunId+/cancel';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -55,7 +55,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const testRunId = fromParams(params, 'testRunId');
   const { testRun } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/index.tsx
@@ -12,7 +12,7 @@ import { TestRunSelector } from '@app-builder/components/Scenario/TestRun/TestRu
 import { isForbiddenHttpError, isNotFoundHttpError, type User } from '@app-builder/models';
 import { adaptScenarioIterationWithType } from '@app-builder/models/scenario-iteration';
 import { CreateTestRun } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/testrun+/create';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams } from '@app-builder/utils/short-uuid';
@@ -28,7 +28,7 @@ import { Icon } from 'ui-icons';
 import { useCurrentScenario, useScenarioIterations } from '../_layout';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const scenarioId = fromParams(params, 'scenarioId');
   const { testRun } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/workflow.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/workflow.tsx
@@ -22,7 +22,7 @@ import {
   scenarioUpdateWorkflowInputSchema,
 } from '@app-builder/models/scenario';
 import { isCreateInboxAvailable, isWorkflowsAvailable } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type LinksFunction, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -57,7 +57,7 @@ export const handle = {
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: workflowFlowStyles }];
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const scenarioId = fromParams(params, 'scenarioId');
 
   const { user, scenario, inbox, dataModelRepository, entitlements } =
@@ -100,7 +100,7 @@ export async function action({ request, params }: LoaderFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
   const scenarioId = fromParams(params, 'scenarioId');
   const { scenario, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/_index.tsx
@@ -1,7 +1,7 @@
 import { ErrorComponent, Page } from '@app-builder/components';
 import { BreadCrumbs } from '@app-builder/components/Breadcrumbs';
 import { CreateScenario } from '@app-builder/routes/ressources+/scenarios+/create';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
@@ -16,7 +16,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_index.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { type Namespace } from 'i18next';
@@ -10,7 +10,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
@@ -13,7 +13,7 @@ import {
   isReadTagAvailable,
   isReadUserAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { NavLink, Outlet, useLoaderData } from '@remix-run/react';
@@ -85,7 +85,7 @@ export function getSettings(user: CurrentUser) {
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/api-keys.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/api-keys.tsx
@@ -8,7 +8,7 @@ import {
   isReadApiKeyAvailable,
 } from '@app-builder/services/feature-access';
 import { tKeyForApiKeyRole } from '@app-builder/services/i18n/translation-keys/api-key';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { Table, useTable } from 'ui-design-system';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService, authSessionService } = serverServices;
+  const { authService, authSessionService } = initServerServices(request);
   const { apiKey, user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
@@ -14,7 +14,7 @@ import {
   isEditInboxAvailable,
   isEditInboxUserAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -57,7 +57,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const {
     user,
     inbox: inboxApi,

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
@@ -5,7 +5,7 @@ import {
   isCreateInboxAvailable,
   isReadAllInboxesAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -17,7 +17,7 @@ import * as R from 'remeda';
 import { Table, useTable } from 'ui-design-system';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { inbox, user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/scenarios.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/scenarios.tsx
@@ -5,7 +5,7 @@ import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { FormSelectTimezone } from '@app-builder/components/Settings/FormSelectTimezone';
 import { isAdmin } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { UTC, validTimezones } from '@app-builder/utils/validTimezones';
@@ -18,7 +18,7 @@ import { Button } from 'ui-design-system';
 import { z } from 'zod';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const {
     organization: repository,
     user,
@@ -47,7 +47,7 @@ export async function action({ request }: LoaderFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, formData, { organization: repository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/_builder+/settings+/tags.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/tags.tsx
@@ -8,7 +8,7 @@ import {
   isEditTagAvailable,
   isReadTagAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -26,7 +26,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { organization, user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/users.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/users.tsx
@@ -10,7 +10,7 @@ import {
   isEditUserAvailable,
   isReadUserAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -22,7 +22,7 @@ import * as R from 'remeda';
 import { Table, useTable } from 'ui-design-system';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user, inbox, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/webhooks.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/webhooks.tsx
@@ -10,7 +10,7 @@ import {
   isEditWebhookAvailable,
   isReadWebhookAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
@@ -26,7 +26,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { webhookRepository, user, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/settings+/webhooks_.$webhookId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/webhooks_.$webhookId.tsx
@@ -9,7 +9,7 @@ import {
   isEditWebhookAvailable,
   isReadWebhookAvailable,
 } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -27,7 +27,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { webhookRepository, user, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -5,7 +5,7 @@ import { useBackendInfo } from '@app-builder/services/auth/auth.client';
 import { ingestingDataByCsvDocHref } from '@app-builder/services/documentation-href';
 import { isIngestDataAvailable } from '@app-builder/services/feature-access';
 import { clientServices } from '@app-builder/services/init.client';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { formatDateTime, formatNumber, useFormatLanguage } from '@app-builder/utils/format';
 import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
 import { getRoute } from '@app-builder/utils/routes';
@@ -28,7 +28,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { apiClient, user, dataModelRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/app-router.tsx
+++ b/packages/app-builder/src/routes/app-router.tsx
@@ -1,7 +1,7 @@
 import { ErrorComponent } from '@app-builder/components';
 import { authI18n } from '@app-builder/components/Auth/auth-i18n';
 import { isMarbleCoreUser, isTransferCheckUser } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { segment } from '@app-builder/services/segment';
 import { forbidden } from '@app-builder/utils/http/http-responses';
 import { FORBIDDEN } from '@app-builder/utils/http/http-status-codes';
@@ -26,7 +26,7 @@ export const handle = {
  */
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/auth+/logout.tsx
+++ b/packages/app-builder/src/routes/ressources+/auth+/logout.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from '@remix-run/node';
 
@@ -12,13 +12,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     redirectTo = `${redirectTo}?redirectTo=${redirectToParam}`;
   }
 
-  await serverServices.authService.logout(request, {
+  await initServerServices(request).authService.logout(request, {
     redirectTo,
   });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  await serverServices.authService.logout(request, {
+  await initServerServices(request).authService.logout(request, {
     redirectTo: getRoute('/sign-in'),
   });
 }

--- a/packages/app-builder/src/routes/ressources+/auth+/refresh.tsx
+++ b/packages/app-builder/src/routes/ressources+/auth+/refresh.tsx
@@ -1,5 +1,5 @@
 import { clientServices } from '@app-builder/services/init.client';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useInterval, useVisibilityChange } from '@app-builder/utils/hooks';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -11,7 +11,7 @@ export function loader() {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   return await authService.refresh(request, {
     failureRedirect: getRoute('/ressources/auth/logout'),
   });

--- a/packages/app-builder/src/routes/ressources+/cases+/add-comment.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/add-comment.tsx
@@ -1,6 +1,6 @@
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
@@ -20,7 +20,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { cases }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/cases+/add-rule-snooze.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/add-rule-snooze.tsx
@@ -8,7 +8,7 @@ import { LoadingIcon } from '@app-builder/components/Spinner';
 import { adaptDateTimeFieldCodes, type DurationUnit } from '@app-builder/models/duration';
 import { isStatusConflictHttpError } from '@app-builder/models/http-errors';
 import { ruleSnoozesDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
@@ -38,7 +38,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { decision }] = await Promise.all([
     getFixedT(request, ['common', 'cases']),

--- a/packages/app-builder/src/routes/ressources+/cases+/add-to-case.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/add-to-case.tsx
@@ -3,7 +3,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { isStatusBadRequestHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
@@ -35,7 +35,7 @@ const addToCaseFormSchema = z.discriminatedUnion('newCase', [
 ]);
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { inbox, cases } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
@@ -55,7 +55,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [raw, session, { cases }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/cases+/create-case.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/create-case.tsx
@@ -3,7 +3,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -22,7 +22,7 @@ const createCaseFormSchema = z.object({
 });
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
@@ -36,7 +36,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [raw, session, { cases }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/cases+/edit-snooze.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/edit-snooze.tsx
@@ -1,6 +1,6 @@
 import { CalloutV2 } from '@app-builder/components';
 import { casesI18n } from '@app-builder/components/Cases';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
@@ -23,7 +23,7 @@ const editSnoozeSchema = z.object({
 type EditSnoozeForm = z.infer<typeof editSnoozeSchema>;
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const [raw, { cases }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/cases+/edit-status.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/edit-status.tsx
@@ -6,7 +6,7 @@ import {
   useCaseStatuses,
 } from '@app-builder/components/Cases';
 import { type CaseStatus as CasesStatusType, caseStatuses } from '@app-builder/models/cases';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -30,7 +30,7 @@ const schema = z.object({
 type Schema = z.infer<typeof schema>;
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const [raw, { cases }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/cases+/edit.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/edit.tsx
@@ -5,7 +5,7 @@ import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { type CaseDetail } from '@app-builder/models/cases';
 import { type Inbox } from '@app-builder/models/inbox';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationTags } from '@app-builder/services/organization/organization-tags';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
@@ -32,7 +32,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { cases }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/cases+/review-decision.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/review-decision.tsx
@@ -8,7 +8,7 @@ import { LoadingIcon } from '@app-builder/components/Spinner';
 import { nonPendingReviewStatuses } from '@app-builder/models/decision';
 import { type SanctionCheck } from '@app-builder/models/sanction-check';
 import { blockingReviewDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import type * as Ariakit from '@ariakit/react';
@@ -33,7 +33,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { cases }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/cases+/review-sanction-match.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/review-sanction-match.tsx
@@ -2,7 +2,7 @@ import { Callout } from '@app-builder/components';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { StatusRadioGroup } from '@app-builder/components/Sanctions/StatusRadioGroup';
 import { type SanctionCheckMatch } from '@app-builder/models/sanction-check';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useCallbackRef } from '@app-builder/utils/hooks';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -26,7 +26,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, raw, { sanctionCheck }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/data+/create-pivot.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/create-pivot.tsx
@@ -8,7 +8,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { type DataModel, isStatusConflictHttpError, type TableModel } from '@app-builder/models';
 import { getPivotOptions, type PivotOption } from '@app-builder/services/data/pivot';
 import { pivotValuesDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -46,7 +46,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, raw, { dataModelRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/data+/createField.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/createField.tsx
@@ -3,7 +3,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { EnumDataTypes, isStatusConflictHttpError, UniqueDataTypes } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { captureUnexpectedRemixError } from '@app-builder/services/monitoring';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
@@ -57,7 +57,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, raw, { dataModelRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/data+/createLink.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/createLink.tsx
@@ -4,7 +4,7 @@ import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { isStatusConflictHttpError } from '@app-builder/models';
 import { type TableModel } from '@app-builder/models/data-model';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -40,7 +40,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, raw, { apiClient }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/data+/createTable.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/createTable.tsx
@@ -3,7 +3,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { isStatusConflictHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -36,7 +36,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, raw, { apiClient }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/data+/editField.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/editField.tsx
@@ -8,7 +8,7 @@ import {
   type LinkToSingle,
   UniqueDataTypes,
 } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { captureUnexpectedRemixError } from '@app-builder/services/monitoring';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
@@ -38,7 +38,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, raw, { dataModelRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/data+/editTable.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/editTable.tsx
@@ -2,7 +2,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { type TableModel } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -26,7 +26,7 @@ const editTableFormSchema = z.object({
 type EditTableForm = z.infer<typeof editTableFormSchema>;
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const [raw, { apiClient }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/decisions+/list-scheduled-execution.tsx
+++ b/packages/app-builder/src/routes/ressources+/decisions+/list-scheduled-execution.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { decision } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/lists+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/lists+/create.tsx
@@ -3,7 +3,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { isStatusConflictHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -32,7 +32,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [raw, session, { customListsRepository }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/lists+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/lists+/delete.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseFormSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -19,7 +19,7 @@ const deleteListFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { customListsRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/lists+/edit.tsx
+++ b/packages/app-builder/src/routes/ressources+/lists+/edit.tsx
@@ -1,7 +1,7 @@
 import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/FormErrorOrDescription';
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -28,7 +28,7 @@ const editListFormSchema = z.object({
 type EditListForm = z.infer<typeof editListFormSchema>;
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const [raw, { customListsRepository }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/lists+/value_create.tsx
+++ b/packages/app-builder/src/routes/ressources+/lists+/value_create.tsx
@@ -1,7 +1,7 @@
 import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/FormErrorOrDescription';
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -26,7 +26,7 @@ const addValueFormSchema = z.object({
 type AddValueForm = z.infer<typeof addValueFormSchema>;
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const [raw, { customListsRepository }] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/lists+/value_delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/lists+/value_delete.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseFormSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -20,7 +20,7 @@ const deleteValueFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { customListsRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/rule-snoozes+/read.$ruleSnoozeId.tsx
+++ b/packages/app-builder/src/routes/ressources+/rule-snoozes+/read.$ruleSnoozeId.tsx
@@ -1,5 +1,5 @@
 import { type RuleSnoozeDetail } from '@app-builder/models/rule-snooze';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
@@ -7,7 +7,7 @@ import { useFetcher } from '@remix-run/react';
 import * as React from 'react';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { ruleSnoozeRepository, scenario, scenarioIterationRuleRepository } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/ressources+/sanction-check+/enrich-match.$matchId.tsx
+++ b/packages/app-builder/src/routes/ressources+/sanction-check+/enrich-match.$matchId.tsx
@@ -1,7 +1,7 @@
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { sanctionsI18n } from '@app-builder/components/Sanctions/sanctions-i18n';
 import { isStatusConflictHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { useCallbackRef } from '@app-builder/utils/hooks';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -16,7 +16,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
   const { sanctionCheck } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/sanction-check+/refine.tsx
+++ b/packages/app-builder/src/routes/ressources+/sanction-check+/refine.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import type { ActionFunctionArgs } from '@remix-run/node';
 import { decode as decodeFormdata } from 'decode-formdata';
@@ -6,7 +6,7 @@ import { decode as decodeFormdata } from 'decode-formdata';
 import { refineSearchSchema } from './search';
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
 
   const { sanctionCheck } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/ressources+/sanction-check+/search.tsx
+++ b/packages/app-builder/src/routes/ressources+/sanction-check+/search.tsx
@@ -1,5 +1,5 @@
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { decode as decodeFormdata } from 'decode-formdata';
@@ -49,7 +49,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const { sanctionCheck } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/activate.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/activate.tsx
@@ -8,7 +8,7 @@ import {
   ValidationError,
 } from '@app-builder/repositories/ScenarioRepository';
 import { useCurrentScenarioIteration } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs } from '@remix-run/node';
@@ -29,7 +29,7 @@ const activateFormSchema = z.object({
 });
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
@@ -52,7 +52,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     toastSessionService: { getSession, commitSession },
     i18nextService: { getFixedT },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { scenario }] = await Promise.all([
     getFixedT(request, ['common', 'scenarios']),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/commit.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/commit.tsx
@@ -1,7 +1,7 @@
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { isStatusBadRequestHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -25,7 +25,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     toastSessionService: { getSession, commitSession },
     i18nextService: { getFixedT },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { scenario }] = await Promise.all([
     getFixedT(request, ['common', 'scenarios']),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/create_draft.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/create_draft.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseFormSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -19,7 +19,7 @@ const createDraftIterationFormSchema = z.object({
 });
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { apiClient } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/deactivate.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/deactivate.tsx
@@ -1,6 +1,6 @@
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -23,7 +23,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { scenario }] = await Promise.all([
     getFixedT(request, ['common', 'scenarios']),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/prepare.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/prepare.tsx
@@ -1,7 +1,7 @@
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { PreparationServiceOccupied } from '@app-builder/repositories/ScenarioRepository';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -24,7 +24,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { scenario }] = await Promise.all([
     getFixedT(request, ['common', 'scenarios']),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/create.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -13,7 +13,7 @@ export const handle = {
 };
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService, i18nextService } = serverServices;
+  const { authService, i18nextService } = initServerServices(request);
   const { scenarioIterationRuleRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/delete.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -13,7 +13,7 @@ export const handle = {
 };
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const iterationId = fromParams(params, 'iterationId');
   const scenarioId = fromParams(params, 'scenarioId');
   const { scenarioIterationRuleRepository } = await authService.isAuthenticated(request, {

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/duplicate.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/duplicate.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -13,7 +13,7 @@ export const handle = {
 };
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService, i18nextService } = serverServices;
+  const { authService, i18nextService } = initServerServices(request);
   const iterationId = fromParams(params, 'iterationId');
   const scenarioId = fromParams(params, 'scenarioId');
 

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
@@ -1,6 +1,6 @@
 import { Nudge } from '@app-builder/components/Nudge';
 import { isAccessible } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -18,7 +18,7 @@ export const handle = {
 };
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenarioIterationSanctionRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -13,7 +13,7 @@ export const handle = {
 };
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const iterationId = fromParams(params, 'iterationId');
   const scenarioId = fromParams(params, 'scenarioId');
   const { scenarioIterationSanctionRepository } = await authService.isAuthenticated(request, {

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule.tsx
@@ -1,5 +1,5 @@
 import { type AstNode } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs } from '@remix-run/node';
@@ -7,7 +7,7 @@ import { useFetcher } from '@remix-run/react';
 import { useCallback } from 'react';
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/builder-options.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/builder-options.tsx
@@ -4,7 +4,7 @@ import {
   type PayloadAstNode,
 } from '@app-builder/models/astNode/data-accessor';
 import { type CustomList } from '@app-builder/models/custom-list';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs } from '@remix-run/node';
@@ -18,7 +18,7 @@ export type BuilderOptionsResource = {
 };
 
 export async function loader({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { editor, scenario, dataModelRepository, customListsRepository } =
     await authService.isAuthenticated(request, {
       failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/$testRunId+/cancel.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/$testRunId+/cancel.tsx
@@ -1,7 +1,7 @@
 import { Callout } from '@app-builder/components';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { useCurrentScenario } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/_layout';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -12,7 +12,7 @@ import { useHydrated } from 'remix-utils/use-hydrated';
 import { Button, ModalV2 } from 'ui-design-system';
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const scenarioId = fromParams(params, 'scenarioId');
   const testRunId = fromParams(params, 'testRunId');
   const { testRun } = await authService.isAuthenticated(request, {
@@ -27,7 +27,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       }),
     );
   } catch (error) {
-    const { getSession, commitSession } = serverServices.toastSessionService;
+    const { getSession, commitSession } = initServerServices(request).toastSessionService;
 
     const session = await getSession(request);
 

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/create.tsx
@@ -8,7 +8,7 @@ import { isStatusConflictHttpError } from '@app-builder/models';
 import { type Scenario } from '@app-builder/models/scenario';
 import { type ScenarioIterationWithType } from '@app-builder/models/scenario-iteration';
 import { scenarioObjectDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
@@ -38,7 +38,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
   const scenarioId = fromParams(params, 'scenarioId');
 
   const [t, session, rawData, { testRun }] = await Promise.all([

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/validate-ast.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/validate-ast.tsx
@@ -9,7 +9,7 @@ import {
   type ReturnValue,
   type ReturnValueType,
 } from '@app-builder/models/node-evaluation';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs } from '@remix-run/node';
@@ -132,7 +132,7 @@ export type AstValidationFunction = (
 ) => Promise<NodeEvaluation>;
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { scenario } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/create.tsx
@@ -5,7 +5,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { scenarioObjectDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -26,7 +26,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { dataModelRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
@@ -46,7 +46,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const {
     authService,
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, rawData, { scenario }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/ressources+/scenarios+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/update.tsx
@@ -2,7 +2,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -29,7 +29,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { scenario }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/api-keys+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/api-keys+/create.tsx
@@ -4,7 +4,7 @@ import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { apiKeyRoleOptions } from '@app-builder/models/api-keys';
 import { tKeyForApiKeyRole } from '@app-builder/services/i18n/translation-keys/api-key';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -29,7 +29,7 @@ export async function action({ request }: ActionFunctionArgs) {
     toastSessionService: { getSession, commitSession },
     authSessionService: { getSession: getAuthSession, commitSession: commitAuthSession },
     i18nextService: { getFixedT },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [data, { apiKey }, session, authSession, t] = await Promise.all([
     request.json(),

--- a/packages/app-builder/src/routes/ressources+/settings+/api-keys+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/api-keys+/delete.tsx
@@ -1,5 +1,5 @@
 import { type ApiKey } from '@app-builder/models/api-keys';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -15,7 +15,7 @@ const deleteApiKeyFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { apiKey } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/create.tsx
@@ -2,7 +2,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -37,7 +37,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [{ inbox }, data, session, t] = await Promise.all([
     authService.isAuthenticated(request, {

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/delete.tsx
@@ -1,5 +1,5 @@
 import { type Inbox } from '@app-builder/models/inbox';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -20,7 +20,7 @@ const deleteInboxFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.create.tsx
@@ -5,7 +5,7 @@ import { Nudge } from '@app-builder/components/Nudge';
 import { type User } from '@app-builder/models';
 import { tKeyForInboxUserRole } from '@app-builder/models/inbox';
 import { getInboxUserRoles, isAccessible } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -39,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { inbox, entitlements }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.delete.tsx
@@ -1,5 +1,5 @@
 import { type InboxUser } from '@app-builder/models/inbox';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -22,7 +22,7 @@ const deleteInboxUserFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.update.tsx
@@ -4,7 +4,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { Nudge } from '@app-builder/components/Nudge';
 import { type InboxUser, tKeyForInboxUserRole } from '@app-builder/models/inbox';
 import { getInboxUserRoles, isAccessible } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -39,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { inbox, entitlements }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/update.tsx
@@ -3,7 +3,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { type Inbox } from '@app-builder/models/inbox';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
@@ -38,7 +38,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { inbox }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/tags+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/tags+/create.tsx
@@ -2,7 +2,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -33,7 +33,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { apiClient }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/tags+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/tags+/delete.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -20,7 +20,7 @@ const deleteTagFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { apiClient } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/settings+/tags+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/tags+/update.tsx
@@ -2,7 +2,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -33,7 +33,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { apiClient }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/users+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/users+/create.tsx
@@ -5,7 +5,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { Nudge } from '@app-builder/components/Nudge';
 import { isStatusConflictHttpError, tKeyForUserRole } from '@app-builder/models';
 import { getUserRoles, isAccessible } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -39,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { apiClient, entitlements }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/users+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/users+/delete.tsx
@@ -1,4 +1,4 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -18,7 +18,7 @@ const deleteUserFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { apiClient } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/settings+/users+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/users+/update.tsx
@@ -5,7 +5,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { Nudge } from '@app-builder/components/Nudge';
 import { tKeyForUserRole, type User } from '@app-builder/models';
 import { getUserRoles, isAccessible } from '@app-builder/services/feature-access';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -40,7 +40,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { apiClient, entitlements }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/webhooks+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/webhooks+/create.tsx
@@ -8,7 +8,7 @@ import { LoadingIcon } from '@app-builder/components/Spinner';
 import { SelectEvents } from '@app-builder/components/Webhooks/EventTypes';
 import { type EventType, eventTypes } from '@app-builder/models/webhook';
 import { webhooksEventsDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
@@ -34,7 +34,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { webhookRepository }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/settings+/webhooks+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/webhooks+/delete.tsx
@@ -1,5 +1,5 @@
 import { LoadingIcon } from '@app-builder/components/Spinner';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
@@ -14,7 +14,7 @@ const deleteWebhookFormSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { webhookRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/ressources+/settings+/webhooks+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/webhooks+/update.tsx
@@ -8,7 +8,7 @@ import { LoadingIcon } from '@app-builder/components/Spinner';
 import { SelectEvents } from '@app-builder/components/Webhooks/EventTypes';
 import { type EventType, eventTypes } from '@app-builder/models/webhook';
 import { webhooksEventsDocHref } from '@app-builder/services/documentation-href';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -34,7 +34,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [t, session, rawData, { webhookRepository }] = await Promise.all([
     getFixedT(request, ['common']),

--- a/packages/app-builder/src/routes/ressources+/user+/language.tsx
+++ b/packages/app-builder/src/routes/ressources+/user+/language.tsx
@@ -1,5 +1,5 @@
 import { supportedLngs } from '@app-builder/services/i18n/i18n-config';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -16,7 +16,7 @@ const formSchema = z.object({
 });
 
 export async function action({ request }: ActionFunctionArgs) {
-  const { i18nextService, toastSessionService } = serverServices;
+  const { i18nextService, toastSessionService } = initServerServices(request);
 
   try {
     const { preferredLanguage } = await parseForm(request, formSchema);

--- a/packages/app-builder/src/routes/transfercheck+/$.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/$.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   return authService.isAuthenticated(request, {
     successRedirect: getRoute('/transfercheck'),
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/transfercheck+/_index.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/_index.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   return authService.isAuthenticated(request, {
     successRedirect: getRoute('/transfercheck/transfers/'),
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/transfercheck+/_layout.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/_layout.tsx
@@ -9,7 +9,7 @@ import { LeftSidebar, ToggleSidebar } from '@app-builder/components/Layout/LeftS
 import { UserInfo } from '@app-builder/components/UserInfo';
 import { isMarbleAdmin, isTransferCheckUser } from '@app-builder/models';
 import { useRefreshToken } from '@app-builder/routes/ressources+/auth+/refresh';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { segment, useSegmentIdentification } from '@app-builder/services/segment';
 import { conflict, forbidden } from '@app-builder/utils/http/http-responses';
 import { CONFLICT } from '@app-builder/utils/http/http-status-codes';
@@ -23,7 +23,7 @@ import { Button } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService, versionRepository } = serverServices;
+  const { authService, versionRepository } = initServerServices(request);
   const { user, partnerRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/_.received.$alertId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/_.received.$alertId.tsx
@@ -2,7 +2,7 @@ import { ErrorComponent, Page } from '@app-builder/components';
 import { AlertData } from '@app-builder/components/TransferAlerts/AlertData';
 import { alertsI18n } from '@app-builder/components/TransferAlerts/alerts-i18n';
 import { isNotFoundHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { handleParseParamError } from '@app-builder/utils/http/handle-errors';
 import { notFound } from '@app-builder/utils/http/http-responses';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
@@ -23,7 +23,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { transferAlertRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/_.sent.$alertId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/_.sent.$alertId.tsx
@@ -6,7 +6,7 @@ import {
   alertStatusVariants,
 } from '@app-builder/components/TransferAlerts/AlertStatus';
 import { isNotFoundHttpError } from '@app-builder/models';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { handleParseParamError } from '@app-builder/utils/http/handle-errors';
 import { notFound } from '@app-builder/utils/http/http-responses';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
@@ -28,7 +28,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { transferAlertRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/_index.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/_index.tsx
@@ -1,9 +1,9 @@
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   return authService.isAuthenticated(request, {
     successRedirect: getRoute('/transfercheck/alerts/received'),
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/received.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/received.tsx
@@ -1,12 +1,12 @@
 import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { json, Link, useLoaderData } from '@remix-run/react';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { transferAlertRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/sent.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/sent.tsx
@@ -1,12 +1,12 @@
 import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { json, Link, useLoaderData } from '@remix-run/react';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { transferAlertRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/routes/transfercheck+/ressources+/alert.create.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/ressources+/alert.create.tsx
@@ -8,7 +8,7 @@ import {
   senderIbanSchema,
   transferEndToEndIdSchema,
 } from '@app-builder/models/transfer-alert';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -35,7 +35,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, rawData, { transferAlertRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/transfercheck+/ressources+/alert.update.status.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/ressources+/alert.update.status.tsx
@@ -7,7 +7,7 @@ import {
   useAlertStatuses,
 } from '@app-builder/components/TransferAlerts/AlertStatus';
 import { transferAlerStatuses } from '@app-builder/models/transfer-alert';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
@@ -28,7 +28,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, rawData, { transferAlertRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/transfercheck+/ressources+/alert.update.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/ressources+/alert.update.tsx
@@ -8,7 +8,7 @@ import {
   senderIbanSchema,
   transferEndToEndIdSchema,
 } from '@app-builder/models/transfer-alert';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
@@ -35,7 +35,7 @@ export async function action({ request }: ActionFunctionArgs) {
     authService,
     i18nextService: { getFixedT },
     toastSessionService: { getSession, commitSession },
-  } = serverServices;
+  } = initServerServices(request);
 
   const [session, t, rawData, { transferAlertRepository }] = await Promise.all([
     getSession(request),

--- a/packages/app-builder/src/routes/transfercheck+/transfers+/$transferId.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/transfers+/$transferId.tsx
@@ -7,7 +7,7 @@ import {
 } from '@app-builder/components/Transfers/TransferStatus';
 import { isNotFoundHttpError } from '@app-builder/models';
 import { transferStatuses } from '@app-builder/models/transfer';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { handleParseParamError } from '@app-builder/utils/http/handle-errors';
 import { notFound } from '@app-builder/utils/http/http-responses';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
@@ -27,7 +27,7 @@ export const handle = {
 };
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { transferRepository, transferAlertRepository } = await authService.isAuthenticated(
     request,
     {
@@ -67,7 +67,7 @@ const transferUpdateBodySchema = z.object({
 });
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const parsedParam = await parseParamsSafe(params, z.object({ transferId: shortUUIDSchema }));
   const { transferRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),

--- a/packages/app-builder/src/routes/transfercheck+/transfers+/_index.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/transfers+/_index.tsx
@@ -3,7 +3,7 @@ import { Spinner } from '@app-builder/components/Spinner';
 import { transfersI18n } from '@app-builder/components/Transfers/transfers-i18n';
 import { TransfersList } from '@app-builder/components/Transfers/TransfersList';
 import { type Transfer } from '@app-builder/models/transfer';
-import { serverServices } from '@app-builder/services/init.server';
+import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Form, useLoaderData, useNavigation, useSubmit } from '@remix-run/react';
@@ -19,7 +19,7 @@ export const handle = {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = serverServices;
+  const { authService } = initServerServices(request);
   const { transferRepository } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });

--- a/packages/app-builder/src/services/init.server.ts
+++ b/packages/app-builder/src/services/init.server.ts
@@ -41,18 +41,21 @@ function makeServerServices(repositories: ServerRepositories) {
   };
 }
 
-function initServerServices() {
+export function initServerServices(request: Request) {
   checkEnv();
 
   const { getMarbleCoreAPIClientWithAuth, marbleCoreApiClient } = initializeMarbleCoreAPIClient({
+    request,
     baseUrl: getServerEnv('MARBLE_API_URL_SERVER'),
   });
 
   const { getTransfercheckAPIClientWithAuth } = initializeTransfercheckAPIClient({
+    request,
     baseUrl: getServerEnv('MARBLE_API_URL_SERVER'),
   });
 
   const { getLicenseAPIClientWithAuth, licenseApi } = initializeLicenseAPIClient({
+    request,
     baseUrl: getServerEnv('MARBLE_API_URL_SERVER'),
   });
 
@@ -76,5 +79,3 @@ function initServerServices() {
 
   return makeServerServices(serverRepositories);
 }
-
-export const serverServices = initServerServices();

--- a/packages/marble-api/src/helpers/authorization.ts
+++ b/packages/marble-api/src/helpers/authorization.ts
@@ -3,22 +3,50 @@ export interface TokenService<Token> {
   refreshToken: () => Promise<Token>;
 }
 
-export function fetchWithAuthMiddleware<Token>({
-  tokenService,
-  getAuthorizationHeader,
-}: {
-  tokenService: TokenService<Token>;
-  getAuthorizationHeader: (token: Token) => { name: string; value: string };
-}) {
+function forwardHeader(
+  currentHeaders: Headers,
+  newHeaders: Headers,
+  name: string,
+  defaultValue?: string,
+) {
+  const headerValue = currentHeaders.get(name) ?? defaultValue;
+  if (headerValue !== null && headerValue !== undefined) {
+    newHeaders.set(name, headerValue);
+  }
+}
+
+type BasicFetchParams = { request: Request };
+export function createBasicFetch({ request }: BasicFetchParams) {
   return async (input: RequestInfo | URL, init?: RequestInit) => {
     const headers = new Headers(init?.headers);
+
+    // forwarding trace headers
+    forwardHeader(request.headers, headers, 'traceparent');
+    forwardHeader(request.headers, headers, 'X-Cloud-Trace-Context');
+
+    return fetch(input, { ...init, headers });
+  };
+}
+
+type FetchWithAuthMiddlewareParam<Token> = BasicFetchParams & {
+  tokenService: TokenService<Token>;
+  getAuthorizationHeader: (token: Token) => { name: string; value: string };
+};
+export function createFetchWithAuthMiddleware<Token>({
+  request,
+  tokenService,
+  getAuthorizationHeader,
+}: FetchWithAuthMiddlewareParam<Token>) {
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    const basicFetch = createBasicFetch({ request });
 
     const token = await tokenService.getToken();
     if (token) {
       const { name, value } = getAuthorizationHeader(token);
       headers.set(name, value);
     }
-    const response = await fetch(input, { ...init, headers });
+    const response = await basicFetch(input, { ...init, headers });
 
     if (response.status === 401) {
       const token = await tokenService.refreshToken();


### PR DESCRIPTION
Rework marbleApiClient to take request and forward `traceparent` and `X-Cloud-Trace-Context` headers