### PR TITLE
chore(eslint): Add i18next plugin

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,6 +19,7 @@
     "eslint": "^9.22.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-import-resolver-typescript": "^4.2.1",
+    "eslint-plugin-i18next": "^6.1.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-jest-dom": "^5.5.0",

--- a/packages/eslint-config/react.mjs
+++ b/packages/eslint-config/react.mjs
@@ -1,3 +1,4 @@
+import i18next from 'eslint-plugin-i18next';
 import eslintJsxA11y from 'eslint-plugin-jsx-a11y';
 import eslintReact from 'eslint-plugin-react';
 import eslintReactHooks from 'eslint-plugin-react-hooks';
@@ -35,4 +36,5 @@ export default [
       ],
     },
   },
+  i18next.configs['flat/recommended'],
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       eslint-import-resolver-typescript:
         specifier: ^4.2.1
         version: 4.2.4(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@1.21.7))
+      eslint-plugin-i18next:
+        specifier: ^6.1.1
+        version: 6.1.1
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@4.2.4)(eslint@9.23.0(jiti@1.21.7))
@@ -5611,6 +5614,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
+  eslint-plugin-i18next@6.1.1:
+    resolution: {integrity: sha512-/Vy6BfX44njxpRnbJm7bbph0KaNJF2eillqN5W+u03hHuxmh9BjtjdPSrI9HPtyoEbG4j5nBn9gXm/dg99mz3Q==}
+    engines: {node: '>=0.10.0'}
+
   eslint-plugin-import@2.31.0:
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
@@ -8148,6 +8155,10 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  requireindex@1.1.0:
+    resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
+    engines: {node: '>=0.10.5'}
 
   requireindex@1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
@@ -15524,6 +15535,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-i18next@6.1.1:
+    dependencies:
+      lodash: 4.17.21
+      requireindex: 1.1.0
+
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.26.1(eslint@9.23.0(jiti@1.21.7))(typescript@5.8.2))(eslint-import-resolver-typescript@4.2.4)(eslint@9.23.0(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -18373,6 +18389,8 @@ snapshots:
   require-like@0.1.2: {}
 
   require-main-filename@2.0.0: {}
+
+  requireindex@1.1.0: {}
 
   requireindex@1.2.0: {}
 


### PR DESCRIPTION
Add [eslint-plugin-i18next](https://github.com/edvardchen/eslint-plugin-i18next) to `@marble/eslint-config` package.

See [disallow literal string (no-literal-string)](https://github.com/edvardchen/eslint-plugin-i18next/blob/main/docs/rules/no-literal-string.md#disallow-literal-string-no-literal-string) rule doc