### PR TITLE
Fail early on invalid environment, default value for SESSION_MAX_AGE

### DIFF
--- a/packages/app-builder/src/entry.server.tsx
+++ b/packages/app-builder/src/entry.server.tsx
@@ -12,7 +12,7 @@ import { PassThrough } from 'stream';
 
 import { initServerServices } from './services/init.server';
 import { captureUnexpectedRemixError } from './services/monitoring';
-import { getServerEnv } from './utils/environment';
+import { checkEnv, getServerEnv } from './utils/environment';
 
 const ABORT_DELAY = 70000;
 
@@ -192,3 +192,6 @@ export const handleError: HandleErrorFunction = (error, { request }) => {
   }
   captureUnexpectedRemixError(error, 'remix.server', request);
 };
+
+// Sanity check at startup to verify we have all the environment needed to start the server
+checkEnv();

--- a/packages/app-builder/src/services/init.server.ts
+++ b/packages/app-builder/src/services/init.server.ts
@@ -67,7 +67,7 @@ export function initServerServices(request: Request) {
     getMarbleCoreAPIClientWithAuth,
     getTransfercheckAPIClientWithAuth,
     sessionStorageRepositoryOptions: {
-      maxAge: Number(getServerEnv('SESSION_MAX_AGE')),
+      maxAge: Number(getServerEnv('SESSION_MAX_AGE')) || 43200,
       secrets: [getServerEnv('SESSION_SECRET')],
       secure:
         getServerEnv('ENV') !== 'development'

--- a/packages/app-builder/src/utils/environment.ts
+++ b/packages/app-builder/src/utils/environment.ts
@@ -22,7 +22,7 @@ const PublicEnvVarsSchema = z.object({
   NODE_ENV: z.string(),
   APP_VERSION: z.string().optional(),
 
-  SESSION_MAX_AGE: z.string(),
+  SESSION_MAX_AGE: z.string().optional(),
   MARBLE_API_URL_CLIENT: z.string(),
   MARBLE_API_URL_SERVER: z.string(),
   MARBLE_APP_URL: z.string(),
@@ -78,7 +78,7 @@ interface ServerEnvVars {
   ENV: string;
   NODE_ENV: string;
   APP_VERSION?: string;
-  SESSION_MAX_AGE: string;
+  SESSION_MAX_AGE?: string;
   MARBLE_API_URL_CLIENT: string;
   MARBLE_API_URL_SERVER: string;
   MARBLE_APP_URL: string;


### PR DESCRIPTION
**Warning:** This PR is a breaking change related to the deployment!

When in production mode, it checks the environment for any missing or invalid variables and refuses to start if it finds an issue. It is quite contrary to what currently happens where the server would always start properly, and error out during the requests.

This is one approach. There could be better ones if we find crashing out a bit excessive, for instance, we could fail the healthcheck (the server would still start in probeless environments).

@ChibiBlasphem Please roast this to do it TheRightWay ™️ .