### PR TITLE
Fix rule snooze gating using webhook entitlement.

### DIFF
--- a/packages/app-builder/src/models/license.ts
+++ b/packages/app-builder/src/models/license.ts
@@ -40,7 +40,7 @@ export function adaptLicenseEntitlements(dto: LicenseEntitlementsDto): LicenseEn
     analytics: dto.analytics,
     userRoles: dto.roles,
     webhooks: dto.webhooks,
-    ruleSnoozes: dto.webhooks,
+    ruleSnoozes: dto.rule_snoozes,
     testRun: dto.test_run,
     sanctions: dto.sanctions,
   };


### PR DESCRIPTION
The frontends seemed to be using the `webhooks` entitlement for gating access to rule snoozing instead of the proper `rule_snoozes` entitlement.