### PR TITLE
fix(case-manager): Reset component state

### DIFF
--- a/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotsPanel.tsx
+++ b/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotsPanel.tsx
@@ -48,6 +48,7 @@ export function PivotsPanel(props: PivotsPanelProps) {
         <div className="w-[519px] p-8 pt-0">
           <PivotsPanelContent
             currentUser={props.currentUser}
+            key={props.case.id}
             case={props.case}
             pivotObjects={props.pivotObjects}
             dataModel={props.dataModel}


### PR DESCRIPTION
Pass a key attribute to the PivotsPanelContent component to force its state to reset when navigating from one case to another.
see https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes