### PR TITLE
fix: fix color dropdown height on tag creation modal

### DIFF
--- a/packages/app-builder/src/components/Tags/ColorSelect.tsx
+++ b/packages/app-builder/src/components/Tags/ColorSelect.tsx
@@ -16,7 +16,7 @@ export const ColorSelect = ({
   return (
     <MenuCommand.Menu open={open} onOpenChange={setOpen}>
       <MenuCommand.Trigger>
-        <Button variant="secondary" className="h-full gap-4">
+        <Button variant="secondary" className="h-10 gap-4">
           <ColorPreview color={value} />
           <MenuCommand.Arrow />
         </Button>


### PR DESCRIPTION
Bug:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/bd339f3b-dc8c-4818-9bc6-bca7566c334c" />
