### PR TITLE
add warning on the webhooks UI: filtering by event type is restricted

### DIFF
--- a/packages/app-builder/src/locales/ar/settings.json
+++ b/packages/app-builder/src/locales/ar/settings.json
@@ -84,7 +84,7 @@
   "webhooks.event_types": "الأحداث",
   "webhooks.event_types.empty_matches": "لا توجد أحداث تطابق بحثك",
   "webhooks.event_types.placeholder": "جميع الأحداث افتراضيا",
-  "webhooks.events_documentation": "لمزيد من المعلومات حول الأحداث، يرجى الرجوع إلى <DocLink>الوثائق</DocLink>.",
+  "webhooks.events_documentation": "لمزيد من المعلومات حول الأحداث ، يرجى الرجوع إلى <DocLink> الوثائق </DocLink>. \nيقتصر تصفية التسليم حسب نوع الحدث على مستخدمي القافلة المدفوعين.",
   "webhooks.http_timeout": "نفذ الوقت",
   "webhooks.http_timeout.description": "تحديد مهلة http لنقطة النهاية بالثواني",
   "webhooks.new_webhook": "خطاف ويب جديد",

--- a/packages/app-builder/src/locales/en/settings.json
+++ b/packages/app-builder/src/locales/en/settings.json
@@ -101,7 +101,7 @@
   "webhooks.secret.expires_at": "Expires at",
   "webhooks.secret.value": "Value",
   "webhooks.setup_documentation": "For more information on webhooks, please refer to <DocLink>the documentation</DocLink>.",
-  "webhooks.events_documentation": "For more information on events, please refer to <DocLink>the documentation</DocLink>.",
+  "webhooks.events_documentation": "For more information on events, please refer to <DocLink>the documentation</DocLink>. Filtering delivery by event type is restricted to paid Convoy users.",
   "webhooks.configuration_error": "Configuration Error",
   "webhooks.convoy_error": "Convoy doesn't seem to be properly configured on Marble Backend. For more information on webhooks, please refer to <DocLink>the documentation</DocLink>.",
   "scenarios": "Scenarios",

--- a/packages/app-builder/src/locales/fr/settings.json
+++ b/packages/app-builder/src/locales/fr/settings.json
@@ -84,7 +84,7 @@
   "webhooks.event_types": "Événements",
   "webhooks.event_types.empty_matches": "aucun événement ne correspond à votre recherche",
   "webhooks.event_types.placeholder": "Tous les événements par défaut",
-  "webhooks.events_documentation": "Pour plus d'informations sur les événements, veuillez vous référer à <DocLink>la documentation</DocLink>.",
+  "webhooks.events_documentation": "Pour plus d'informations sur les événements, veuillez vous référer à <DocLink>la documentation</DocLink>. L'envoi filtré par type d'évènement est limité aux clients payants de Convoy.",
   "webhooks.http_timeout": "Timeout",
   "webhooks.http_timeout.description": "Définir le délai maximum de réponse de l'hôte en secondes",
   "webhooks.new_webhook": "Nouveau webhook",


### PR DESCRIPTION
See https://github.com/checkmarble/marble-backend/pull/929