### PR TITLE
fix(case-manager): Improve case escalation check

### DIFF
--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -154,5 +154,8 @@
   "case_detail.history.event_type.sar_status_changed": "تغيرت حالة SAR",
   "case.escalated": "تصاعدت القضية بنجاح",
   "case.assignedTo": "مُسند إلى",
-  "case_detail.assign-to-me-button.label": "تعيين لي"
+  "case_detail.assign-to-me-button.label": "تعيين لي",
+  "case.escalate-button.hint": "تصعيد الحالة إلى {{inboxName}}.",
+  "case.escalate-button.forbidden.hint": "لا توجد علبة وارد للتصعيد مُعينة. يرجى التواصل مع المسؤول.",
+  "case.escalate-button.forbidden.hint.admin": "لم يتم تعيين علبة وارد للتصعيد."
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -154,5 +154,8 @@
   "unsnooze.title": "Unsnooze",
   "include_snoozed": "Include snoozed",
   "case.assignedTo": "Assigned",
-  "case_detail.assign-to-me-button.label": "Assign to me"
+  "case_detail.assign-to-me-button.label": "Assign to me",
+  "case.escalate-button.hint": "Escalate the case to {{inboxName}}.",
+  "case.escalate-button.forbidden.hint": "There is no escalation inbox set. Please contact your administrator.",
+  "case.escalate-button.forbidden.hint.admin": "There is no escalation inbox set."
 }

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -154,5 +154,8 @@
   "case_detail.history.event_type.sar_status_changed": "SAR mis à jour",
   "case.escalated": "Case a réussi à intensifier",
   "case.assignedTo": "Assigné",
-  "case_detail.assign-to-me-button.label": "M'assigner"
+  "case_detail.assign-to-me-button.label": "M'assigner",
+  "case.escalate-button.hint": "Escalader le cas vers {{inboxName}}.",
+  "case.escalate-button.forbidden.hint": "Aucune boîte de réception d’escalade n’est définie. Veuillez contacter votre administrateur.",
+  "case.escalate-button.forbidden.hint.admin": "Aucune boîte de réception d’escalade n’est définie."
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
@@ -15,7 +15,7 @@ import { badRequest } from '@app-builder/utils/http/http-responses';
 import { parseIdParamSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
-import { defer, type LoaderFunctionArgs, redirect, type SerializeFrom } from '@remix-run/node';
+import { type LoaderFunctionArgs, redirect, type SerializeFrom } from '@remix-run/node';
 import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
 import { type Namespace } from 'i18next';
@@ -54,7 +54,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       cases.getCase({ caseId }),
       cases.getNextUnassignedCaseId({ caseId }),
       cases.listSuspiciousActivityReports({ caseId }),
-      inbox.listInboxes(),
+      inbox.listInboxes().then((inboxes) => {
+        console.log(inboxes);
+        return inboxes;
+      }),
       cases.listPivotObjects({ caseId }),
       dataModelRepository.getDataModel(),
       dataModelRepository.listPivots({}),
@@ -96,7 +99,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     return redirect(getRoute('/cases/inboxes'));
   }
 
-  return defer({
+  return {
     case: currentCase,
     pivotObjects,
     dataModel,
@@ -108,7 +111,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     pivots,
     customLists,
     decisionsPromise,
-  });
+  };
 };
 
 export const handle = {

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
@@ -16,7 +16,13 @@ import { parseIdParamSafe } from '@app-builder/utils/input-validation';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs, redirect, type SerializeFrom } from '@remix-run/node';
-import { isRouteErrorResponse, useLoaderData, useNavigate, useRouteError } from '@remix-run/react';
+import {
+  defer,
+  isRouteErrorResponse,
+  useLoaderData,
+  useNavigate,
+  useRouteError,
+} from '@remix-run/react';
 import { captureRemixErrorBoundaryError } from '@sentry/remix';
 import { type Namespace } from 'i18next';
 import { pick } from 'radash';
@@ -54,10 +60,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       cases.getCase({ caseId }),
       cases.getNextUnassignedCaseId({ caseId }),
       cases.listSuspiciousActivityReports({ caseId }),
-      inbox.listInboxes().then((inboxes) => {
-        console.log(inboxes);
-        return inboxes;
-      }),
+      inbox.listInboxes(),
       cases.listPivotObjects({ caseId }),
       dataModelRepository.getDataModel(),
       dataModelRepository.listPivots({}),
@@ -99,7 +102,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     return redirect(getRoute('/cases/inboxes'));
   }
 
-  return {
+  return defer({
     case: currentCase,
     pivotObjects,
     dataModel,
@@ -111,7 +114,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     pivots,
     customLists,
     decisionsPromise,
-  };
+  });
 };
 
 export const handle = {

--- a/packages/app-builder/src/routes/ressources+/cases+/escalate-case.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/escalate-case.tsx
@@ -1,14 +1,16 @@
 import { Callout, casesI18n } from '@app-builder/components';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
+import { isAdmin } from '@app-builder/models';
+import { type loader } from '@app-builder/routes/_builder+/cases+/$caseId+/_index';
 import { initServerServices } from '@app-builder/services/init.server';
 import { handleSubmit } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
-import { useFetcher } from '@remix-run/react';
+import { Link, useFetcher, useLoaderData } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
 import { useTranslation } from 'react-i18next';
-import { Button, Modal } from 'ui-design-system';
+import { Button, Modal, Tooltip } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { z } from 'zod';
 
@@ -71,6 +73,14 @@ export const EscalateCase = ({ id, inboxId }: { id: string; inboxId: string }) =
   const { t } = useTranslation(casesI18n);
   const fetcher = useFetcher<typeof action>();
 
+  const { inboxes, currentUser } = useLoaderData<typeof loader>();
+
+  const inboxDetail = inboxes.find((inbox) => inbox.id === inboxId)!;
+  const targetInbox = inboxes.find((inbox) => inbox.id === inboxDetail.escalationInboxId);
+  const canEscalate = inboxDetail.escalationInboxId !== undefined;
+
+  const isAdminUser = isAdmin(currentUser);
+
   const form = useForm({
     onSubmit: async ({ value }) => {
       fetcher.submit(value, {
@@ -90,10 +100,35 @@ export const EscalateCase = ({ id, inboxId }: { id: string; inboxId: string }) =
   return (
     <Modal.Root>
       <Modal.Trigger asChild>
-        <Button variant="secondary" size="medium" type="button">
-          <Icon icon="arrow-up" className="size-5" aria-hidden />
-          Escalate
-        </Button>
+        <Tooltip.Default
+          open={true}
+          content={
+            <div className="z-20 pb-2">
+              <div>
+                {canEscalate
+                  ? t('cases:case.escalate-button.hint', { inboxName: targetInbox?.name })
+                  : isAdminUser
+                    ? t('cases:case.escalate-button.forbidden.hint.admin')
+                    : t('cases:case.escalate-button.forbidden.hint')}
+              </div>
+              {!canEscalate && isAdminUser ? (
+                <Link
+                  to={getRoute('/settings/inboxes/:inboxId', {
+                    inboxId: fromUUIDtoSUUID(inboxId),
+                  })}
+                  className="hover:text-purple-60 focus:text-purple-60 text-purple-65 font-semibold hover:underline focus:underline"
+                >
+                  Inbox settings
+                </Link>
+              ) : null}
+            </div>
+          }
+        >
+          <Button variant="secondary" size="medium" type="button" disabled={!canEscalate}>
+            <Icon icon="arrow-up" className="size-5" aria-hidden />
+            Escalate
+          </Button>
+        </Tooltip.Default>
       </Modal.Trigger>
       <Modal.Content>
         <Modal.Title>Escalate Case</Modal.Title>

--- a/packages/app-builder/src/routes/ressources+/cases+/escalate-case.tsx
+++ b/packages/app-builder/src/routes/ressources+/cases+/escalate-case.tsx
@@ -101,9 +101,8 @@ export const EscalateCase = ({ id, inboxId }: { id: string; inboxId: string }) =
     <Modal.Root>
       <Modal.Trigger asChild>
         <Tooltip.Default
-          open={true}
           content={
-            <div className="z-20 pb-2">
+            <div className="pb-2">
               <div>
                 {canEscalate
                   ? t('cases:case.escalate-button.hint', { inboxName: targetInbox?.name })

--- a/packages/ui-design-system/src/Tooltip/Tooltip.tsx
+++ b/packages/ui-design-system/src/Tooltip/Tooltip.tsx
@@ -25,7 +25,7 @@ export function DefaultTooltip({
     <TooltipPrimitive.Root open={open} defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
       <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal>
-        <TooltipPrimitive.Content side="top" align="center" className="drop-shadow" {...props}>
+        <TooltipPrimitive.Content side="top" align="center" className="z-50 drop-shadow" {...props}>
           <div className={cn('bg-grey-100 max-h-40 overflow-y-auto rounded p-2', className)}>
             {content}
           </div>


### PR DESCRIPTION
- Disable the case escalation button when the current inbox does not have an escalation inbox configured.

- Display a tooltip when the button is disabled.


------------------------------------------------------
**1. For non admin users**
<img width="558" alt="image" src="https://github.com/user-attachments/assets/795b4d95-6c46-4f6f-a6c5-47ba8d098600" />

------------------------------------------------------

**2. For admins (with a link to the current inbox settings page) :**
<img width="286" alt="image" src="https://github.com/user-attachments/assets/0d907a5a-905b-46d0-87ed-8c394e95d306" />

------------------------------------------------------

**3. When the button is active :**
<img width="347" alt="image" src="https://github.com/user-attachments/assets/cc915eb1-b2b2-407f-92bf-bbf7d1690e52" />
