### PR TITLE
Make inbox settings accessible by inbox admins.

### DIFF
--- a/packages/app-builder/src/models/inbox.ts
+++ b/packages/app-builder/src/models/inbox.ts
@@ -1,5 +1,10 @@
 import { type ParseKeys } from 'i18next';
-import { type AddInboxUserBodyDto, type InboxDto, type InboxUserDto } from 'marble-api';
+import {
+  type AddInboxUserBodyDto,
+  type InboxDto,
+  type InboxMetadataDto,
+  type InboxUserDto,
+} from 'marble-api';
 import invariant from 'tiny-invariant';
 
 export interface Inbox {
@@ -21,6 +26,18 @@ export function adaptInbox(inbox: InboxDto): Inbox {
     status: inbox.status,
     users: (inbox.users ?? []).map(adaptInboxUser),
     escalationInboxId: inbox.escalation_inbox_id,
+  };
+}
+
+export interface InboxMetadata {
+  id: string;
+  name: string;
+}
+
+export function adaptInboxMetadata(inbox: InboxMetadataDto): InboxMetadata {
+  return {
+    id: inbox.id,
+    name: inbox.name,
   };
 }
 

--- a/packages/app-builder/src/repositories/InboxRepository.ts
+++ b/packages/app-builder/src/repositories/InboxRepository.ts
@@ -1,12 +1,14 @@
 import { type MarbleCoreApi } from '@app-builder/infra/marblecore-api';
 import {
   adaptInbox,
+  adaptInboxMetadata,
   adaptInboxUser,
   adaptInboxUserCreateBody,
   adaptInboxWithCasesCount,
   adaptUpdateInboxDto,
   type Inbox,
   type InboxCreateBody,
+  type InboxMetadata,
   type InboxUpdateBody,
   type InboxUser,
   type InboxUserCreateBody,
@@ -17,9 +19,11 @@ import * as R from 'remeda';
 
 export interface InboxRepository {
   listInboxes(): Promise<Inbox[]>;
+  listInboxesMetadata(): Promise<InboxMetadata[]>;
   listInboxesWithCaseCount(): Promise<InboxWithCasesCount[]>;
   createInbox(data: InboxCreateBody): Promise<Inbox>;
   getInbox(inboxId: string): Promise<Inbox>;
+  getInboxMetadata(inboxId: string): Promise<InboxMetadata>;
   updateInbox(inboxId: string, data: InboxUpdateBody): Promise<Inbox>;
   deleteInbox(inboxId: string): Promise<void>;
   listAllInboxUsers(): Promise<InboxUser[]>;
@@ -44,6 +48,11 @@ export function makeGetInboxRepository() {
 
       return inboxes.map(adaptInboxWithCasesCount);
     },
+    listInboxesMetadata: async () => {
+      const inboxes = await marbleCoreApiClient.listInboxesMetadata();
+
+      return R.pipe(inboxes, R.map(adaptInboxMetadata), R.sortBy(R.prop('name')));
+    },
     createInbox: async (data) => {
       const { inbox } = await marbleCoreApiClient.createInbox(data);
 
@@ -53,6 +62,11 @@ export function makeGetInboxRepository() {
       const { inbox } = await marbleCoreApiClient.getInbox(inboxId);
 
       return adaptInbox(inbox);
+    },
+    getInboxMetadata: async (inboxId) => {
+      const inbox = await marbleCoreApiClient.getInboxMetadata(inboxId);
+
+      return adaptInboxMetadata(inbox);
     },
     updateInbox: async (inboxId, data) => {
       const { inbox } = await marbleCoreApiClient.updateInbox(inboxId, adaptUpdateInboxDto(data));

--- a/packages/app-builder/src/routes/_builder+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/_layout.tsx
@@ -37,14 +37,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw forbidden('Only Marble Core users can access this app.');
   }
 
-  const inboxes = await inbox.listInboxes();
-  const firstSettings = getSettings(user, inboxes)[0];
-  const [organizationDetail, orgUsers, orgTags, versions] = await Promise.all([
+  const [organizationDetail, orgUsers, orgTags, versions, inboxes] = await Promise.all([
     organization.getCurrentOrganization(),
     organization.listUsers(),
     organization.listTags(),
     versionRepository.getBackendVersion(),
+    inbox.listInboxes(),
   ]);
+
+  const firstSettings = getSettings(user, inboxes)[0];
 
   return {
     user,

--- a/packages/app-builder/src/routes/_builder+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/_layout.tsx
@@ -29,7 +29,7 @@ import { getSettings } from './settings+/_layout';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { authService, versionRepository } = initServerServices(request);
-  const { user, organization, entitlements } = await authService.isAuthenticated(request, {
+  const { user, inbox, organization, entitlements } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
 
@@ -37,7 +37,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw forbidden('Only Marble Core users can access this app.');
   }
 
-  const firstSettings = getSettings(user)[0];
+  const inboxes = await inbox.listInboxes();
+  const firstSettings = getSettings(user, inboxes)[0];
   const [organizationDetail, orgUsers, orgTags, versions] = await Promise.all([
     organization.getCurrentOrganization(),
     organization.listUsers(),

--- a/packages/app-builder/src/routes/_builder+/settings+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_index.tsx
@@ -11,11 +11,12 @@ export const handle = {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { authService } = initServerServices(request);
-  const { user } = await authService.isAuthenticated(request, {
+  const { user, inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
 
-  const settings = getSettings(user);
+  const inboxes = await inbox.listInboxes();
+  const settings = getSettings(user, inboxes);
   const firstSettings = settings[0];
 
   if (firstSettings) {

--- a/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
@@ -9,6 +9,7 @@ import { type CurrentUser, isAdmin } from '@app-builder/models';
 import { type Inbox } from '@app-builder/models/inbox';
 import {
   isAccessible,
+  isInboxAdmin,
   isReadApiKeyAvailable,
   isReadTagAvailable,
   isReadUserAvailable,
@@ -55,7 +56,7 @@ export function getSettings(user: CurrentUser, inboxes: Inbox[]) {
       to: getRoute('/settings/scenarios'),
     });
   }
-  if (inboxes.length > 0) {
+  if (inboxes.some((inbox) => isInboxAdmin(user, inbox))) {
     settings.push({
       section: 'case_manager' as const,
       title: 'inboxes' as const,

--- a/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
@@ -6,9 +6,9 @@ import {
 } from '@app-builder/components/Breadcrumbs';
 import { Nudge } from '@app-builder/components/Nudge';
 import { type CurrentUser, isAdmin } from '@app-builder/models';
+import { type Inbox } from '@app-builder/models/inbox';
 import {
   isAccessible,
-  isReadAllInboxesAvailable,
   isReadApiKeyAvailable,
   isReadTagAvailable,
   isReadUserAvailable,
@@ -39,7 +39,7 @@ export const handle = {
   ],
 };
 
-export function getSettings(user: CurrentUser) {
+export function getSettings(user: CurrentUser, inboxes: Inbox[]) {
   const settings = [];
   if (isReadUserAvailable(user)) {
     settings.push({
@@ -53,7 +53,7 @@ export function getSettings(user: CurrentUser) {
     title: 'scenarios' as const,
     to: getRoute('/settings/scenarios'),
   });
-  if (isReadAllInboxesAvailable(user)) {
+  if (inboxes.length > 0) {
     settings.push({
       section: 'case_manager' as const,
       title: 'inboxes' as const,
@@ -93,11 +93,12 @@ export function getSettings(user: CurrentUser) {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const { authService } = initServerServices(request);
-  const { user, entitlements } = await authService.isAuthenticated(request, {
+  const { user, entitlements, inbox } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
 
-  const settings = getSettings(user);
+  const inboxes = await inbox.listInboxes();
+  const settings = getSettings(user, inboxes);
 
   const sections = R.pipe(
     settings,

--- a/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
@@ -48,11 +48,13 @@ export function getSettings(user: CurrentUser, inboxes: Inbox[]) {
       to: getRoute('/settings/users'),
     });
   }
-  settings.push({
-    section: 'scenarios' as const,
-    title: 'scenarios' as const,
-    to: getRoute('/settings/scenarios'),
-  });
+  if (isAdmin(user)) {
+    settings.push({
+      section: 'scenarios' as const,
+      title: 'scenarios' as const,
+      to: getRoute('/settings/scenarios'),
+    });
+  }
   if (inboxes.length > 0) {
     settings.push({
       section: 'case_manager' as const,

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes.$inboxId.tsx
@@ -81,11 +81,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     caseCount: inbox.casesCount,
     entitlements,
     inboxUserRoles: getInboxUserRoles(entitlements),
-    isEditInboxAvailable: isEditInboxAvailable(user),
+    isEditInboxAvailable: isEditInboxAvailable(user, inbox),
     isDeleteInboxAvailable: isDeleteInboxAvailable(user),
-    isCreateInboxUserAvailable: isCreateInboxUserAvailable(user),
-    isEditInboxUserAvailable: isEditInboxUserAvailable(user),
-    isDeleteInboxUserAvailable: isDeleteInboxUserAvailable(user),
+    isCreateInboxUserAvailable: isCreateInboxUserAvailable(user, inbox),
+    isEditInboxUserAvailable: isEditInboxUserAvailable(user, inbox),
+    isDeleteInboxUserAvailable: isDeleteInboxUserAvailable(user, inbox),
   });
 }
 

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
@@ -1,7 +1,7 @@
 import { CollapsiblePaper, Page } from '@app-builder/components';
 import { type InboxWithCasesCount, tKeyForInboxUserRole } from '@app-builder/models/inbox';
 import { CreateInbox } from '@app-builder/routes/ressources+/settings+/inboxes+/create';
-import { isCreateInboxAvailable } from '@app-builder/services/feature-access';
+import { isCreateInboxAvailable, isInboxAdmin } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
@@ -21,7 +21,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const inboxes = await inbox.listInboxesWithCaseCount();
 
-  if (inboxes.length === 0) {
+  if (!inboxes.some((inbox) => isInboxAdmin(user, inbox))) {
     return redirect(getRoute('/'));
   }
 

--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
@@ -1,10 +1,7 @@
 import { CollapsiblePaper, Page } from '@app-builder/components';
 import { type InboxWithCasesCount, tKeyForInboxUserRole } from '@app-builder/models/inbox';
 import { CreateInbox } from '@app-builder/routes/ressources+/settings+/inboxes+/create';
-import {
-  isCreateInboxAvailable,
-  isReadAllInboxesAvailable,
-} from '@app-builder/services/feature-access';
+import { isCreateInboxAvailable } from '@app-builder/services/feature-access';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
@@ -21,11 +18,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const { inbox, user } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
-  if (!isReadAllInboxesAvailable(user)) {
-    return redirect(getRoute('/'));
-  }
 
   const inboxes = await inbox.listInboxesWithCaseCount();
+
+  if (inboxes.length === 0) {
+    return redirect(getRoute('/'));
+  }
 
   return json({
     inboxes,

--- a/packages/app-builder/src/routes/_builder+/settings+/scenarios.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/scenarios.tsx
@@ -10,7 +10,7 @@ import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { UTC, validTimezones } from '@app-builder/utils/validTimezones';
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import { useFetcher, useLoaderData } from '@remix-run/react';
+import { redirect, useFetcher, useLoaderData } from '@remix-run/react';
 import { useForm } from '@tanstack/react-form';
 import { decode as formDataToObject } from 'decode-formdata';
 import { useTranslation } from 'react-i18next';
@@ -26,6 +26,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   } = await authService.isAuthenticated(request, {
     failureRedirect: getRoute('/sign-in'),
   });
+
+  if (!isAdmin(user)) {
+    return redirect(getRoute('/'));
+  }
 
   return {
     organization: await repository.getCurrentOrganization(),

--- a/packages/app-builder/src/routes/ressources+/settings+/inboxes+/update.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/inboxes+/update.tsx
@@ -2,7 +2,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { setToastMessage } from '@app-builder/components/MarbleToaster';
-import { type Inbox } from '@app-builder/models/inbox';
+import { type Inbox, type InboxMetadata } from '@app-builder/models/inbox';
 import { initServerServices } from '@app-builder/services/init.server';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
@@ -92,11 +92,11 @@ export async function action({ request }: ActionFunctionArgs) {
 
 export function UpdateInbox({
   inbox,
-  inboxesList,
+  escalationInboxes,
   redirectRoutePath,
 }: {
   inbox: Inbox;
-  inboxesList: Inbox[];
+  escalationInboxes: InboxMetadata[];
   redirectRoutePath: (typeof redirectRouteOptions)[number];
 }) {
   const { t } = useTranslation(handle.i18n);
@@ -120,7 +120,7 @@ export function UpdateInbox({
       <Modal.Content onClick={(e) => e.stopPropagation()}>
         <UpdateInboxContent
           inbox={inbox}
-          inboxesList={inboxesList}
+          escalationInboxes={escalationInboxes}
           redirectRoutePath={redirectRoutePath}
         />
       </Modal.Content>
@@ -130,17 +130,17 @@ export function UpdateInbox({
 
 export function UpdateInboxContent({
   inbox,
-  inboxesList,
+  escalationInboxes,
   redirectRoutePath,
 }: {
   inbox: Inbox;
-  inboxesList: Inbox[];
+  escalationInboxes: InboxMetadata[];
   redirectRoutePath: (typeof redirectRouteOptions)[number];
 }) {
   const { t } = useTranslation(handle.i18n);
   const fetcher = useFetcher<typeof action>();
   const [isEscalationInboxOpen, setEscalationOpen] = useState(false);
-  const otherInboxes = inboxesList.filter((i) => i.id !== inbox.id);
+  const otherInboxes = escalationInboxes.filter((i) => i.id !== inbox.id);
 
   const form = useForm({
     defaultValues: {
@@ -192,7 +192,7 @@ export function UpdateInboxContent({
         </form.Field>
         <form.Field name="escalationInboxId">
           {(field) => {
-            const selectedInbox = inboxesList.find((inbox) => inbox.id === field.state.value);
+            const selectedInbox = escalationInboxes.find((inbox) => inbox.id === field.state.value);
 
             return (
               <div className="group flex flex-col gap-2">

--- a/packages/app-builder/src/services/feature-access.ts
+++ b/packages/app-builder/src/services/feature-access.ts
@@ -1,4 +1,5 @@
 import { type CurrentUser } from '@app-builder/models';
+import { type Inbox } from '@app-builder/models/inbox';
 import { type LicenseEntitlements } from '@app-builder/models/license';
 import { type FeatureAccessDto } from 'marble-api/generated/license-api';
 
@@ -15,6 +16,9 @@ export const isReadUserAvailable = ({ role }: CurrentUser) =>
 
 export const isReadAllInboxesAvailable = ({ role }: CurrentUser) =>
   role === 'ADMIN' || role === 'MARBLE_ADMIN';
+
+export const isInboxAdmin = ({ actorIdentity: { userId } }: CurrentUser, inbox: Inbox) =>
+  inbox.users.some((inboxUser) => inboxUser.userId === userId && inboxUser.role === 'admin');
 
 export const isReadTagAvailable = ({ role }: CurrentUser) =>
   role === 'ADMIN' || role === 'MARBLE_ADMIN';
@@ -95,18 +99,19 @@ export const isDeleteApiKeyAvailable = ({ permissions }: CurrentUser) =>
 export const getInboxUserRoles = (entitlements: LicenseEntitlements) =>
   isAccessible(entitlements.userRoles) ? (['admin', 'member'] as const) : (['admin'] as const);
 
-export const isEditInboxAvailable = ({ permissions }: CurrentUser) => permissions.canEditInboxes;
+export const isEditInboxAvailable = (user: CurrentUser, inbox: Inbox) =>
+  user.permissions.canEditInboxes || isInboxAdmin(user, inbox);
 
 export const isDeleteInboxAvailable = ({ permissions }: CurrentUser) => permissions.canEditInboxes;
 
-export const isCreateInboxUserAvailable = ({ permissions }: CurrentUser) =>
-  permissions.canEditInboxes;
+export const isCreateInboxUserAvailable = (user: CurrentUser, inbox: Inbox) =>
+  user.permissions.canEditInboxes || isInboxAdmin(user, inbox);
 
-export const isEditInboxUserAvailable = ({ permissions }: CurrentUser) =>
-  permissions.canEditInboxes;
+export const isEditInboxUserAvailable = (user: CurrentUser, inbox: Inbox) =>
+  user.permissions.canEditInboxes || isInboxAdmin(user, inbox);
 
-export const isDeleteInboxUserAvailable = ({ permissions }: CurrentUser) =>
-  permissions.canEditInboxes;
+export const isDeleteInboxUserAvailable = (user: CurrentUser, inbox: Inbox) =>
+  user.permissions.canEditInboxes || isInboxAdmin(user, inbox);
 
 export const isCreateTagAvailable = ({ permissions }: CurrentUser) => permissions.canEditInboxes;
 

--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -250,8 +250,12 @@ paths:
 
   /inboxes:
     $ref: ./marblecore-api/inboxes.yml#/~1inboxes
+  /inboxes/metadata:
+    $ref: ./marblecore-api/inboxes.yml#/~1inboxes~1metadata
   /inboxes/{inboxId}:
     $ref: ./marblecore-api/inboxes.yml#/~1inboxes~1{inboxId}
+  /inboxes/{inboxId}/metadata:
+    $ref: ./marblecore-api/inboxes.yml#/~1inboxes~1{inboxId}~1metadata
   /inboxes/{inboxId}/users:
     $ref: ./marblecore-api/inboxes.yml#/~1inboxes~1{inboxId}~1users
   /inbox_users:

--- a/packages/marble-api/openapis/marblecore-api/_schemas.yml
+++ b/packages/marble-api/openapis/marblecore-api/_schemas.yml
@@ -328,6 +328,8 @@ CreatedApiKeyDto:
 
 InboxDto:
   $ref: inboxes.yml#/components/schemas/InboxDto
+InboxMetadataDto:
+  $ref: inboxes.yml#/components/schemas/InboxMetadataDto
 CreateInboxBodyDto:
   $ref: inboxes.yml#/components/schemas/CreateInboxBodyDto
 InboxUserDto:

--- a/packages/marble-api/openapis/marblecore-api/inboxes.yml
+++ b/packages/marble-api/openapis/marblecore-api/inboxes.yml
@@ -61,6 +61,29 @@
         $ref: 'components.yml#/responses/401'
       '403':
         $ref: 'components.yml#/responses/403'
+/inboxes/metadata:
+  get:
+    tags:
+      - Inboxes
+    summary: Get an inbox metadata by id
+    operationId: listInboxesMetadata
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: The inbox metadata corresponding to the provided `inboxId`
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/InboxMetadataDto'
+      '401':
+        $ref: 'components.yml#/responses/401'
+      '403':
+        $ref: 'components.yml#/responses/403'
+      '404':
+        $ref: 'components.yml#/responses/404'
 /inboxes/{inboxId}:
   get:
     tags:
@@ -163,6 +186,35 @@
         $ref: 'components.yml#/responses/401'
       '403':
         $ref: 'components.yml#/responses/403'
+/inboxes/{inboxId}/metadata:
+  get:
+    tags:
+      - Inboxes
+    summary: Get an inbox metadata by id
+    operationId: getInboxMetadata
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: inboxId
+        description: ID of the inbox that needs to be fetched
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '200':
+        description: The inbox metadata corresponding to the provided `inboxId`
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InboxMetadataDto'
+      '401':
+        $ref: 'components.yml#/responses/401'
+      '403':
+        $ref: 'components.yml#/responses/403'
+      '404':
+        $ref: 'components.yml#/responses/404'
 /inboxes/{inboxId}/users:
   get:
     tags:
@@ -393,6 +445,17 @@ components:
         escalation_inbox_id:
           type: string
           format: uuid
+    InboxMetadataDto:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
     CreateInboxBodyDto:
       type: object
       required:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -979,6 +979,10 @@ export type InboxDto = {
 export type CreateInboxBodyDto = {
     name: string;
 };
+export type InboxMetadataDto = {
+    id: string;
+    name: string;
+};
 export type AddInboxUserBodyDto = {
     user_id: string;
     role: string;
@@ -3458,6 +3462,26 @@ export function createInbox(createInboxBodyDto: CreateInboxBodyDto, opts?: Oazap
     })));
 }
 /**
+ * Get an inbox metadata by id
+ */
+export function listInboxesMetadata(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: InboxMetadataDto[];
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    }>("/inboxes/metadata", {
+        ...opts
+    }));
+}
+/**
  * Get an inbox by id
  */
 export function getInbox(inboxId: string, opts?: Oazapfts.RequestOpts) {
@@ -3518,6 +3542,26 @@ export function deleteInbox(inboxId: string, opts?: Oazapfts.RequestOpts) {
     }>(`/inboxes/${encodeURIComponent(inboxId)}`, {
         ...opts,
         method: "DELETE"
+    }));
+}
+/**
+ * Get an inbox metadata by id
+ */
+export function getInboxMetadata(inboxId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: InboxMetadataDto;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    }>(`/inboxes/${encodeURIComponent(inboxId)}/metadata`, {
+        ...opts
     }));
 }
 /**


### PR DESCRIPTION
The `Inboxes` tab of the setting was only accessible to organization admins, and any action within it as well. This PR makes it so the list can be accessed if the user is admin on at least one inbox, and so are all the actions offered by the feature.

This goes with checkmarble/marble-backend#988 that adds checks for update permissions.