### PR TITLE
fix: case status tag color and displayed status

### DIFF
--- a/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotsPanelContent.tsx
+++ b/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotsPanelContent.tsx
@@ -147,7 +147,7 @@ function RelatedCases({
                   <div
                     className={cellVariants({ isLast, className: 'flex items-center border-l' })}
                   >
-                    <CaseStatusTag status={caseObj.status} />
+                    <CaseStatusTag status={caseObj.status} outcome={caseObj.outcome} />
                   </div>
                 </Fragment>
               );

--- a/packages/app-builder/src/components/Cases/CaseStatus.tsx
+++ b/packages/app-builder/src/components/Cases/CaseStatus.tsx
@@ -1,4 +1,4 @@
-import { caseStatuses } from '@app-builder/models/cases';
+import { type CaseOutcome, caseStatuses, type FinalOutcome } from '@app-builder/models/cases';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ParseKeys } from 'i18next';
 import { type CaseStatusForCaseEventDto } from 'marble-api';
@@ -15,6 +15,7 @@ export const caseStatusVariants = cva('inline-flex items-center justify-center r
       blue: 'text-blue-58 bg-blue-96',
       green: 'text-green-38 bg-green-94',
       grey: 'text-grey-50 bg-grey-95',
+      yellow: 'text-yellow-50 bg-yellow-90',
     },
     size: {
       small: undefined,
@@ -50,7 +51,7 @@ export const caseStatusVariants = cva('inline-flex items-center justify-center r
 });
 
 type CaseStatusMapping = Record<
-  CaseStatusForCaseEventDto,
+  CaseStatusForCaseEventDto | FinalOutcome,
   {
     color: VariantProps<typeof caseStatusVariants>['color'];
     tKey: ParseKeys<['cases']>;
@@ -63,7 +64,7 @@ export const caseStatusMapping: CaseStatusMapping = {
     tKey: 'cases:case.status.investigating',
   },
   pending: {
-    color: 'red',
+    color: 'grey',
     tKey: 'cases:case.status.pending',
   },
   closed: {
@@ -81,6 +82,18 @@ export const caseStatusMapping: CaseStatusMapping = {
   open: {
     color: 'red',
     tKey: 'cases:case.status.open',
+  },
+  confirmed_risk: {
+    color: 'red',
+    tKey: 'cases:case.outcome.confirmed_risk',
+  },
+  false_positive: {
+    color: 'grey',
+    tKey: 'cases:case.outcome.false_positive',
+  },
+  valuable_alert: {
+    color: 'yellow',
+    tKey: 'cases:case.outcome.valuable_alert',
   },
 };
 
@@ -118,9 +131,15 @@ export function CaseStatusPreview({
   );
 }
 
-export function CaseStatusTag({ status }: { status: CaseStatusForCaseEventDto }) {
+export function CaseStatusTag({
+  status,
+  outcome,
+}: {
+  status: CaseStatusForCaseEventDto;
+  outcome: CaseOutcome;
+}) {
   const { t } = useTranslation(['cases']);
-  const { color, tKey } = caseStatusMapping[status];
+  const { color, tKey } = caseStatusMapping[outcome === 'unset' ? status : outcome];
 
   return <Tag color={color ?? undefined}>{t(tKey)}</Tag>;
 }

--- a/packages/app-builder/src/models/cases.ts
+++ b/packages/app-builder/src/models/cases.ts
@@ -82,7 +82,7 @@ export interface Case {
   status: CaseStatus;
   inboxId: string;
   contributors: CaseContributor[];
-  outcome?: CaseOutcome;
+  outcome: CaseOutcome;
   tags: CaseTag[];
   snoozedUntil?: string;
   assignedTo?: string;

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -717,6 +717,7 @@ components:
         - decisions_count
         - name
         - status
+        - outcome
         - inbox_id
         - contributors
         - tags

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -60,7 +60,7 @@ export type CaseDto = {
     decisions_count: number;
     name: string;
     status: CaseStatusDto;
-    outcome?: "false_positive" | "valuable_alert" | "confirmed_risk" | "unset";
+    outcome: "false_positive" | "valuable_alert" | "confirmed_risk" | "unset";
     inbox_id: string;
     contributors: CaseContributorDto[];
     tags: CaseTagDto[];


### PR DESCRIPTION
Fix status case to:
- Have pending status in grey
- Have the outcome display when the case has one which is not "unset"