### PR TITLE
fix: fix css issue ast builder date edition modal

### DIFF
--- a/packages/app-builder/src/components/AstBuilder/edition/EditModal/Container.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditModal/Container.tsx
@@ -1,4 +1,5 @@
 import { type EditableAstNode } from '@app-builder/models/astNode/builder-ast-node';
+import { useCallbackRef } from '@marble/shared';
 import { type ReactElement, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, cn, Modal } from 'ui-design-system';
@@ -15,15 +16,22 @@ export type OperandEditModalContainerProps = Omit<OperandEditModalProps, 'node'>
 export function OperandEditModalContainer({ className, ...props }: OperandEditModalContainerProps) {
   const { t } = useTranslation(['common']);
   const nodeSharp = AstBuilderNodeSharpFactory.useSharp();
-  const handleOpenChange = (open: boolean) => {
+  const handleOpenChange = useCallbackRef((open: boolean) => {
     if (!open) {
       props.onCancel();
     }
-  };
+  });
+  const handleImplicitClose = useCallbackRef((event: Event) => {
+    event.preventDefault();
+  });
 
   return (
     <Modal.Root open onOpenChange={handleOpenChange}>
-      <Modal.Content size={props.size}>
+      <Modal.Content
+        size={props.size}
+        onInteractOutside={handleImplicitClose}
+        onEscapeKeyDown={handleImplicitClose}
+      >
         <Modal.Title>{props.title}</Modal.Title>
         <div className={cn('flex flex-col gap-4 p-4', className)}>{props.children}</div>
         <Modal.Footer>

--- a/packages/app-builder/src/components/AstBuilder/edition/EditModal/modals/TimeAdd/TimeAdd.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditModal/modals/TimeAdd/TimeAdd.tsx
@@ -62,7 +62,7 @@ export function EditTimeAdd(props: Omit<OperandEditModalProps, 'node'>) {
         </Modal.Description>
       </Callout>
       <div className="flex flex-col gap-2">
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <EditionAstBuilderOperand
             node={node.namedChildren.timestampField}
             onChange={(newNode) => {

--- a/packages/app-builder/src/components/AstBuilder/edition/EditionNode.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditionNode.tsx
@@ -132,6 +132,7 @@ export const EditionAstBuilderNode = memo(function EditionAstBuilderNode(props: 
         isMainAstNode(node.children[1]) && node.children[1].children.length > 0;
       const hasAllNestedChildren = hasNestedLeftChild && hasNestedRightChild;
       const hasDirectError = getErrorsForNode(nodeSharp.value.validation, node.id, true).length > 0;
+      const showBrackets = !props.root || hasAllNestedChildren;
 
       const children = (
         <>
@@ -147,7 +148,7 @@ export const EditionAstBuilderNode = memo(function EditionAstBuilderNode(props: 
         </>
       );
 
-      return !props.root || hasAllNestedChildren ? (
+      const wrappedChildren = showBrackets ? (
         <Brackets
           removeNesting={() => {
             setNode(node.children[0]);
@@ -169,11 +170,18 @@ export const EditionAstBuilderNode = memo(function EditionAstBuilderNode(props: 
           {children}
         </Brackets>
       ) : (
-        <div className="inline-flex flex-row flex-wrap items-center gap-2">{children}</div>
+        children
+      );
+
+      return props.root ? (
+        <div className="inline-flex flex-row flex-wrap items-center gap-2">{wrappedChildren}</div>
+      ) : (
+        wrappedChildren
       );
     })
     .when(isMainAstUnaryNode, (node) => {
       const hasDirectError = getErrorsForNode(nodeSharp.value.validation, node.id, true).length > 0;
+      const showBrackets = !props.root;
 
       const children = (
         <>
@@ -188,7 +196,7 @@ export const EditionAstBuilderNode = memo(function EditionAstBuilderNode(props: 
         </>
       );
 
-      return !props.root ? (
+      const wrappedChildren = showBrackets ? (
         <Brackets
           unary
           removeNesting={() => {
@@ -202,7 +210,13 @@ export const EditionAstBuilderNode = memo(function EditionAstBuilderNode(props: 
           {children}
         </Brackets>
       ) : (
-        <div className="inline-flex flex-row flex-wrap items-center gap-2">{children}</div>
+        children
+      );
+
+      return props.root ? (
+        <div className="inline-flex flex-row flex-wrap items-center gap-2">{wrappedChildren}</div>
+      ) : (
+        wrappedChildren
       );
     })
     .when(isKnownOperandAstNode, (node) => {


### PR DESCRIPTION
- Fix CSS issue on date edition modale when field content was too long:
  <img width="508" alt="image" src="https://github.com/user-attachments/assets/d9521784-059c-4f5b-9251-e4475488b470" />
  <img width="508" alt="image" src="https://github.com/user-attachments/assets/c84ef94c-0021-496c-9786-6fd786876b87" />
- Make AST Builder modal not closable from outside click or escape key down (same as before the rework)