### PR TITLE
feat(aggregation filters): disabling fuzzy match filter temporarily

### DIFF
--- a/packages/app-builder/src/components/AstBuilder/edition/EditModal/modals/Aggregation/EditFilters.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditModal/modals/Aggregation/EditFilters.tsx
@@ -136,7 +136,7 @@ export function EditFilters({ aggregatedField, dataModel }: EditFiltersProps) {
                       <span>{t('scenarios:edit_aggregation.filter_operator_label')}</span>
                       <OperatorSelect
                         isFilter
-                        options={aggregationFilterOperators}
+                        options={aggregationFilterOperators.filter((op) => op !== 'FuzzyMatch')}
                         operator={filter.namedChildren.operator.constant}
                         onOperatorChange={(operator) => {
                           nodeSharp.update(() => {


### PR DESCRIPTION
Temporary workaround: This PR removes the fuzzy match filter from the selector UI to avoid issues caused by missing or broken database functions. It will be reintroduced once the DB-side implementation is fixed.