### PR TITLE
fix: accept both UUID an short UUID in routes params

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseDecisions.tsx
+++ b/packages/app-builder/src/components/Cases/CaseDecisions.tsx
@@ -12,7 +12,7 @@ import { type ScenarioIterationRule } from '@app-builder/models/scenario-iterati
 import { ReviewDecisionModal } from '@app-builder/routes/ressources+/cases+/review-decision';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import * as Ariakit from '@ariakit/react';
 import { Await, Link } from '@remix-run/react';
 import * as React from 'react';
@@ -116,7 +116,7 @@ export function CaseDecisions({
                   <Tooltip.Default content={row.scenario.name}>
                     <Link
                       to={getRoute('/scenarios/:scenarioId', {
-                        scenarioId: fromUUID(row.scenario.id),
+                        scenarioId: fromUUIDtoSUUID(row.scenario.id),
                       })}
                       className="hover:text-purple-60 focus:text-purple-60 text-purple-65 relative line-clamp-2 font-semibold hover:underline focus:underline"
                     >
@@ -243,7 +243,7 @@ function DecisionActions({
             render={
               <Link
                 to={getRoute('/decisions/:decisionId', {
-                  decisionId: fromUUID(decision.id),
+                  decisionId: fromUUIDtoSUUID(decision.id),
                 })}
               />
             }
@@ -357,8 +357,8 @@ function DecisionDetail({
                 <SanctionState sanctionCheck={sanctionCheck} />
                 <Link
                   to={getRoute('/cases/:caseId/sanctions/:decisionId', {
-                    caseId: fromUUID(caseId),
-                    decisionId: fromUUID(decision.id),
+                    caseId: fromUUIDtoSUUID(caseId),
+                    decisionId: fromUUIDtoSUUID(decision.id),
                   })}
                 >
                   <Button>

--- a/packages/app-builder/src/components/Cases/CaseHistory/CaseEvents.tsx
+++ b/packages/app-builder/src/components/Cases/CaseHistory/CaseEvents.tsx
@@ -16,7 +16,7 @@ import { useOrganizationUsers } from '@app-builder/services/organization/organiz
 import { getFullName } from '@app-builder/services/user';
 import { formatDateRelative, formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import * as Ariakit from '@ariakit/react';
 import { Link } from '@remix-run/react';
 import { cx } from 'class-variance-authority';
@@ -340,7 +340,7 @@ function DecisionReviewedEventDetail({ event }: { event: DecisionReviewedEvent }
       <Link
         className="text-s hover:text-purple-60 focus:text-purple-60 text-purple-65 relative font-normal hover:underline focus:underline"
         to={getRoute('/decisions/:decisionId', {
-          decisionId: fromUUID(event.decisionId),
+          decisionId: fromUUIDtoSUUID(event.decisionId),
         })}
       >
         {t('cases:case_detail.history.event_detail.rule_snooze_created.decision_detail')}
@@ -458,7 +458,7 @@ function RuleSnoozeDetail({ ruleSnoozeId }: { ruleSnoozeId: string }) {
           <Link
             className="hover:text-purple-60 focus:text-purple-60 text-purple-65 relative font-normal hover:underline focus:underline"
             to={getRoute('/decisions/:decisionId', {
-              decisionId: fromUUID(data.ruleSnoozeDetail.createdFromDecisionId),
+              decisionId: fromUUIDtoSUUID(data.ruleSnoozeDetail.createdFromDecisionId),
             })}
           >
             {t('cases:case_detail.history.event_detail.rule_snooze_created.decision_detail')}
@@ -477,9 +477,11 @@ function RuleSnoozeDetail({ ruleSnoozeId }: { ruleSnoozeId: string }) {
           <Link
             className="hover:text-purple-60 focus:text-purple-60 text-purple-65 relative font-normal hover:underline focus:underline"
             to={getRoute('/scenarios/:scenarioId/i/:iterationId/rules/:ruleId', {
-              scenarioId: fromUUID(data.ruleSnoozeDetail.createdFromRule.scenarioId),
-              iterationId: fromUUID(data.ruleSnoozeDetail.createdFromRule.scenarioIterationId),
-              ruleId: fromUUID(data.ruleSnoozeDetail.createdFromRule.ruleId),
+              scenarioId: fromUUIDtoSUUID(data.ruleSnoozeDetail.createdFromRule.scenarioId),
+              iterationId: fromUUIDtoSUUID(
+                data.ruleSnoozeDetail.createdFromRule.scenarioIterationId,
+              ),
+              ruleId: fromUUIDtoSUUID(data.ruleSnoozeDetail.createdFromRule.ruleId),
             })}
           >
             {data.ruleSnoozeDetail.createdFromRule.ruleName ??

--- a/packages/app-builder/src/components/Cases/CasesList.tsx
+++ b/packages/app-builder/src/components/Cases/CasesList.tsx
@@ -2,7 +2,7 @@ import { type Case } from '@app-builder/models/cases';
 import { useOrganizationTags } from '@app-builder/services/organization/organization-tags';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Link } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel, type SortingState } from '@tanstack/react-table';
 import clsx from 'clsx';
@@ -56,7 +56,7 @@ export function CasesList({
             <Tooltip.Default content={caseName}>
               <Link
                 className="text-purple-65 text-s line-clamp-2 w-fit font-normal underline"
-                to={getRoute('/cases/:caseId', { caseId: fromUUID(row.id) })}
+                to={getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(row.id) })}
               >
                 {caseName}
               </Link>
@@ -116,7 +116,7 @@ export function CasesList({
     state: { sorting },
     manualSorting: true,
     onSortingChange: setSorting,
-    rowLink: ({ id }) => <Link to={getRoute('/cases/:caseId', { caseId: fromUUID(id) })} />,
+    rowLink: ({ id }) => <Link to={getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(id) })} />,
   });
 
   return (

--- a/packages/app-builder/src/components/Decisions/DecisionDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionDetail.tsx
@@ -2,7 +2,7 @@ import { CaseStatus, decisionsI18n } from '@app-builder/components';
 import { type DecisionDetail } from '@app-builder/models/decision';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Link } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 import { Collapsible } from 'ui-design-system';
@@ -24,7 +24,7 @@ export function DecisionDetail({ decision }: { decision: DecisionDetail }) {
           <DetailLabel>{t('decisions:scenario.name')}</DetailLabel>
           <Link
             to={getRoute('/scenarios/:scenarioId', {
-              scenarioId: fromUUID(scenario.id),
+              scenarioId: fromUUIDtoSUUID(scenario.id),
             })}
             className="hover:text-purple-60 focus:text-purple-60 text-purple-65 font-semibold hover:underline focus:underline"
           >
@@ -34,8 +34,8 @@ export function DecisionDetail({ decision }: { decision: DecisionDetail }) {
           <DetailLabel>{t('decisions:scenario.version')}</DetailLabel>
           <Link
             to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
-              scenarioId: fromUUID(scenario.id),
-              iterationId: fromUUID(scenario.scenarioIterationId),
+              scenarioId: fromUUIDtoSUUID(scenario.id),
+              iterationId: fromUUIDtoSUUID(scenario.scenarioIterationId),
             })}
             className="hover:text-purple-60 focus:text-purple-60 text-purple-65 font-semibold hover:underline focus:underline"
           >
@@ -51,7 +51,7 @@ export function DecisionDetail({ decision }: { decision: DecisionDetail }) {
               <CaseStatus size="small" type="first-letter" status={caseDetail.status} />
               <Link
                 to={getRoute('/cases/:caseId', {
-                  caseId: fromUUID(caseDetail.id),
+                  caseId: fromUUIDtoSUUID(caseDetail.id),
                 })}
                 className="hover:text-purple-60 focus:text-purple-60 text-purple-65 font-semibold hover:underline focus:underline"
               >

--- a/packages/app-builder/src/components/Decisions/DecisionsList.tsx
+++ b/packages/app-builder/src/components/Decisions/DecisionsList.tsx
@@ -4,7 +4,7 @@ import { type ReviewStatus } from '@app-builder/models/decision';
 import { type Outcome } from '@app-builder/models/outcome';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Link } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
@@ -248,7 +248,7 @@ export function DecisionsList({
     rowLink: (decision) => (
       <Link
         to={getRoute('/decisions/:decisionId', {
-          decisionId: fromUUID(decision.id),
+          decisionId: fromUUIDtoSUUID(decision.id),
         })}
       />
     ),

--- a/packages/app-builder/src/components/Scenario/TestRun/TestRunSelector.tsx
+++ b/packages/app-builder/src/components/Scenario/TestRun/TestRunSelector.tsx
@@ -3,7 +3,7 @@ import { type ScenarioIterationWithType } from '@app-builder/models/scenario-ite
 import { type TestRun } from '@app-builder/models/testrun';
 import { useCurrentScenario } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/_layout';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Link } from '@remix-run/react';
 import clsx from 'clsx';
 import { Avatar } from 'ui-design-system';
@@ -31,8 +31,8 @@ export const TestRunSelector = ({
   return (
     <Link
       to={getRoute('/scenarios/:scenarioId/test-run/:testRunId', {
-        scenarioId: fromUUID(currentScenario.id),
-        testRunId: fromUUID(id),
+        scenarioId: fromUUIDtoSUUID(currentScenario.id),
+        testRunId: fromUUIDtoSUUID(id),
       })}
       className={clsx(
         'grid cursor-pointer grid-cols-[30%_30%_8%_auto] items-center rounded-lg border py-4 transition-colors',

--- a/packages/app-builder/src/components/Transfers/TransfersList.tsx
+++ b/packages/app-builder/src/components/Transfers/TransfersList.tsx
@@ -1,7 +1,7 @@
 import { type Transfer } from '@app-builder/models/transfer';
 import { formatCurrency, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Link } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
@@ -59,7 +59,7 @@ export function TransfersList({ className, transfers }: TransfersListProps) {
     rowLink: (transfer) => (
       <Link
         to={getRoute('/transfercheck/transfers/:transferId', {
-          transferId: fromUUID(transfer.id),
+          transferId: fromUUIDtoSUUID(transfer.id),
         })}
       />
     ),

--- a/packages/app-builder/src/queries/builder-options.ts
+++ b/packages/app-builder/src/queries/builder-options.ts
@@ -1,6 +1,6 @@
 import { type BuilderOptionsResource } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/builder-options';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { useQuery } from '@tanstack/react-query';
 
 const endpoint = (scenarioId: string) =>
@@ -13,7 +13,7 @@ type UseBuilderOptionsQueryParams = {
   initialData?: BuilderOptionsResource;
 };
 export function useBuilderOptionsQuery(params: UseBuilderOptionsQueryParams) {
-  const queryKey = ['resources', 'builder-options', fromUUID(params.scenarioId)] as const;
+  const queryKey = ['resources', 'builder-options', fromUUIDtoSUUID(params.scenarioId)] as const;
 
   return useQuery({
     queryKey,

--- a/packages/app-builder/src/queries/validate-ast.ts
+++ b/packages/app-builder/src/queries/validate-ast.ts
@@ -3,7 +3,7 @@ import {
   type AstValidationReturnType,
 } from '@app-builder/routes/ressources+/scenarios+/$scenarioId+/validate-ast';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { useMutation } from '@tanstack/react-query';
 
 const endpoint = (scenarioId: string) =>
@@ -15,7 +15,7 @@ type UseValidateAstMutationParams = {
   scenarioId: string;
 };
 export function useValidateAstMutation(params: UseValidateAstMutationParams) {
-  const scenarioNanoId = fromUUID(params.scenarioId);
+  const scenarioNanoId = fromUUIDtoSUUID(params.scenarioId);
 
   return useMutation({
     mutationFn: async (payload: AstValidationPayload & { ac: AbortController }) => {

--- a/packages/app-builder/src/repositories/TestRunRepository.ts
+++ b/packages/app-builder/src/repositories/TestRunRepository.ts
@@ -12,7 +12,7 @@ import {
   type TestRunStatus,
   testRunStatuses,
 } from '@app-builder/models/testrun';
-import { toUUID } from '@app-builder/utils/short-uuid';
+import { fromSUUIDtoUUID } from '@app-builder/utils/short-uuid';
 import { addDays } from 'date-fns';
 import { sleep } from 'radash';
 import { randomInteger } from 'remeda';
@@ -182,7 +182,7 @@ export const makeGetTestRunRepository2 = () => {
     },
     launchTestRun: (args: TestRunCreateInput) => {
       const testRun: TestRun = {
-        id: toUUID(short.generate()),
+        id: fromSUUIDtoUUID(short.generate()),
         refIterationId: '6f6fe0d8-9a1a-4d5a-bdd7-fa7fcda1b4e3',
         scenarioId: args.scenarioId,
         testIterationId: args.testIterationId,

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId._index.tsx
@@ -1,6 +1,6 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -16,7 +16,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
     successRedirect: getRoute('/cases/:caseId/decisions', {
-      caseId: fromUUID(caseId),
+      caseId: fromUUIDtoSUUID(caseId),
     }),
   });
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId._index.tsx
@@ -1,22 +1,22 @@
 import { initServerServices } from '@app-builder/services/init.server';
+import { parseIdParamSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { authService } = initServerServices(request);
 
-  const caseId = fromParams(params, 'caseId');
-  if (!caseId) {
-    return {
-      redirect: getRoute('/cases/inboxes'),
-    };
+  const parsedParams = await parseIdParamSafe(params, 'caseId');
+
+  if (!parsedParams.success) {
+    return { redirect: getRoute('/cases/inboxes') };
   }
 
   await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
     successRedirect: getRoute('/cases/:caseId/decisions', {
-      caseId: fromUUIDtoSUUID(caseId),
+      caseId: fromUUIDtoSUUID(parsedParams.data.caseId),
     }),
   });
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId._layout.tsx
@@ -32,7 +32,7 @@ import { initServerServices } from '@app-builder/services/init.server';
 import { getCaseFileUploadEndpoint } from '@app-builder/utils/files';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { defer, type LoaderFunctionArgs, type SerializeFrom } from '@remix-run/node';
 import {
   isRouteErrorResponse,
@@ -67,7 +67,7 @@ export const handle = {
       return (
         <BreadCrumbLink
           to={getRoute('/cases/inboxes/:inboxId', {
-            inboxId: fromUUID(inbox.id),
+            inboxId: fromUUIDtoSUUID(inbox.id),
           })}
           isLast={isLast}
         >
@@ -81,7 +81,7 @@ export const handle = {
       return (
         <div className="flex items-center gap-4">
           <BreadCrumbLink
-            to={getRoute('/cases/:caseId', { caseId: fromUUID(caseDetail.id) })}
+            to={getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(caseDetail.id) })}
             isLast={isLast}
           >
             <span className="line-clamp-2 text-start">{caseDetail.name}</span>

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId._layout.tsx
@@ -31,12 +31,14 @@ import {
 import { initServerServices } from '@app-builder/services/init.server';
 import { getCaseFileUploadEndpoint } from '@app-builder/utils/files';
 import { formatDateTime, useFormatLanguage } from '@app-builder/utils/format';
+import { parseIdParamSafe } from '@app-builder/utils/input-validation';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
-import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { defer, type LoaderFunctionArgs, type SerializeFrom } from '@remix-run/node';
 import {
   isRouteErrorResponse,
   Outlet,
+  redirect,
   useLoaderData,
   useNavigate,
   useRouteError,
@@ -62,7 +64,7 @@ export const handle = {
       );
     },
     ({ isLast }: BreadCrumbProps) => {
-      const { inbox } = useLoaderData<typeof loader>();
+      const { inbox } = useLoaderData<typeof loader>(); // Ensure inbox is part of the loader's return type
 
       return (
         <BreadCrumbLink
@@ -76,7 +78,8 @@ export const handle = {
       );
     },
     ({ isLast }: BreadCrumbProps) => {
-      const { caseDetail } = useLoaderData<typeof loader>();
+      const data = useLoaderData<typeof loader>();
+      const caseDetail = data.caseDetail; // Safely access caseDetail from the loader data
 
       return (
         <div className="flex items-center gap-4">
@@ -114,9 +117,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     failureRedirect: getRoute('/sign-in'),
   });
 
-  const caseId = fromParams(params, 'caseId');
+  const parsedParams = await parseIdParamSafe(params, 'caseId');
+
+  if (!parsedParams.success) return redirect(getRoute('/cases/inboxes'));
+
   try {
-    const caseDetail = await cases.getCase({ caseId });
+    const caseDetail = await cases.getCase({ caseId: parsedParams.data.caseId });
     const currentInbox = await inbox.getInbox(caseDetail.inboxId);
 
     const dataModelPromise = dataModelRepository.getDataModel();
@@ -159,9 +165,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         };
       }),
     );
-
     return defer({
-      caseDetail,
+      caseDetail, // Ensure caseDetail is explicitly included in the returned data
       inbox: currentInbox,
       user,
       entitlements,
@@ -182,10 +187,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   }
 }
 
-export function useCurrentCase() {
-  return useRouteLoaderData(
+export function useCurrentCase(): SerializeFrom<typeof loader> {
+  const data = useRouteLoaderData<typeof loader>(
     'routes/_builder+/cases+/$caseId._layout' satisfies RouteID,
-  ) as SerializeFrom<typeof loader>;
+  );
+  if (!data || typeof data !== 'object') {
+    throw new Error('Loader data is undefined or invalid');
+  }
+  return data as SerializeFrom<typeof loader>;
 }
 
 export default function CasePage() {

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_index.tsx
@@ -1,6 +1,6 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -17,7 +17,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (!decisionId) {
     return {
       redirect: getRoute('/cases/:caseId/decisions', {
-        caseId: fromUUID(caseId),
+        caseId: fromUUIDtoSUUID(caseId),
       }),
     };
   }
@@ -25,8 +25,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
     successRedirect: getRoute('/cases/:caseId/sanctions/:decisionId/hits', {
-      caseId: fromUUID(caseId),
-      decisionId: fromUUID(decisionId),
+      caseId: fromUUIDtoSUUID(caseId),
+      decisionId: fromUUIDtoSUUID(decisionId),
     }),
   });
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId_.sanctions.$decisionId+/_layout.tsx
@@ -19,7 +19,7 @@ import { UploadFile } from '@app-builder/routes/ressources+/files+/upload-file';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getSanctionCheckFileUploadEndpoint } from '@app-builder/utils/files';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { defer, type LoaderFunctionArgs, type SerializeFrom } from '@remix-run/node';
 import {
   isRouteErrorResponse,
@@ -54,7 +54,7 @@ export const handle = {
       return (
         <BreadCrumbLink
           to={getRoute('/cases/inboxes/:inboxId', {
-            inboxId: fromUUID(inbox.id),
+            inboxId: fromUUIDtoSUUID(inbox.id),
           })}
           isLast={isLast}
         >
@@ -70,7 +70,7 @@ export const handle = {
       return (
         <div className="flex items-center gap-2">
           <BreadCrumbLink
-            to={getRoute('/cases/:caseId', { caseId: fromUUID(caseDetail.id) })}
+            to={getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(caseDetail.id) })}
             isLast={isLast}
           >
             <span className="line-clamp-2 text-start">{t('cases:case.page_title')}</span>
@@ -90,8 +90,8 @@ export const handle = {
         <div className="flex items-center gap-2">
           <BreadCrumbLink
             to={getRoute('/cases/:caseId/sanctions/:decisionId', {
-              caseId: fromUUID(caseDetail.id),
-              decisionId: fromUUID(decision.id),
+              caseId: fromUUIDtoSUUID(caseDetail.id),
+              decisionId: fromUUIDtoSUUID(decision.id),
             })}
             isLast={isLast}
           >
@@ -164,7 +164,9 @@ export default function CaseSanctionReviewPage() {
     <Page.Main>
       <Page.Header className="justify-between gap-8">
         <div className="flex gap-4">
-          <Page.BackLink to={getRoute('/cases/:caseId', { caseId: fromUUID(caseDetail.id) })} />
+          <Page.BackLink
+            to={getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(caseDetail.id) })}
+          />
           <BreadCrumbs />
         </div>
       </Page.Header>

--- a/packages/app-builder/src/routes/_builder+/cases+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/_index.tsx
@@ -3,7 +3,7 @@ import { CreateInbox } from '@app-builder/routes/ressources+/settings+/inboxes+/
 import { isCreateInboxAvailable } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +19,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const inboxes = await inbox.listInboxes();
 
   if (R.hasAtLeast(inboxes, 1)) {
-    return redirect(getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUID(inboxes[0].id) }));
+    return redirect(
+      getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUIDtoSUUID(inboxes[0].id) }),
+    );
   }
 
   return json({

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -19,7 +19,7 @@ import { type CaseFilters } from '@app-builder/repositories/CaseRepository';
 import { initServerServices } from '@app-builder/services/init.server';
 import { parseQuerySafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID, useParam } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData, useNavigate } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -71,7 +71,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const parsedQuery = await parseQuerySafe(request, casesFiltersSchema);
   const parsedPaginationQuery = await parseQuerySafe(request, paginationSchema);
   if (!parsedQuery.success || !parsedPaginationQuery.success) {
-    return redirect(getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUID(inboxId) }));
+    return redirect(getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUIDtoSUUID(inboxId) }));
   }
 
   const filtersForBackend: CaseFilters = {
@@ -186,7 +186,7 @@ export default function Cases() {
       if (!pagination) {
         reset();
 
-        const pathname = getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUID(inboxId) });
+        const pathname = getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUIDtoSUUID(inboxId) });
         const search = qs.stringify(buildQueryParams(casesFilters, null, null), {
           addQueryPrefix: true,
           skipNulls: true,
@@ -212,7 +212,7 @@ export default function Cases() {
         navigate(
           {
             pathname: getRoute('/cases/inboxes/:inboxId', {
-              inboxId: fromUUID(inboxId),
+              inboxId: fromUUIDtoSUUID(inboxId),
             }),
             search: qs.stringify(buildQueryParams(casesFilters, null, pagination.order), {
               addQueryPrefix: true,

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
@@ -9,7 +9,7 @@ import { CreateInbox } from '@app-builder/routes/ressources+/settings+/inboxes+/
 import { isCreateInboxAvailable } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { NavLink, Outlet, useLoaderData } from '@remix-run/react';
 import clsx from 'clsx';
@@ -77,7 +77,7 @@ export default function Cases() {
                         )
                       }
                       to={getRoute('/cases/inboxes/:inboxId', {
-                        inboxId: fromUUID(inbox.id),
+                        inboxId: fromUUIDtoSUUID(inbox.id),
                       })}
                     >
                       {inbox.name}

--- a/packages/app-builder/src/routes/_builder+/cases_new+/$caseId._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases_new+/$caseId._index.tsx
@@ -9,7 +9,7 @@ import { type CaseDetail } from '@app-builder/models/cases';
 import { type Inbox } from '@app-builder/models/inbox';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { useEffect } from 'react';
@@ -61,7 +61,9 @@ export const handle = {
       return (
         <BreadCrumbLink
           isLast={isLast}
-          to={getRoute('/cases/inboxes/:inboxId', { inboxId: fromUUID(data.currentInbox.id) })}
+          to={getRoute('/cases/inboxes/:inboxId', {
+            inboxId: fromUUIDtoSUUID(data.currentInbox.id),
+          })}
         >
           {data.currentInbox.name}
         </BreadCrumbLink>
@@ -72,7 +74,7 @@ export const handle = {
         <>
           <BreadCrumbLink
             isLast={isLast}
-            to={getRoute('/cases_new/:caseId', { caseId: fromUUID(data.case.id) })}
+            to={getRoute('/cases_new/:caseId', { caseId: fromUUIDtoSUUID(data.case.id) })}
           >
             {data.case.name}
           </BreadCrumbLink>

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -25,7 +25,7 @@ import { notFound } from '@app-builder/utils/http/http-responses';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { shortUUIDSchema } from '@app-builder/utils/schema/shortUUIDSchema';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { defer, type LoaderFunctionArgs } from '@remix-run/node';
 import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -48,7 +48,7 @@ export const handle = {
           <BreadCrumbLink
             isLast={isLast}
             to={getRoute('/decisions/:decisionId', {
-              decisionId: fromUUID(decision.id),
+              decisionId: fromUUIDtoSUUID(decision.id),
             })}
           >
             <span className="line-clamp-1 text-start">{t('decisions:decision')}</span>

--- a/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/_index.tsx
@@ -23,7 +23,7 @@ import { type PaginatedResponse, type PaginationParams } from '@app-builder/mode
 import { initServerServices } from '@app-builder/services/init.server';
 import { parseQuerySafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { Form, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -238,7 +238,7 @@ function AddToCase({
 
 const decisionIdToParams = (decisionId: string | null) => {
   try {
-    return fromUUID(decisionId ?? '');
+    return fromUUIDtoSUUID(decisionId ?? '');
   } catch {
     return decisionId;
   }

--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -25,6 +25,7 @@ import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
 import { parseParamsSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { shortUUIDSchema } from '@app-builder/utils/schema/shortUUIDSchema';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData, useRevalidator, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -80,7 +81,10 @@ export const handle = {
       const { customList } = useLoaderData<typeof loader>();
 
       return (
-        <BreadCrumbLink to={getRoute('/lists/:listId', { listId: customList.id })} isLast={isLast}>
+        <BreadCrumbLink
+          to={getRoute('/lists/:listId', { listId: fromUUIDtoSUUID(customList.id) })}
+          isLast={isLast}
+        >
           {customList.name}
         </BreadCrumbLink>
       );

--- a/packages/app-builder/src/routes/_builder+/lists+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/_index.tsx
@@ -5,7 +5,7 @@ import { CreateList } from '@app-builder/routes/ressources+/lists+/create';
 import { isCreateListAvailable } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useLoaderData, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -79,7 +79,7 @@ export default function ListsPage() {
     rowLink: ({ id }) => (
       <Link
         to={getRoute('/lists/:listId', {
-          listId: fromUUID(id),
+          listId: fromUUIDtoSUUID(id),
         })}
       />
     ),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/_layout.tsx
@@ -4,7 +4,7 @@ import { TriggerObjectTag } from '@app-builder/components/Scenario/TriggerObject
 import { adaptScenarioIterationWithType } from '@app-builder/models/scenario-iteration';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs, type SerializeFrom } from '@remix-run/node';
 import { Outlet, useRouteError, useRouteLoaderData } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -21,7 +21,7 @@ export const handle = {
           <BreadCrumbLink
             isLast={isLast}
             to={getRoute('/scenarios/:scenarioId', {
-              scenarioId: fromUUID(currentScenario.id),
+              scenarioId: fromUUIDtoSUUID(currentScenario.id),
             })}
           >
             {currentScenario.name}

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/home.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/home.tsx
@@ -26,7 +26,7 @@ import {
 import { initServerServices } from '@app-builder/services/init.server';
 import { formatDateRelative, formatSchedule, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import * as Ariakit from '@ariakit/react';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useFetcher, useLoaderData } from '@remix-run/react';
@@ -259,8 +259,8 @@ function VersionSection({
         version: si.version,
         updatedAt: si.updatedAt,
         linkTo: getRoute('/scenarios/:scenarioId/i/:iterationId', {
-          scenarioId: fromUUID(si.scenarioId),
-          iterationId: fromUUID(si.id),
+          scenarioId: fromUUIDtoSUUID(si.scenarioId),
+          iterationId: fromUUIDtoSUUID(si.id),
         }),
         formattedVersion: getFormattedVersion(si, t),
         formattedLive: getFormattedLive(si, t),
@@ -308,8 +308,8 @@ function QuickVersionAccess({
   return (
     <Link
       to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(scenarioIteration.scenarioId),
-        iterationId: fromUUID(scenarioIteration.id),
+        scenarioId: fromUUIDtoSUUID(scenarioIteration.scenarioId),
+        iterationId: fromUUIDtoSUUID(scenarioIteration.id),
       })}
       className="bg-grey-100 border-grey-90 text-grey-00 text-s hover:bg-grey-95 active:bg-grey-90 flex min-w-24 flex-row items-center justify-center gap-1 rounded-full border py-2 transition-colors"
     >
@@ -379,8 +379,8 @@ function TestRunSection({ scenarioId, access }: { scenarioId: string; access: Fe
               color: 'grey',
             })}
             to={getRoute('/scenarios/:scenarioId/test-run/:testRunId', {
-              scenarioId: fromUUID(scenarioId),
-              testRunId: fromUUID(currentTestRun[0]!.id),
+              scenarioId: fromUUIDtoSUUID(scenarioId),
+              testRunId: fromUUIDtoSUUID(currentTestRun[0]!.id),
             })}
           >
             {t('scenarios:testrun.current_run')}
@@ -391,7 +391,7 @@ function TestRunSection({ scenarioId, access }: { scenarioId: string; access: Fe
           <Link
             className={CtaClassName({ variant: 'secondary', color: 'grey' })}
             to={getRoute('/scenarios/:scenarioId/test-run', {
-              scenarioId: fromUUID(scenarioId),
+              scenarioId: fromUUIDtoSUUID(scenarioId),
             })}
           >
             {t('scenarios:testrun.archived')}
@@ -532,7 +532,7 @@ function BatchSection({
         <Link
           className={CtaClassName({ variant: 'secondary', color: 'grey' })}
           to={getRoute('/scenarios/:scenarioId/scheduled-executions', {
-            scenarioId: fromUUID(scenarioId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
           })}
         >
           {t('scenarios:home.execution.batch.scheduled_execution', {
@@ -645,7 +645,7 @@ function WorkflowSection({ scenario, access }: { scenario: Scenario; access: Fea
             color: isEdit ? 'grey' : 'purple',
           })}
           to={getRoute('/scenarios/:scenarioId/workflow', {
-            scenarioId: fromUUID(scenario.id),
+            scenarioId: fromUUIDtoSUUID(scenario.id),
           })}
         >
           <Icon icon={isEdit ? 'edit-square' : 'plus'} className="size-6" />

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_edit-view+/rules.tsx
@@ -23,7 +23,7 @@ import {
 } from '@app-builder/services/validation';
 import { formatNumber, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID, useParam } from '@app-builder/utils/short-uuid';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
@@ -256,12 +256,12 @@ export default function Rules() {
     getSortedRowModel: getSortedRowModel(),
     rowLink: (row) =>
       row.type === 'rule' ? (
-        <Link to={`./${fromUUID(row.id)}`} />
+        <Link to={`./${fromUUIDtoSUUID(row.id)}`} />
       ) : (
         <Link
           to={getRoute('/scenarios/:scenarioId/i/:iterationId/sanction', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           })}
         />
       ),

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout.tsx
@@ -14,7 +14,7 @@ import { initServerServices } from '@app-builder/services/init.server';
 import { findRuleValidation } from '@app-builder/services/validation';
 import { formatDateRelative, useFormatLanguage } from '@app-builder/utils/format';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
-import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID, useParam } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, type SerializeFrom } from '@remix-run/node';
 import { Outlet, useLoaderData, useLocation, useRouteLoaderData } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -49,8 +49,8 @@ export const handle = {
           <BreadCrumbLink
             isLast={isLast}
             to={getRoute('/scenarios/:scenarioId/i/:iterationId', {
-              scenarioId: fromUUID(currentIteration.scenarioId),
-              iterationId: fromUUID(currentIteration.id),
+              scenarioId: fromUUIDtoSUUID(currentIteration.scenarioId),
+              iterationId: fromUUIDtoSUUID(currentIteration.id),
             })}
           >
             <p className="text-s flex flex-row gap-1 font-semibold">
@@ -178,7 +178,10 @@ export function VersionSelect({
         type: si.type,
         version: si.version,
         updatedAt: si.updatedAt,
-        linkTo: location.pathname.replace(fromUUID(currentIteration.id), fromUUID(si.id)),
+        linkTo: location.pathname.replace(
+          fromUUIDtoSUUID(currentIteration.id),
+          fromUUIDtoSUUID(si.id),
+        ),
         formattedVersion: getFormattedVersion(si, t),
         formattedLive: getFormattedLive(si, t),
         formattedUpdatedAt: formatDateRelative(si.updatedAt, {

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/rules.$ruleId.tsx
@@ -18,7 +18,7 @@ import { useEditorMode } from '@app-builder/services/editor/editor-mode';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID, useParam } from '@app-builder/utils/short-uuid';
 import * as Ariakit from '@ariakit/react';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
@@ -44,8 +44,8 @@ export const handle = {
         <BreadCrumbLink
           isLast={isLast}
           to={getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           })}
         >
           {t('navigation:scenario.rules')}
@@ -64,12 +64,12 @@ export const handle = {
           <BreadCrumbLink
             isLast={isLast}
             to={getRoute('/scenarios/:scenarioId/i/:iterationId/rules/:ruleId', {
-              scenarioId: fromUUID(scenarioId),
-              iterationId: fromUUID(iterationId),
-              ruleId: fromUUID(rule.id),
+              scenarioId: fromUUIDtoSUUID(scenarioId),
+              iterationId: fromUUIDtoSUUID(iterationId),
+              ruleId: fromUUIDtoSUUID(rule.id),
             })}
           >
-            {rule.name ?? fromUUID(rule.id)}
+            {rule.name ?? fromUUIDtoSUUID(rule.id)}
           </BreadCrumbLink>
           {editorMode === 'edit' ? (
             <Tag size="big" border="square">
@@ -223,8 +223,8 @@ export default function RuleDetail() {
       <Page.Header>
         <BreadCrumbs
           back={getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-            iterationId: fromUUID(iterationId),
-            scenarioId: fromUUID(scenario.id),
+            iterationId: fromUUIDtoSUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenario.id),
           })}
         />
       </Page.Header>

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanction.tsx
@@ -26,7 +26,7 @@ import { useEditorMode } from '@app-builder/services/editor/editor-mode';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID, useParam } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID, useParam } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 import { Dict } from '@swan-io/boxed';
@@ -54,8 +54,8 @@ export const handle = {
         <BreadCrumbLink
           isLast={isLast}
           to={getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           })}
         >
           {t('navigation:scenario.rules')}
@@ -72,8 +72,8 @@ export const handle = {
           <BreadCrumbLink
             isLast={isLast}
             to={getRoute('/scenarios/:scenarioId/i/:iterationId/sanction', {
-              scenarioId: fromUUID(iteration.scenarioId),
-              iterationId: fromUUID(iteration.id),
+              scenarioId: fromUUIDtoSUUID(iteration.scenarioId),
+              iterationId: fromUUIDtoSUUID(iteration.id),
             })}
           >
             {iteration.sanctionCheckConfig?.name ?? t('common:no_name')}
@@ -257,8 +257,8 @@ export default function SanctionDetail() {
       <Page.Header className="justify-between">
         <BreadCrumbs
           back={getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-            iterationId: fromUUID(iterationId),
-            scenarioId: fromUUID(scenario.id),
+            iterationId: fromUUIDtoSUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenario.id),
           })}
         />
       </Page.Header>

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/scheduled-executions.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/scheduled-executions.tsx
@@ -7,7 +7,7 @@ import {
 import { ScheduledExecutionsList } from '@app-builder/components/Scenario/ScheduledExecutionsList';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -26,7 +26,7 @@ export const handle = {
       return (
         <BreadCrumbLink
           to={getRoute('/scenarios/:scenarioId/scheduled-executions', {
-            scenarioId: fromUUID(currentScenario.id),
+            scenarioId: fromUUIDtoSUUID(currentScenario.id),
           })}
           isLast={isLast}
         >

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/$testRunId+/index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/$testRunId+/index.tsx
@@ -15,7 +15,7 @@ import { CancelTestRun } from '@app-builder/routes/ressources+/scenarios+/$scena
 import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { defer, type LoaderFunctionArgs } from '@remix-run/node';
 import { Await, useLoaderData } from '@remix-run/react';
 import { Suspense, useMemo } from 'react';
@@ -37,8 +37,8 @@ export const handle = {
           <BreadCrumbLink
             isLast={isLast}
             to={getRoute('/scenarios/:scenarioId/test-run/:testRunId', {
-              scenarioId: fromUUID(run.scenarioId),
-              testRunId: fromUUID(run.id),
+              scenarioId: fromUUIDtoSUUID(run.scenarioId),
+              testRunId: fromUUIDtoSUUID(run.id),
             })}
           >
             {t('scenarios:home.testrun')}

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/test-run+/_layout.tsx
@@ -1,6 +1,6 @@
 import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Outlet } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
 
@@ -16,7 +16,7 @@ export const handle = {
         <BreadCrumbLink
           isLast={isLast}
           to={getRoute('/scenarios/:scenarioId/test-run', {
-            scenarioId: fromUUID(currentScenario.id),
+            scenarioId: fromUUIDtoSUUID(currentScenario.id),
           })}
         >
           {t('scenarios:testrun.home')}

--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/workflow.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/workflow.tsx
@@ -24,7 +24,7 @@ import {
 import { isCreateInboxAvailable, isWorkflowsAvailable } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LinksFunction, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher, useLoaderData, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -44,7 +44,7 @@ export const handle = {
         <BreadCrumbLink
           isLast={isLast}
           to={getRoute('/scenarios/:scenarioId/workflow', {
-            scenarioId: fromUUID(currentScenario.id),
+            scenarioId: fromUUIDtoSUUID(currentScenario.id),
           })}
         >
           {t('scenarios:home.workflow')}
@@ -68,7 +68,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (!isWorkflowsAvailable(entitlements)) {
     return redirect(
       getRoute('/scenarios/:scenarioId/home', {
-        scenarioId: fromUUID(scenarioId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
       }),
     );
   }
@@ -109,7 +109,7 @@ export async function action({ request, params }: LoaderFunctionArgs) {
   if (!isWorkflowsAvailable(entitlements)) {
     return redirect(
       getRoute('/scenarios/:scenarioId/home', {
-        scenarioId: fromUUID(scenarioId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
       }),
     );
   }
@@ -127,7 +127,7 @@ export async function action({ request, params }: LoaderFunctionArgs) {
     });
     return redirect(
       getRoute('/scenarios/:scenarioId/workflow', {
-        scenarioId: fromUUID(scenarioId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
       }),
       {
         headers: { 'Set-Cookie': await commitSession(session) },
@@ -146,7 +146,7 @@ export async function action({ request, params }: LoaderFunctionArgs) {
 
   return redirect(
     getRoute('/scenarios/:scenarioId/home', {
-      scenarioId: fromUUID(scenarioId),
+      scenarioId: fromUUIDtoSUUID(scenarioId),
     }),
     {
       headers: { 'Set-Cookie': await commitSession(session) },

--- a/packages/app-builder/src/routes/_builder+/scenarios+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/_index.tsx
@@ -3,7 +3,7 @@ import { BreadCrumbs } from '@app-builder/components/Breadcrumbs';
 import { CreateScenario } from '@app-builder/routes/ressources+/scenarios+/create';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { Link, useLoaderData, useRouteError } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -55,7 +55,7 @@ export default function ScenariosPage() {
                     <Link
                       key={scenario.id}
                       to={getRoute('/scenarios/:scenarioId', {
-                        scenarioId: fromUUID(scenario.id),
+                        scenarioId: fromUUIDtoSUUID(scenario.id),
                       })}
                     >
                       <div className="bg-grey-100 border-grey-90 flex flex-col gap-1 rounded-lg border border-solid p-4 hover:shadow-md">

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
@@ -17,7 +17,7 @@ import {
 import { initServerServices } from '@app-builder/services/init.server';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getRoute, type RouteID } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect, type SerializeFrom } from '@remix-run/node';
 import { useLoaderData, useRouteLoaderData } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
@@ -46,7 +46,7 @@ export const handle = {
         <BreadCrumbLink
           isLast={isLast}
           to={getRoute('/settings/inboxes/:inboxId', {
-            inboxId: fromUUID(inbox.id),
+            inboxId: fromUUIDtoSUUID(inbox.id),
           })}
         >
           {inbox.name}

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
@@ -82,7 +82,7 @@ export default function Inboxes() {
     rowLink: ({ id }) => (
       <Link
         to={getRoute('/settings/inboxes/:inboxId', {
-          inboxId: fromUUID(id),
+          inboxId: fromUUIDtoSUUID(id),
         })}
       />
     ),

--- a/packages/app-builder/src/routes/ressources+/cases+/add-to-case.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/add-to-case.tsx
@@ -7,7 +7,7 @@ import { isStatusBadRequestHttpError } from '@app-builder/models';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { useForm, useStore } from '@tanstack/react-form';
@@ -74,7 +74,7 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     if (data.newCase) {
       const createdCase = await cases.createCase(data);
-      return redirect(getRoute('/cases/:caseId', { caseId: fromUUID(createdCase.id) }));
+      return redirect(getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(createdCase.id) }));
     } else {
       await cases.addDecisionsToCase(data);
 

--- a/packages/app-builder/src/routes/ressources+/cases+/create-case.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/create-case.tsx
@@ -6,7 +6,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -53,7 +53,7 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const createdCase = await cases.createCase(data);
 
-    return redirect(getRoute('/cases/:caseId', { caseId: fromUUID(createdCase.id) }));
+    return redirect(getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(createdCase.id) }));
   } catch (error) {
     setToastMessage(session, {
       type: 'error',

--- a/packages/app-builder/src/routes/ressources+/lists+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/lists+/create.tsx
@@ -6,7 +6,7 @@ import { isStatusConflictHttpError } from '@app-builder/models';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -49,7 +49,7 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const result = await customListsRepository.createCustomList(data);
 
-    return redirect(getRoute('/lists/:listId', { listId: fromUUID(result.id) }));
+    return redirect(getRoute('/lists/:listId', { listId: fromUUIDtoSUUID(result.id) }));
   } catch (error) {
     setToastMessage(session, {
       type: 'error',

--- a/packages/app-builder/src/routes/ressources+/rule-snoozes+/read.$ruleSnoozeId.tsx
+++ b/packages/app-builder/src/routes/ressources+/rule-snoozes+/read.$ruleSnoozeId.tsx
@@ -1,7 +1,7 @@
 import { type RuleSnoozeDetail } from '@app-builder/models/rule-snooze';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import * as React from 'react';
@@ -51,7 +51,7 @@ export function useGetRuleSnoozeFetcher({ ruleSnoozeId }: { ruleSnoozeId: string
     if (loadFetcher.state === 'idle' && !loadFetcher.data) {
       loadFetcher.load(
         getRoute('/ressources/rule-snoozes/read/:ruleSnoozeId', {
-          ruleSnoozeId: fromUUID(ruleSnoozeId),
+          ruleSnoozeId: fromUUIDtoSUUID(ruleSnoozeId),
         }),
       );
     }

--- a/packages/app-builder/src/routes/ressources+/sanction-check+/enrich-match.$matchId.tsx
+++ b/packages/app-builder/src/routes/ressources+/sanction-check+/enrich-match.$matchId.tsx
@@ -4,7 +4,7 @@ import { isStatusConflictHttpError } from '@app-builder/models';
 import { initServerServices } from '@app-builder/services/init.server';
 import { useCallbackRef } from '@app-builder/utils/hooks';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { useTranslation } from 'react-i18next';
@@ -72,7 +72,7 @@ export function EnrichMatchButton({ matchId }: { matchId: string }) {
       {
         method: 'POST',
         action: getRoute('/ressources/sanction-check/enrich-match/:matchId', {
-          matchId: fromUUID(matchId),
+          matchId: fromUUIDtoSUUID(matchId),
         }),
       },
     );

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/activate.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/activate.tsx
@@ -10,7 +10,7 @@ import {
 import { useCurrentScenarioIteration } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/_layout';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -85,8 +85,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirectBack(request, {
       fallback: getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       }),
     });
   } catch (error) {
@@ -191,8 +191,8 @@ function ActivateScenarioVersionContent({
         fetcher.submit(value, {
           method: 'POST',
           action: getRoute('/ressources/scenarios/:scenarioId/:iterationId/activate', {
-            scenarioId: fromUUID(scenario.id),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenario.id),
+            iterationId: fromUUIDtoSUUID(iterationId),
           }),
           encType: 'application/json',
         });
@@ -288,8 +288,8 @@ function RuleSnoozeDetail() {
     if (state === 'idle' && !data) {
       load(
         getRoute('/ressources/scenarios/:scenarioId/:iterationId/activate', {
-          scenarioId: fromUUID(iteration.scenarioId),
-          iterationId: fromUUID(iteration.id),
+          scenarioId: fromUUIDtoSUUID(iteration.scenarioId),
+          iterationId: fromUUIDtoSUUID(iteration.id),
         }),
       );
     }

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/commit.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/commit.tsx
@@ -3,7 +3,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { isStatusBadRequestHttpError } from '@app-builder/models';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -57,8 +57,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirectBack(request, {
       fallback: getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       }),
     });
   } catch (error) {
@@ -147,8 +147,8 @@ function CommitScenarioDraftContent({
         fetcher.submit(value, {
           method: 'POST',
           action: getRoute('/ressources/scenarios/:scenarioId/:iterationId/commit', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           }),
           encType: 'application/json',
         });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/create_draft.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/create_draft.tsx
@@ -1,7 +1,7 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { parseFormSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigate } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -41,8 +41,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(draftIteration.id),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(draftIteration.id),
       }),
     );
   } catch (error) {
@@ -89,8 +89,8 @@ const NewDraftButton = ({
     <fetcher.Form
       method="POST"
       action={getRoute('/ressources/scenarios/:scenarioId/:iterationId/create_draft', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       })}
     >
       <HiddenInputs iterationId={iterationId} />
@@ -131,8 +131,8 @@ const ExistingDraftModal = ({
         <fetcher.Form
           method="POST"
           action={getRoute('/ressources/scenarios/:scenarioId/:iterationId/create_draft', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           })}
         >
           <HiddenInputs iterationId={iterationId} />
@@ -150,7 +150,12 @@ const ExistingDraftModal = ({
                   className="flex-1"
                   variant="secondary"
                   onClick={() =>
-                    navigate(location.pathname.replace(fromUUID(iterationId), fromUUID(draftId)))
+                    navigate(
+                      location.pathname.replace(
+                        fromUUIDtoSUUID(iterationId),
+                        fromUUIDtoSUUID(draftId),
+                      ),
+                    )
                   }
                 >
                   {t('scenarios:create_draft.keep_existing_draft')}

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/deactivate.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/deactivate.tsx
@@ -2,7 +2,7 @@ import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -56,8 +56,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirectBack(request, {
       fallback: getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       }),
     });
   } catch (error) {
@@ -127,8 +127,8 @@ function DeactivateScenarioVersionContent({
         fetcher.submit(value, {
           method: 'POST',
           action: getRoute('/ressources/scenarios/:scenarioId/:iterationId/deactivate', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           }),
           encType: 'application/json',
         });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/prepare.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/prepare.tsx
@@ -3,7 +3,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { PreparationServiceOccupied } from '@app-builder/repositories/ScenarioRepository';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -56,8 +56,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirectBack(request, {
       fallback: getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       }),
     });
   } catch (error) {
@@ -159,8 +159,8 @@ function PrepareScenarioVersionContent({
         fetcher.submit(value, {
           method: 'POST',
           action: getRoute('/ressources/scenarios/:scenarioId/:iterationId/prepare', {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           }),
           encType: 'application/json',
         });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/create.tsx
@@ -1,6 +1,6 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -34,9 +34,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/scenarios/:scenarioId/i/:iterationId/rules/:ruleId', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
-        ruleId: fromUUID(rule.id),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
+        ruleId: fromUUIDtoSUUID(rule.id),
       }),
     );
   } catch (error) {
@@ -61,8 +61,8 @@ export function CreateRule({
     <fetcher.Form
       method="POST"
       action={getRoute('/ressources/scenarios/:scenarioId/:iterationId/rules/create', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       })}
     >
       <Button

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/delete.tsx
@@ -1,6 +1,6 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -28,8 +28,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   return redirect(
     getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-      scenarioId: fromUUID(scenarioId),
-      iterationId: fromUUID(iterationId),
+      scenarioId: fromUUIDtoSUUID(scenarioId),
+      iterationId: fromUUIDtoSUUID(iterationId),
     }),
   );
 }
@@ -76,8 +76,8 @@ export function DeleteRule({
                 fetcher.submit(data, {
                   method: 'DELETE',
                   action: getRoute(`/ressources/scenarios/:scenarioId/:iterationId/rules/delete`, {
-                    scenarioId: fromUUID(scenarioId),
-                    iterationId: fromUUID(iterationId),
+                    scenarioId: fromUUIDtoSUUID(scenarioId),
+                    iterationId: fromUUIDtoSUUID(iterationId),
                   }),
                 });
               }}

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/duplicate.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/rules+/duplicate.tsx
@@ -1,6 +1,6 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -36,8 +36,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   return redirect(
     getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-      scenarioId: fromUUID(scenarioId),
-      iterationId: fromUUID(iterationId),
+      scenarioId: fromUUIDtoSUUID(scenarioId),
+      iterationId: fromUUIDtoSUUID(iterationId),
     }),
   );
 }
@@ -85,8 +85,8 @@ export function DuplicateRule({
                   action: getRoute(
                     `/ressources/scenarios/:scenarioId/:iterationId/rules/duplicate`,
                     {
-                      scenarioId: fromUUID(scenarioId),
-                      iterationId: fromUUID(iterationId),
+                      scenarioId: fromUUIDtoSUUID(scenarioId),
+                      iterationId: fromUUIDtoSUUID(iterationId),
                     },
                   ),
                 });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/create.tsx
@@ -2,7 +2,7 @@ import { Nudge } from '@app-builder/components/Nudge';
 import { isAccessible } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import clsx from 'clsx';
@@ -37,8 +37,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/scenarios/:scenarioId/i/:iterationId/sanction', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       }),
     );
   } catch (error) {
@@ -72,8 +72,8 @@ export function CreateSanction({
     <fetcher.Form
       method="POST"
       action={getRoute('/ressources/scenarios/:scenarioId/:iterationId/sanctions/create', {
-        scenarioId: fromUUID(scenarioId),
-        iterationId: fromUUID(iterationId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
+        iterationId: fromUUIDtoSUUID(iterationId),
       })}
     >
       <Button

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/sanctions+/delete.tsx
@@ -1,6 +1,6 @@
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -26,8 +26,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   return redirect(
     getRoute('/scenarios/:scenarioId/i/:iterationId/rules', {
-      scenarioId: fromUUID(scenarioId),
-      iterationId: fromUUID(iterationId),
+      scenarioId: fromUUIDtoSUUID(scenarioId),
+      iterationId: fromUUIDtoSUUID(iterationId),
     }),
   );
 }
@@ -72,8 +72,8 @@ export function DeleteSanction({
                   action: getRoute(
                     `/ressources/scenarios/:scenarioId/:iterationId/sanctions/delete`,
                     {
-                      scenarioId: fromUUID(scenarioId),
-                      iterationId: fromUUID(iterationId),
+                      scenarioId: fromUUIDtoSUUID(scenarioId),
+                      iterationId: fromUUIDtoSUUID(iterationId),
                     },
                   ),
                 })

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/$iterationId+/validate-with-given-trigger-or-rule.tsx
@@ -1,7 +1,7 @@
 import { type AstNode } from '@app-builder/models';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
 import { useCallback } from 'react';
@@ -45,8 +45,8 @@ export function useTriggerValidationFetcher(scenarioId: string, iterationId: str
         action: getRoute(
           '/ressources/scenarios/:scenarioId/:iterationId/validate-with-given-trigger-or-rule',
           {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           },
         ),
       });
@@ -80,8 +80,8 @@ export function useRuleValidationFetcher(scenarioId: string, iterationId: string
         action: getRoute(
           '/ressources/scenarios/:scenarioId/:iterationId/validate-with-given-trigger-or-rule',
           {
-            scenarioId: fromUUID(scenarioId),
-            iterationId: fromUUID(iterationId),
+            scenarioId: fromUUIDtoSUUID(scenarioId),
+            iterationId: fromUUIDtoSUUID(iterationId),
           },
         ),
       });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/$testRunId+/cancel.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/$testRunId+/cancel.tsx
@@ -3,7 +3,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { useCurrentScenario } from '@app-builder/routes/_builder+/scenarios+/$scenarioId+/_layout';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useEffect, useState } from 'react';
@@ -23,7 +23,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     await testRun.cancelTestRun({ testRunId });
     return redirect(
       getRoute('/scenarios/:scenarioId/test-run', {
-        scenarioId: fromUUID(scenarioId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
       }),
     );
   } catch (error) {
@@ -72,8 +72,8 @@ export function CancelTestRun({
           className="flex flex-col gap-6 p-6"
           method="POST"
           action={getRoute('/ressources/scenarios/:scenarioId/testrun/:testRunId/cancel', {
-            scenarioId: fromUUID(currentScenario.id),
-            testRunId: fromUUID(testRunId),
+            scenarioId: fromUUIDtoSUUID(currentScenario.id),
+            testRunId: fromUUIDtoSUUID(testRunId),
           })}
         >
           <ModalV2.Description render={<Callout variant="outlined" />}>

--- a/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/$scenarioId+/testrun+/create.tsx
@@ -11,7 +11,7 @@ import { scenarioObjectDocHref } from '@app-builder/services/documentation-href'
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromParams, fromUUID } from '@app-builder/utils/short-uuid';
+import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -66,7 +66,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/scenarios/:scenarioId/test-run', {
-        scenarioId: fromUUID(scenarioId),
+        scenarioId: fromUUIDtoSUUID(scenarioId),
       }),
     );
   } catch (error) {
@@ -171,7 +171,7 @@ function CreateTestRunToContent({
         fetcher.submit(value, {
           method: 'POST',
           action: getRoute('/ressources/scenarios/:scenarioId/testrun/create', {
-            scenarioId: fromUUID(currentScenario.id),
+            scenarioId: fromUUIDtoSUUID(currentScenario.id),
           }),
           encType: 'application/json',
         });

--- a/packages/app-builder/src/routes/ressources+/scenarios+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/create.tsx
@@ -8,7 +8,7 @@ import { scenarioObjectDocHref } from '@app-builder/services/documentation-href'
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import * as Ariakit from '@ariakit/react';
 import { type ActionFunctionArgs, json, type LoaderFunctionArgs, redirect } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
@@ -75,8 +75,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/scenarios/:scenarioId/i/:iterationId', {
-        scenarioId: fromUUID(createdScenario.id),
-        iterationId: fromUUID(scenarioIteration.id),
+        scenarioId: fromUUIDtoSUUID(createdScenario.id),
+        iterationId: fromUUIDtoSUUID(scenarioIteration.id),
       }),
     );
   } catch (error) {

--- a/packages/app-builder/src/routes/ressources+/scenarios+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/scenarios+/update.tsx
@@ -5,7 +5,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -56,7 +56,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     return redirectBack(request, {
       fallback: getRoute('/scenarios/:scenarioId', {
-        scenarioId: fromUUID(data.scenarioId),
+        scenarioId: fromUUIDtoSUUID(data.scenarioId),
       }),
     });
   } catch (error) {

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/create.tsx
@@ -5,7 +5,7 @@ import { setToastMessage } from '@app-builder/components/MarbleToaster';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -63,7 +63,7 @@ export async function action({ request }: ActionFunctionArgs) {
     if (data.redirectRoute)
       return redirect(
         getRoute(data.redirectRoute, {
-          inboxId: fromUUID(createdInbox.id),
+          inboxId: fromUUIDtoSUUID(createdInbox.id),
         }),
       );
 

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.create.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.create.tsx
@@ -8,7 +8,7 @@ import { getInboxUserRoles, isAccessible } from '@app-builder/services/feature-a
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -68,7 +68,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/settings/inboxes/:inboxId', {
-        inboxId: fromUUID(data.inboxId),
+        inboxId: fromUUIDtoSUUID(data.inboxId),
       }),
     );
   } catch (error) {

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.delete.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.delete.tsx
@@ -2,7 +2,7 @@ import { type InboxUser } from '@app-builder/models/inbox';
 import { initServerServices } from '@app-builder/services/init.server';
 import { parseForm } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
 import { Form, useNavigation } from '@remix-run/react';
 import { type Namespace } from 'i18next';
@@ -32,7 +32,7 @@ export async function action({ request }: ActionFunctionArgs) {
   await inbox.deleteInboxUser(formData.inboxUserId);
   return redirect(
     getRoute('/settings/inboxes/:inboxId', {
-      inboxId: fromUUID(formData.inboxId),
+      inboxId: fromUUIDtoSUUID(formData.inboxId),
     }),
   );
 }

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/inbox-users.update.tsx
@@ -7,7 +7,7 @@ import { getInboxUserRoles, isAccessible } from '@app-builder/services/feature-a
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -68,7 +68,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     return redirect(
       getRoute('/settings/inboxes/:inboxId', {
-        inboxId: fromUUID(data.inboxId),
+        inboxId: fromUUIDtoSUUID(data.inboxId),
       }),
     );
   } catch (error) {

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/update.tsx
@@ -6,7 +6,7 @@ import { type Inbox } from '@app-builder/models/inbox';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, json, redirect } from '@remix-run/node';
 import { useFetcher, useNavigation } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
@@ -66,7 +66,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return redirect(
       safeRedirect(
         getRoute(data.redirectRoute, {
-          inboxId: fromUUID(updatedInbox.id),
+          inboxId: fromUUIDtoSUUID(updatedInbox.id),
         }),
         getRoute('/ressources/auth/logout'),
       ),

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/received.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/received.tsx
@@ -1,7 +1,7 @@
 import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { json, Link, useLoaderData } from '@remix-run/react';
 
@@ -26,7 +26,7 @@ export default function ReceivedAlertsPage() {
       rowLink={(alertId) => (
         <Link
           to={getRoute('/transfercheck/alerts/received/:alertId', {
-            alertId: fromUUID(alertId),
+            alertId: fromUUIDtoSUUID(alertId),
           })}
         />
       )}

--- a/packages/app-builder/src/routes/transfercheck+/alerts+/sent.tsx
+++ b/packages/app-builder/src/routes/transfercheck+/alerts+/sent.tsx
@@ -1,7 +1,7 @@
 import { AlertsList } from '@app-builder/components/TransferAlerts/AlertsList';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
-import { fromUUID } from '@app-builder/utils/short-uuid';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { json, Link, useLoaderData } from '@remix-run/react';
 
@@ -26,7 +26,7 @@ export default function SentAlertsPage() {
       rowLink={(alertId) => (
         <Link
           to={getRoute('/transfercheck/alerts/sent/:alertId', {
-            alertId: fromUUID(alertId),
+            alertId: fromUUIDtoSUUID(alertId),
           })}
         />
       )}

--- a/packages/app-builder/src/utils/http/handle-errors.ts
+++ b/packages/app-builder/src/utils/http/handle-errors.ts
@@ -2,7 +2,7 @@ import { redirect } from '@remix-run/node';
 import { type ZodError, type ZodIssueOptionalMessage } from 'zod';
 
 import { isRawUUIDIssue } from '../schema/shortUUIDSchema';
-import { fromUUID } from '../short-uuid';
+import { fromUUIDtoSUUID } from '../short-uuid';
 import { badRequest } from './http-responses';
 
 /**
@@ -17,7 +17,7 @@ export function handleParseParamError<Input>(request: Request, error: ZodError<I
     const redirectURL = (issues as ZodIssueOptionalMessage[])
       .filter(isRawUUIDIssue)
       .reduce((acc, { params: { value } }) => {
-        return acc.replace(value, fromUUID(value));
+        return acc.replace(value, fromUUIDtoSUUID(value));
       }, request.url);
     return redirect(redirectURL);
   }

--- a/packages/app-builder/src/utils/schema/shortUUIDSchema.ts
+++ b/packages/app-builder/src/utils/schema/shortUUIDSchema.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { toUUID } from '../short-uuid';
+import { fromSUUIDtoUUID } from '../short-uuid';
 
 export interface RawUUIDIssue extends z.ZodCustomIssue {
   params: {
@@ -19,7 +19,7 @@ export function isRawUUIDIssue(issue: z.ZodIssueOptionalMessage): issue is RawUU
 
 export const shortUUIDSchema = z.string().transform((value, ctx) => {
   try {
-    return toUUID(value);
+    return fromSUUIDtoUUID(value);
   } catch (e) {
     const parsedValue = z.string().uuid().safeParse(value);
     if (parsedValue.success) {

--- a/packages/app-builder/src/utils/short-uuid.ts
+++ b/packages/app-builder/src/utils/short-uuid.ts
@@ -1,23 +1,23 @@
 /**
  * This module is used to format URL friendly (=shorter) UUID
- * - fromUUID: convert UUID to be used as URL segment
- * - toUUID: convert URL segment id to UUID
+ * - fromUUIDtoSUUID: convert UUID to be used as URL segment
+ * - fromSUUIDtoUUID: convert URL segment id to UUID
  */
 
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { useParams } from '@remix-run/react';
-import shortUUID from 'short-uuid';
+import shortUUID, { type UUID } from 'short-uuid';
 import invariant from 'tiny-invariant';
 
 const translator = shortUUID();
 
-export const toUUID = (val: string) => translator.toUUID(val);
-export const fromUUID = (val: string) => translator.fromUUID(val);
+export const fromSUUIDtoUUID = (val: string) => translator.toUUID(val);
+export const fromUUIDtoSUUID = (val: string) => translator.fromUUID(val);
 
-export const fromParams = (params: LoaderFunctionArgs['params'], name: string) => {
+export const fromParams = (params: LoaderFunctionArgs['params'], name: string): UUID => {
   const value = params[name];
   invariant(value, `${name} is required`);
-  return toUUID(value);
+  return fromSUUIDtoUUID(value);
 };
 
 export const useParam = (name: string) => {


### PR DESCRIPTION
- Updated the custom list edit page to accept both UUID and shortUUID in the URL parameter.
- Refactored the UUID-to-shortUUID conversion function to improve code clarity and maintainability.
- Updated the custom list breadcrumb to use shortUUID for consistency in links.