### PR TITLE
feat: move github banner in LeftSidebar

### DIFF
--- a/packages/app-builder/src/components/GithubBanner.tsx
+++ b/packages/app-builder/src/components/GithubBanner.tsx
@@ -10,11 +10,11 @@ export const GithubBanner = () => {
   const { t } = useTranslation(['common']);
 
   return isShown === 'true' ? (
-    <div className="text-s text-grey-100 bg-purple-65 absolute left-0 top-0 z-50 flex w-full flex-row justify-between gap-2 p-4 font-normal">
-      <div className="flex w-full flex-row items-center gap-4">
-        <Icon icon="notifications" className="size-6" />
-        <span className="inline-flex gap-1 font-semibold">
-          <span>{t('common:github_banner')}</span>
+    <div className="text-s border-purple-96 bg-purple-98 text-purple-65 sticky bottom-0 mt-auto flex w-full flex-row justify-between gap-2 border-y px-8 py-2">
+      <div className="flex w-full flex-row items-center gap-2">
+        <Icon icon="notifications" className="size-5" />
+        <span>
+          <span>{t('common:github_banner')} </span>
           <a
             href="https://github.com/checkmarble/marble"
             className="underline"

--- a/packages/app-builder/src/components/Page.tsx
+++ b/packages/app-builder/src/components/Page.tsx
@@ -41,16 +41,22 @@ function PageHeader({ className, children, ...props }: React.ComponentProps<'div
       )}
       {...props}
     >
-      <ClientOnly fallback={null}>{() => <GithubBanner />}</ClientOnly>
       {children}
     </div>
   );
 }
 
 const PageContainer = forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(
-  function PageContainer({ className, ...props }, ref) {
+  function PageContainer({ className, children, ...props }, ref) {
     return (
-      <div ref={ref} className="scrollbar-gutter-stable size-full overflow-y-scroll" {...props} />
+      <div
+        ref={ref}
+        className="scrollbar-gutter-stable flex size-full flex-col overflow-y-scroll"
+        {...props}
+      >
+        {children}
+        <ClientOnly fallback={null}>{() => <GithubBanner />}</ClientOnly>
+      </div>
     );
   },
 );


### PR DESCRIPTION
Moving github banner in the left sidebar to be less intrusive for the user
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/25ea6547-2ffb-4942-9784-52a0e2c4ef24" />

