### PR TITLE
fix(custom-lists): use shortUUID in breadcrumb

### DIFF
--- a/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
+++ b/packages/app-builder/src/routes/_builder+/lists+/$listId.tsx
@@ -24,6 +24,7 @@ import { handleParseParamError } from '@app-builder/utils/http/handle-errors';
 import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
 import { parseIdParamSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData, useRevalidator, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
@@ -74,7 +75,10 @@ export const handle = {
       const { customList } = useLoaderData<typeof loader>();
 
       return (
-        <BreadCrumbLink to={getRoute('/lists/:listId', { listId: customList.id })} isLast={isLast}>
+        <BreadCrumbLink
+          to={getRoute('/lists/:listId', { listId: fromUUIDtoSUUID(customList.id) })}
+          isLast={isLast}
+        >
           {customList.name}
         </BreadCrumbLink>
       );


### PR DESCRIPTION
This builds on #777.
After functional testing of the new params schema introduced there, we can now update the custom lists breadcrumb to use short UUIDs for consistency across pages.