### PR TITLE
display comments AND file uploads by default

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseEvents.tsx
+++ b/packages/app-builder/src/components/Cases/CaseEvents.tsx
@@ -37,7 +37,9 @@ export function CaseEvents({ events, inboxes }: { events: CaseEvent[]; inboxes: 
   const [showAll, setShowAll] = useState(false);
   const [olderEvents, setOlderEventsCount] = useState(0);
   const [newerEvents, setNewerEventsCount] = useState(0);
-  const [filters, setFilters] = useState<CaseEventFiltersForm>({ types: ['comment_added'] });
+  const [filters, setFilters] = useState<CaseEventFiltersForm>({
+    types: ['comment_added', 'file_added'],
+  });
   const orderedEvents = useMemo(
     () => events.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
     [events],

--- a/packages/app-builder/src/components/Cases/Events/Filters/index.tsx
+++ b/packages/app-builder/src/components/Cases/Events/Filters/index.tsx
@@ -42,7 +42,7 @@ export const CaseEventFilters = ({
   const language = useFormatLanguage();
   const isDirty = useMemo(
     () =>
-      diff(filters.types, ['comment_added']).length !== 0 ||
+      diff(filters.types, ['comment_added', 'file_added']).length !== 0 ||
       filters.types.length === 0 ||
       filters.startDate ||
       filters.endDate,
@@ -55,7 +55,7 @@ export const CaseEventFilters = ({
         <Button
           variant="secondary"
           size="xs"
-          onClick={() => setFilters({ types: ['comment_added'] })}
+          onClick={() => setFilters({ types: ['comment_added', 'file_added'] })}
         >
           <Icon icon="cross" className="size-4" />
           <span className="text-xs">{t('cases:case_detail.history.filter_reset')}</span>


### PR DESCRIPTION
File uploads should be displayed along with comments by default, otherwise you have no visual hint that your file has actually been uploaded

<img width="1799" alt="Capture d’écran 2025-05-07 à 16 53 00" src="https://github.com/user-attachments/assets/2d5f5ad5-e794-4fcb-a7ea-cb4ce019e932" />
