### PR TITLE
Remove inbox settings from inbox members.

### DIFF
--- a/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/inboxes._index.tsx
@@ -20,9 +20,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
     failureRedirect: getRoute('/sign-in'),
   });
 
-  const inboxes = await inbox.listInboxesWithCaseCount();
+  const inboxes = (await inbox.listInboxesWithCaseCount()).filter(
+    (inbox) => isAdmin(user) || isInboxAdmin(user, inbox),
+  );
 
-  if (!isAdmin(user) && !inboxes.some((inbox) => isInboxAdmin(user, inbox))) {
+  if (inboxes.length === 0) {
     return redirect(getRoute('/'));
   }
 


### PR DESCRIPTION
Hopefully, this is the last fix on inbox management. We need to filter out inboxes where the user is only a member, since there is no real value in showing them.