### PR TITLE
restrict permissions on workflow to fix code scanning alert

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -22,6 +22,11 @@ on:
       SEGMENT_WRITE_KEY_OPENSOURCE:
         description: write key for segment (open source deployment). Can be overridden at runtime
 
+permissions:
+  contents: read
+  actions: read
+  id-token: 'write' # needed for using open id token to authenticate with GCP
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -3,6 +3,10 @@ name: Reusable check job
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes https://github.com/checkmarble/marble-frontend/security/code-scanning/15, following a similar fix on the backend