### PR TITLE
feat(cases-manager): Add a all-my-cases filtered inbox view

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseRightPanel.tsx
+++ b/packages/app-builder/src/components/Cases/CaseRightPanel.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { casesI18n } from './cases-i18n';
 
 type Data = {
-  inboxId: string;
+  inboxId: string | null;
 };
 
 type State =

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -158,5 +158,6 @@
   "case.escalate-button.hint": "تصعيد الحالة إلى {{inboxName}}.",
   "case.escalate-button.forbidden.hint": "لا توجد علبة وارد للتصعيد مُعينة. يرجى التواصل مع المسؤول.",
   "case.escalate-button.forbidden.hint.admin": "لم يتم تعيين علبة وارد للتصعيد.",
-  "case_detail.add_a_tag.empty": "لا توجد علامة"
+  "case_detail.add_a_tag.empty": "لا توجد علامة",
+  "inbox.assigned_to_me": "جميع قضاياي"
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -158,5 +158,6 @@
   "case.escalate-button.hint": "Escalate the case to {{inboxName}}.",
   "case.escalate-button.forbidden.hint": "There is no escalation inbox set. Please contact your administrator.",
   "case.escalate-button.forbidden.hint.admin": "There is no escalation inbox set.",
-  "case_detail.add_a_tag.empty": "There's no tag"
+  "case_detail.add_a_tag.empty": "There's no tag",
+  "inbox.assigned_to_me": "All my cases"
 }

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -158,5 +158,6 @@
   "case.escalate-button.hint": "Escalader le cas vers {{inboxName}}.",
   "case.escalate-button.forbidden.hint": "Aucune boîte de réception d’escalade n’est définie. Veuillez contacter votre administrateur.",
   "case.escalate-button.forbidden.hint.admin": "Aucune boîte de réception d’escalade n’est définie.",
-  "case_detail.add_a_tag.empty": "Aucun label trouvé"
+  "case_detail.add_a_tag.empty": "Aucun label trouvé",
+  "inbox.assigned_to_me": "Tous mes cas"
 }

--- a/packages/app-builder/src/repositories/CaseRepository.ts
+++ b/packages/app-builder/src/repositories/CaseRepository.ts
@@ -41,6 +41,7 @@ export type CaseFilters = {
         fromNow: string;
       };
   inboxIds?: string[];
+  assigneeId?: string;
 };
 
 export type CaseFiltersWithPagination = FiltersWithPagination<CaseFilters>;

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -268,14 +268,12 @@ export default function Cases() {
                   <CasesFiltersMenu filterNames={casesFilterNames}>
                     <FiltersButton />
                   </CasesFiltersMenu>
-                  {inboxId ? (
-                    <CaseRightPanel.Trigger asChild data={{ inboxId }}>
-                      <Button>
-                        <Icon icon="plus" className="size-5" />
-                        {t('cases:case.new_case')}
-                      </Button>
-                    </CaseRightPanel.Trigger>
-                  ) : null}
+                  <CaseRightPanel.Trigger asChild data={{ inboxId }}>
+                    <Button>
+                      <Icon icon="plus" className="size-5" />
+                      {t('cases:case.new_case')}
+                    </Button>
+                  </CaseRightPanel.Trigger>
                 </div>
               </div>
               <CasesFiltersBar />

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -268,12 +268,14 @@ export default function Cases() {
                   <CasesFiltersMenu filterNames={casesFilterNames}>
                     <FiltersButton />
                   </CasesFiltersMenu>
-                  <CaseRightPanel.Trigger asChild data={{ inboxId }}>
-                    <Button>
-                      <Icon icon="plus" className="size-5" />
-                      {t('cases:case.new_case')}
-                    </Button>
-                  </CaseRightPanel.Trigger>
+                  {inboxId ? (
+                    <CaseRightPanel.Trigger asChild data={{ inboxId }}>
+                      <Button>
+                        <Icon icon="plus" className="size-5" />
+                        {t('cases:case.new_case')}
+                      </Button>
+                    </CaseRightPanel.Trigger>
+                  ) : null}
                 </div>
               </div>
               <CasesFiltersBar />

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes._layout.tsx
@@ -84,6 +84,21 @@ export default function Cases() {
                     </NavLink>
                   </li>
                 ))}
+                <li>
+                  <NavLink
+                    className={({ isActive }) =>
+                      clsx(
+                        'text-s flex w-full cursor-pointer flex-row items-center rounded p-2 font-medium',
+                        isActive
+                          ? 'bg-purple-96 text-purple-65'
+                          : 'text-grey-00 hover:bg-purple-96 hover:text-purple-65',
+                      )
+                    }
+                    to="/cases/inboxes/assigned-to-me"
+                  >
+                    {t('cases:inbox.assigned_to_me')}
+                  </NavLink>
+                </li>
               </ul>
             </nav>
           </div>

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -50,6 +50,12 @@
         schema:
           type: boolean
           default: false
+      - name: assignee_id
+        description: Include cases that are assigned to a specific user
+        in: query
+        required: false
+        schema:
+          type: string
     responses:
       '200':
         description: List of corresponding cases

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1160,7 +1160,7 @@ export function createDecision(createDecisionBody: CreateDecisionBody, opts?: Oa
 /**
  * List cases
  */
-export function listCases({ status, inboxId, startDate, endDate, sorting, name, offsetId, limit, order, includeSnoozed }: {
+export function listCases({ status, inboxId, startDate, endDate, sorting, name, offsetId, limit, order, includeSnoozed, assigneeId }: {
     status?: CaseStatusDto[];
     inboxId?: string[];
     startDate?: string;
@@ -1171,6 +1171,7 @@ export function listCases({ status, inboxId, startDate, endDate, sorting, name, 
     limit?: number;
     order?: "ASC" | "DESC";
     includeSnoozed?: boolean;
+    assigneeId?: string;
 } = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
@@ -1193,7 +1194,8 @@ export function listCases({ status, inboxId, startDate, endDate, sorting, name, 
         offset_id: offsetId,
         limit,
         order,
-        include_snoozed: includeSnoozed
+        include_snoozed: includeSnoozed,
+        assignee_id: assigneeId
     }))}`, {
         ...opts
     }));


### PR DESCRIPTION
Appends a link to the case inboxes list to display all cases assigned to the user.

To avoid duplication and preserve the existing layout and logic of the inbox view, this new list is rendered as a standard inbox with an 'assigned-to-me' identifier. This allows us to fully reuse the existing logic. Only filters and navigation links are overridden as needed.

Feel free to challenge or suggest improvements to this approach.
