### PR TITLE
Add data model table options specs + fix case event specs

### DIFF
--- a/packages/app-builder/src/components/Cases/Events/SarCreated.tsx
+++ b/packages/app-builder/src/components/Cases/Events/SarCreated.tsx
@@ -25,11 +25,7 @@ export const SarCreatedDetail = ({ event }: { event: SarCreatedEvent }) => {
       <span className="text-grey-00 inline-flex h-full items-center whitespace-pre text-xs">
         <Trans
           t={t}
-          i18nKey={
-            event.status === 'pending'
-              ? 'case_detail.history.event_detail.sar_requested'
-              : 'case_detail.history.event_detail.sar_reported'
-          }
+          i18nKey="case_detail.history.event_detail.sar_requested"
           components={{
             Actor: <span className="font-bold capitalize" />,
           }}

--- a/packages/app-builder/src/models/cases.ts
+++ b/packages/app-builder/src/models/cases.ts
@@ -207,7 +207,6 @@ export interface CaseAssignedEvent extends CaseEventBase<'case_assigned'> {
 export interface SarCreatedEvent extends CaseEventBase<'sar_created'> {
   userId?: string;
   sarId: string;
-  status: string;
 }
 
 export interface SarDeletedEvent extends CaseEventBase<'sar_deleted'> {
@@ -347,7 +346,6 @@ export function adaptCaseEventDto(caseEventDto: CaseEventDto): CaseEvent {
       eventType: dto.event_type,
       userId: dto.user_id,
       sarId: dto.resource_id,
-      status: dto.new_value,
     }))
     .with({ event_type: 'sar_deleted' }, (dto) => ({
       ...baseEvent,

--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -215,6 +215,8 @@ paths:
     $ref: ./marblecore-api/data-model.yml#/~1data-model~1pivots
   /data-model/tables/{tableId}/navigation_options:
     $ref: ./marblecore-api/data-model.yml#/~1data-model~1tables~1{tableId}~1navigation_options
+  /data-model/tables/{tableId}/options:
+    $ref: ./marblecore-api/data-model.yml#/~1data-model~1tables~1{tableId}~1options
 
   # MISC
 

--- a/packages/marble-api/openapis/marblecore-api/_schemas.yml
+++ b/packages/marble-api/openapis/marblecore-api/_schemas.yml
@@ -293,6 +293,10 @@ NavigationOptionDto:
   $ref: data-model.yml#/components/schemas/NavigationOptionDto
 CreateNavigationOptionDto:
   $ref: data-model.yml#/components/schemas/CreateNavigationOptionDto
+DataModelTableOptionsDto:
+  $ref: data-model.yml#/components/schemas/DataModelTableOptionsDto
+SetDataModelTableOptionsBodyDto:
+  $ref: data-model.yml#/components/schemas/SetDataModelTableOptionsBodyDto
 
 # MISC
 

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -1056,6 +1056,7 @@ components:
             - new_value
           properties:
             new_value:
+              description: ID of the user the case was assigned to
               type: string
               format: uuid
             user_id:
@@ -1068,17 +1069,15 @@ components:
           required:
             - resource_type
             - resource_id
-            - new_value
           properties:
-            new_value:
-              type: string
-              format: uuid
             user_id:
               type: string
               format: uuid
             resource_type:
+              description: Resource being created, should be `sar`
               type: string
             resource_id:
+              description: ID of the suspicious activity report being created
               type: string
               format: uuid
     SarDeletedEventDto:
@@ -1088,17 +1087,15 @@ components:
           required:
             - resource_type
             - resource_id
-            - new_value
           properties:
-            new_value:
-              type: string
-              format: uuid
             user_id:
               type: string
               format: uuid
             resource_type:
+              description: Resource being deleted, should be `sar`
               type: string
             resource_id:
+              description: ID of the suspicious activity report being deleted
               type: string
               format: uuid
     SarStatusChangedEventDto:
@@ -1111,14 +1108,16 @@ components:
             - new_value
           properties:
             new_value:
+              description: New status for the suspicious activity report
               type: string
-              format: uuid
             user_id:
               type: string
               format: uuid
             resource_type:
+              description: Resource being modified, should be `sar`
               type: string
             resource_id:
+              description: ID of the suspicious activity report being modified
               type: string
               format: uuid
     SarFileUploadedEventDto:
@@ -1131,14 +1130,16 @@ components:
             - new_value
           properties:
             new_value:
+              description: Name of the file that was uploaded
               type: string
-              format: uuid
             user_id:
               type: string
               format: uuid
             resource_type:
+              description: Resource being modified, should be `sar`
               type: string
             resource_id:
+              description: ID of the suspicious activity report the file was uploaded to
               type: string
               format: uuid
     RuleSnoozeCreatedDto:

--- a/packages/marble-api/openapis/marblecore-api/data-model.yml
+++ b/packages/marble-api/openapis/marblecore-api/data-model.yml
@@ -144,6 +144,66 @@
         $ref: 'components.yml#/responses/403'
       '404':
         $ref: 'components.yml#/responses/404'
+/data-model/tables/{tableId}/options:
+  get:
+    tags:
+      - Data Model
+    summary: Get display options for data model tables
+    operationId: getDataModelTableOptions
+    parameters:
+      - name: tableId
+        description: ID of the source table for the display options
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: Display options for the provided table
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataModelTableOptionsDto'
+      '401':
+        $ref: 'components.yml#/responses/401'
+      '403':
+        $ref: 'components.yml#/responses/403'
+      '404':
+        $ref: 'components.yml#/responses/404'
+  post:
+    tags:
+      - Data Model
+    summary: Set display options for data model tables
+    operationId: setDataModelTableOptions
+    parameters:
+      - name: tableId
+        description: ID of the source table for the display options
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    requestBody:
+      description: Display options for the provided table
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SetDataModelTableOptionsBodyDto'
+      required: true
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: Empty response body
+      '401':
+        $ref: 'components.yml#/responses/401'
+      '403':
+        $ref: 'components.yml#/responses/403'
+      '404':
+        $ref: 'components.yml#/responses/404'
 /data-model/fields/{fieldId}:
   patch:
     tags:
@@ -620,3 +680,21 @@ components:
         ordering_field_id:
           type: string
           format: uuid
+    DataModelTableOptionsDto:
+      type: object
+      properties:
+        displayed_fields:
+          description: List of ordered field IDs to display when navigating the table
+          type: array
+          items:
+            type: string
+            format: uuid
+    SetDataModelTableOptionsBodyDto:
+      type: object
+      properties:
+        displayed_fields:
+          description: List of ordered field IDs to display when navigating the table
+          type: array
+          items:
+            type: string
+            format: uuid

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -262,39 +262,48 @@ export type CaseUnsnoozedDto = {
 export type CaseAssignedEventDto = {
     event_type: "case_assigned";
 } & CaseEventDtoBase & {
+    /** ID of the user the case was assigned to */
     new_value: string;
     user_id?: string;
 };
 export type SarCreatedEventDto = {
     event_type: "sar_created";
 } & CaseEventDtoBase & {
-    new_value: string;
     user_id?: string;
+    /** Resource being created, should be `sar` */
     resource_type: string;
+    /** ID of the suspicious activity report being created */
     resource_id: string;
 };
 export type SarDeletedEventDto = {
     event_type: "sar_deleted";
 } & CaseEventDtoBase & {
-    new_value: string;
     user_id?: string;
+    /** Resource being deleted, should be `sar` */
     resource_type: string;
+    /** ID of the suspicious activity report being deleted */
     resource_id: string;
 };
 export type SarStatusChangedEventDto = {
     event_type: "sar_status_changed";
 } & CaseEventDtoBase & {
+    /** New status for the suspicious activity report */
     new_value: string;
     user_id?: string;
+    /** Resource being modified, should be `sar` */
     resource_type: string;
+    /** ID of the suspicious activity report being modified */
     resource_id: string;
 };
 export type SarFileUploadedEventDto = {
     event_type: "sar_file_uploaded";
 } & CaseEventDtoBase & {
+    /** Name of the file that was uploaded */
     new_value: string;
     user_id?: string;
+    /** Resource being modified, should be `sar` */
     resource_type: string;
+    /** ID of the suspicious activity report the file was uploaded to */
     resource_id: string;
 };
 export type CaseEventDto = CaseCreatedEventDto | CaseStatusUpdatedEventDto | CaseOutcomeUpdatedEventDto | DecisionAddedEventDto | CommentAddedEventDto | NameUpdatedEventDto | CaseTagsUpdatedEventDto | FileAddedEventDto | InboxChangedEventDto | RuleSnoozeCreatedDto | DecisionReviewedEventDto | CaseSnoozedDto | CaseUnsnoozedDto | CaseAssignedEventDto | SarCreatedEventDto | SarDeletedEventDto | SarStatusChangedEventDto | SarFileUploadedEventDto;
@@ -875,6 +884,14 @@ export type CreateNavigationOptionDto = {
     target_table_id?: string;
     filter_field_id?: string;
     ordering_field_id?: string;
+};
+export type DataModelTableOptionsDto = {
+    /** List of ordered field IDs to display when navigating the table */
+    displayed_fields?: string[];
+};
+export type SetDataModelTableOptionsBodyDto = {
+    /** List of ordered field IDs to display when navigating the table */
+    displayed_fields?: string[];
 };
 export type AnalyticsDto = {
     embedding_type: "global_dashboard" | "unknown_embedding_type";
@@ -2956,6 +2973,47 @@ export function postDataModelTableNavigationOption(tableId: string, createNaviga
         ...opts,
         method: "POST",
         body: createNavigationOptionDto
+    })));
+}
+/**
+ * Get display options for data model tables
+ */
+export function getDataModelTableOptions(tableId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: DataModelTableOptionsDto;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    }>(`/data-model/tables/${encodeURIComponent(tableId)}/options`, {
+        ...opts
+    }));
+}
+/**
+ * Set display options for data model tables
+ */
+export function setDataModelTableOptions(tableId: string, setDataModelTableOptionsBodyDto: SetDataModelTableOptionsBodyDto, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    }>(`/data-model/tables/${encodeURIComponent(tableId)}/options`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: setDataModelTableOptionsBodyDto
     })));
 }
 /**


### PR DESCRIPTION
This PR contains two changes:

* Fix new case events OpenAPI specs to remove extra constraint and fields that were incorrectly set.
* Add specs for new data model table display options endpoints.