### PR TITLE
feat(case-manager): Disable go to next case button while unassigned

### DIFF
--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
@@ -269,6 +269,7 @@ export default function CaseManagerIndexPage() {
           <Button
             variant="secondary"
             size="medium"
+            disabled={!!(nextCaseId === details.id && !details.assignedTo)}
             onClick={() =>
               navigate(getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(nextCaseId) }))
             }


### PR DESCRIPTION
Disable "go to the next unassigned case" when the user is already on the oldest unassigned case.
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/1fa4666f-43a6-4e5d-b251-288d8809006e" />

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/7a148539-bf8c-4a6f-915b-63990beef9c6" />
