### PR TITLE
fix: replace field name by table name in link section of data model #803

### DIFF
--- a/packages/app-builder/src/components/Data/TableDetails.tsx
+++ b/packages/app-builder/src/components/Data/TableDetails.tsx
@@ -68,7 +68,7 @@ export function TableDetails({ tableModel, dataModel }: TableDetailsProps) {
     () =>
       tableModel.linksToSingle.map((link) => ({
         foreignKey: link.childFieldName,
-        parentTable: link.parentFieldName,
+        parentTable: link.parentTableName,
         parentFieldName: link.parentFieldName,
         exampleUsage: `${tableModel.name}.${link.name}.${link.parentFieldName} = ${tableModel.name}.${link.childFieldName}`,
       })),


### PR DESCRIPTION
- parent field name was referenced instead of the related table