### PR TITLE
fix: value in operand menu made multiple hover due to duplicates MAR-897

### DIFF
--- a/packages/app-builder/src/components/AstBuilder/edition/OperandMenu/DiscoveryList.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/OperandMenu/DiscoveryList.tsx
@@ -67,6 +67,7 @@ export function DiscoveryList({ onSelect }: SmartMenuListProps) {
               return (
                 <SubMenu
                   key={_path}
+                  value={_path}
                   onSelect={onSelect}
                   trigger={<SubMenuFieldTrigger {...{ label, depth: path.length, options }} />}
                   options={options}
@@ -158,17 +159,18 @@ function MenuTitle({ operandType, count, className }: MenuTitleProps) {
 }
 
 type SubMenuProps = {
+  value?: string;
   trigger: ReactNode;
   options: EnrichedMenuOption[];
   onSelect: (astNode: AstNode) => void;
 };
-function SubMenu({ trigger, options, onSelect }: SubMenuProps) {
+function SubMenu({ value, trigger, options, onSelect }: SubMenuProps) {
   const { t } = useTranslation(['common', 'scenarios']);
   const language = useFormatLanguage();
   const customLists = AstBuilderDataSharpFactory.useSharp().value.data.customLists;
 
   return (
-    <MenuCommand.SubMenu forceMount trigger={trigger} className="w-96">
+    <MenuCommand.SubMenu value={value} forceMount trigger={trigger} className="w-96">
       <MenuCommand.List>
         <MenuCommand.Group>
           {options.map((option) => {

--- a/packages/ui-design-system/src/MenuCommand/MenuCommand.tsx
+++ b/packages/ui-design-system/src/MenuCommand/MenuCommand.tsx
@@ -90,17 +90,19 @@ function Root({ hover = false, ...props }: RootProps) {
 }
 
 type SubMenuProps = Omit<RootProps, 'open' | 'onOpenChange'> & {
+  value?: string;
   className?: string;
   trigger: React.ReactNode;
   forceMount?: boolean;
 };
-function SubMenu({ children, trigger, forceMount, className, ...props }: SubMenuProps) {
+function SubMenu({ value, children, trigger, forceMount, className, ...props }: SubMenuProps) {
   const [open, setOpen] = React.useState(false);
   return (
     <Command.Group forceMount={forceMount}>
       <Root {...props} hover open={open} onOpenChange={setOpen}>
         <Trigger>
           <Item
+            value={value}
             className="group/menu-item grid grid-cols-[1fr_20px]"
             onSelect={() => setOpen(true)}
           >


### PR DESCRIPTION
The MenuCommand.Item take its innerText as value, due to the same "content" being possible now there were possibility of duplicate which made the menu highlight multiple items at the same time.