### PR TITLE
fix(pagination): add missing cleanup function in useEffect

### DIFF
--- a/packages/app-builder/src/hooks/useCursorPaginatedFetcher.ts
+++ b/packages/app-builder/src/hooks/useCursorPaginatedFetcher.ts
@@ -34,14 +34,14 @@ export const useCursorPaginatedFetcher = <T, D = T>({
 
   useEffect(() => {
     if (paginationState.isPristine) {
-      return;
+      return () => reset();
     }
 
     const queryParams = getQueryParamsRef(paginationState.cursor) ?? {};
     submit(qs.stringify(queryParams, { skipNulls: true }), {
       method: 'GET',
     });
-  }, [paginationState, submit, getQueryParamsRef]);
+  }, [paginationState, submit, reset, getQueryParamsRef]);
 
   const [previousInitialData, setPreviousInitialData] = useState(initialData);
   if (initialData !== previousInitialData && paginationState.isPristine) {


### PR DESCRIPTION
For some reason, the pagination state was not updating when navigating between inboxes on the /inbox pages.
Adding a cleanup function to the useEffect() in useCursorPaginatedFetcher—which resets the pagination state—resolved the issue.