### PR TITLE
fix: fix status tag on case history wrapping on two lines

### DIFF
--- a/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotsPanelContent.tsx
+++ b/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotsPanelContent.tsx
@@ -111,7 +111,7 @@ function RelatedCases({
 
       return (
         <DataCard borderless title={t('cases:case_detail.pivot_panel.case_history')}>
-          <div className="grid w-full grid-cols-[1fr_auto_96px]">
+          <div className="grid w-full grid-cols-[1fr_auto_auto]">
             {cases.map((caseObj, idx) => {
               const isLast = idx === cases.length - 1;
 


### PR DESCRIPTION
Before:
<img width="504" alt="bug_history_cases" src="https://github.com/user-attachments/assets/d51b2f9f-f82e-4fc4-b1a4-c473612e0645" />

After:
<img width="507" alt="image" src="https://github.com/user-attachments/assets/36c71e08-491e-47b1-a12c-c91d83474739" />
