### PR TITLE
feat(inboxes): rework filters

### DIFF
--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
@@ -41,6 +41,11 @@ export function CasesFiltersBar() {
       <Separator className="bg-grey-90" decorative />
       <div className="flex flex-row items-center justify-between gap-2">
         <div className="flex flex-row flex-wrap gap-2">
+          {undefinedCasesFilterNames.length > 0 ? (
+            <CasesFiltersMenu filterNames={undefinedCasesFilterNames}>
+              <AddNewFilterButton />
+            </CasesFiltersMenu>
+          ) : null}
           {definedCasesFilterNames.map((filterName) => {
             const icon = getFilterIcon(filterName);
             const tKey = getFilterTKey(filterName);
@@ -64,11 +69,6 @@ export function CasesFiltersBar() {
               </FilterPopover.Root>
             );
           })}
-          {undefinedCasesFilterNames.length > 0 ? (
-            <CasesFiltersMenu filterNames={undefinedCasesFilterNames}>
-              <AddNewFilterButton />
-            </CasesFiltersMenu>
-          ) : null}
         </div>
         <ClearAllFiltersLink to={getRoute('/cases')} replace />
       </div>

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
@@ -36,10 +36,6 @@ export function CasesFiltersBar() {
   const { undefinedCasesFilterNames, definedCasesFilterNames } = useCasesFiltersPartition();
   const clearFilter = useClearFilter();
 
-  if (definedCasesFilterNames.length === 0) {
-    return null;
-  }
-
   return (
     <>
       <Separator className="bg-grey-90" decorative />

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
@@ -3,6 +3,7 @@ import {
   ClearAllFiltersLink,
   FilterItem,
   FilterPopover,
+  FiltersButton,
 } from '@app-builder/components/Filters';
 import { getRoute } from '@app-builder/utils/routes';
 import { useCallback } from 'react';
@@ -23,7 +24,6 @@ import { getFilterIcon, getFilterTKey } from './filters';
 export function CasesFiltersBar({ excludedFilters }: { excludedFilters?: readonly string[] }) {
   const { t } = useTranslation(casesI18n);
   const { onCasesFilterClose } = useCasesFiltersContext();
-
   const onOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
@@ -42,9 +42,9 @@ export function CasesFiltersBar({ excludedFilters }: { excludedFilters?: readonl
       <Separator className="bg-grey-90" decorative />
       <div className="flex flex-row items-center justify-between gap-2">
         <div className="flex flex-row flex-wrap gap-2">
-          {undefinedCasesFilterNames.length > 0 ? (
+          {undefinedCasesFilterNames.length > 0 && !definedCasesFilterNames.length ? (
             <CasesFiltersMenu filterNames={undefinedCasesFilterNames}>
-              <AddNewFilterButton />
+              <FiltersButton />
             </CasesFiltersMenu>
           ) : null}
           {definedCasesFilterNames.map((filterName) => {
@@ -70,6 +70,12 @@ export function CasesFiltersBar({ excludedFilters }: { excludedFilters?: readonl
               </FilterPopover.Root>
             );
           })}
+
+          {definedCasesFilterNames.length > 0 && undefinedCasesFilterNames.length > 0 ? (
+            <CasesFiltersMenu filterNames={undefinedCasesFilterNames}>
+              <AddNewFilterButton />
+            </CasesFiltersMenu>
+          ) : null}
         </div>
         <ClearAllFiltersLink to={getRoute('/cases')} replace />
       </div>

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
@@ -20,7 +20,7 @@ import { CasesFiltersMenu } from './CasesFiltersMenu';
 import { FilterDetail } from './FilterDetail';
 import { getFilterIcon, getFilterTKey } from './filters';
 
-export function CasesFiltersBar() {
+export function CasesFiltersBar({ excludedFilters }: { excludedFilters?: readonly string[] }) {
   const { t } = useTranslation(casesI18n);
   const { onCasesFilterClose } = useCasesFiltersContext();
 
@@ -33,7 +33,8 @@ export function CasesFiltersBar() {
     [onCasesFilterClose],
   );
 
-  const { undefinedCasesFilterNames, definedCasesFilterNames } = useCasesFiltersPartition();
+  const { undefinedCasesFilterNames, definedCasesFilterNames } =
+    useCasesFiltersPartition(excludedFilters);
   const clearFilter = useClearFilter();
 
   return (

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersBar.tsx
@@ -5,6 +5,7 @@ import {
   FilterPopover,
   FiltersButton,
 } from '@app-builder/components/Filters';
+import { SimpleFilter } from '@app-builder/components/Filters/SimpleFilter';
 import { getRoute } from '@app-builder/utils/routes';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +20,7 @@ import {
 } from './CasesFiltersContext';
 import { CasesFiltersMenu } from './CasesFiltersMenu';
 import { FilterDetail } from './FilterDetail';
-import { getFilterIcon, getFilterTKey } from './filters';
+import { casesSimpleFilterNames, getFilterIcon, getFilterTKey } from './filters';
 
 export function CasesFiltersBar({ excludedFilters }: { excludedFilters?: readonly string[] }) {
   const { t } = useTranslation(casesI18n);
@@ -51,7 +52,19 @@ export function CasesFiltersBar({ excludedFilters }: { excludedFilters?: readonl
             const icon = getFilterIcon(filterName);
             const tKey = getFilterTKey(filterName);
 
-            return (
+            return casesSimpleFilterNames.includes(
+              filterName as (typeof casesSimpleFilterNames)[number],
+            ) ? (
+              <SimpleFilter key={filterName}>
+                <Icon icon={icon} className="size-5" />
+                <span className="text-s font-semibold first-letter:capitalize">{t(tKey)}</span>
+                <FilterItem.Clear
+                  onClick={() => {
+                    clearFilter(filterName);
+                  }}
+                />
+              </SimpleFilter>
+            ) : (
               <FilterPopover.Root key={filterName} onOpenChange={onOpenChange}>
                 <FilterItem.Root>
                   <FilterItem.Trigger>

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
@@ -143,11 +143,11 @@ export function useNameFilter() {
  * - undefinedCasesFilterNames: filter values are undefined
  * - definedCasesFilterNames: filter values are defined
  */
-export function useCasesFiltersPartition() {
+export function useCasesFiltersPartition(excludedFilters?: readonly string[]) {
   const { filterValues } = useCasesFiltersContext();
 
   const [undefinedCasesFilterNames, definedCasesFilterNames] = R.pipe(
-    casesFilterNames,
+    casesFilterNames.filter((filterName) => !excludedFilters?.includes(filterName)),
     R.partition((filterName) => {
       const value = filterValues[filterName];
       if (R.isArray(value)) return value.length === 0;

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
@@ -13,7 +13,7 @@ export const casesFiltersSchema = z.object({
   statuses: z.array(z.enum(caseStatuses)).optional(),
   dateRange: dateRangeSchema.optional(),
   name: z.string().optional(),
-  snoozed: z
+  includeSnoozed: z
     .enum(['true', 'false'])
     .transform((val) => val === 'true')
     .optional(),
@@ -37,7 +37,7 @@ export type CasesFiltersForm = {
   statuses: CaseStatus[];
   dateRange: DateRangeFilterForm;
   name?: string;
-  snoozed?: boolean;
+  includeSnoozed?: boolean;
 };
 
 const emptyCasesFilters: CasesFiltersForm = {

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
@@ -17,6 +17,10 @@ export const casesFiltersSchema = z.object({
     .enum(['true', 'false'])
     .transform((val) => val === 'true')
     .optional(),
+  excludeAssigned: z
+    .enum(['true', 'false'])
+    .transform((val) => val === 'true')
+    .optional(),
 });
 
 export type CasesFilters = z.infer<typeof casesFiltersSchema>;

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
@@ -10,17 +10,7 @@ import * as z from 'zod';
 import { type CasesFilterName, casesFilterNames } from './filters';
 
 export const casesFiltersSchema = z.object({
-  statuses: z
-    .array(
-      z.union(
-        caseStatuses.map((s) => z.literal(s)) as [
-          z.ZodLiteral<CaseStatus>,
-          z.ZodLiteral<CaseStatus>,
-          ...z.ZodLiteral<CaseStatus>[],
-        ],
-      ),
-    )
-    .optional(),
+  statuses: z.array(z.enum(caseStatuses)).optional(),
   dateRange: dateRangeSchema.optional(),
   name: z.string().optional(),
   snoozed: z

--- a/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/CasesFiltersContext.tsx
@@ -38,6 +38,7 @@ export type CasesFiltersForm = {
   dateRange: DateRangeFilterForm;
   name?: string;
   includeSnoozed?: boolean;
+  excludeAssigned?: boolean;
 };
 
 const emptyCasesFilters: CasesFiltersForm = {

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/CasesExcludeAssignedFilter.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/CasesExcludeAssignedFilter.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { type CasesFiltersForm, useCasesFiltersContext } from '../CasesFiltersContext';
+
+export function CasesExcludeAssignedFilter() {
+  const { submitCasesFilters } = useCasesFiltersContext();
+  const { setValue } = useFormContext<CasesFiltersForm>();
+
+  useMemo(() => {
+    setValue('excludeAssigned', true);
+    submitCasesFilters();
+  }, []);
+  return null;
+}

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/CasesSnoozedFilter.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/CasesSnoozedFilter.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { type CasesFiltersForm, useCasesFiltersContext } from '../CasesFiltersContext';
+
+export function CasesSnoozedFilter() {
+  const { submitCasesFilters } = useCasesFiltersContext();
+  const { setValue } = useFormContext<CasesFiltersForm>();
+
+  useMemo(() => {
+    setValue('includeSnoozed', true);
+    submitCasesFilters();
+  }, []);
+  return null;
+}

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/ClosedCasesFilter.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/ClosedCasesFilter.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { type CasesFiltersForm, useCasesFiltersContext } from '../CasesFiltersContext';
+
+export function ClosedCasesFilter() {
+  const { submitCasesFilters } = useCasesFiltersContext();
+  const { setValue } = useFormContext<CasesFiltersForm>();
+
+  useMemo(() => {
+    setValue('statuses', ['closed']);
+    submitCasesFilters();
+  }, []);
+
+  return null;
+}

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
@@ -4,12 +4,12 @@ import { type CasesFilterName } from '../filters';
 import { CasesDateRangeFilter } from './CasesDateRangeFilter';
 import { CasesExcludeAssignedFilter } from './CasesExcludeAssignedFilter';
 import { CasesSnoozedFilter } from './CasesSnoozedFilter';
-import { StatusesFilter } from './StatusesFilter';
+import { ClosedCasesFilter } from './ClosedCasesFilter';
 
 export const FilterDetail = ({ filterName }: { filterName: CasesFilterName }) => {
   return match(filterName)
     .with('dateRange', () => <CasesDateRangeFilter />)
-    .with('statuses', () => <StatusesFilter />)
+    .with('statuses', () => <ClosedCasesFilter />)
     .with('includeSnoozed', () => <CasesSnoozedFilter />)
     .with('excludeAssigned', () => <CasesExcludeAssignedFilter />)
     .exhaustive();

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
@@ -2,10 +2,13 @@ import { match } from 'ts-pattern';
 
 import { type CasesFilterName } from '../filters';
 import { CasesDateRangeFilter } from './CasesDateRangeFilter';
+import { CasesSnoozedFilter } from './CasesSnoozedFilter';
 import { StatusesFilter } from './StatusesFilter';
 
-export const FilterDetail = ({ filterName }: { filterName: CasesFilterName }) =>
-  match(filterName)
+export const FilterDetail = ({ filterName }: { filterName: CasesFilterName }) => {
+  return match(filterName)
     .with('dateRange', () => <CasesDateRangeFilter />)
     .with('statuses', () => <StatusesFilter />)
+    .with('includeSnoozed', () => <CasesSnoozedFilter />)
     .exhaustive();
+};

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
@@ -6,11 +6,10 @@ import { CasesExcludeAssignedFilter } from './CasesExcludeAssignedFilter';
 import { CasesSnoozedFilter } from './CasesSnoozedFilter';
 import { ClosedCasesFilter } from './ClosedCasesFilter';
 
-export const FilterDetail = ({ filterName }: { filterName: CasesFilterName }) => {
-  return match(filterName)
+export const FilterDetail = ({ filterName }: { filterName: CasesFilterName }) =>
+  match(filterName)
     .with('dateRange', () => <CasesDateRangeFilter />)
     .with('statuses', () => <ClosedCasesFilter />)
     .with('includeSnoozed', () => <CasesSnoozedFilter />)
     .with('excludeAssigned', () => <CasesExcludeAssignedFilter />)
     .exhaustive();
-};

--- a/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
+++ b/packages/app-builder/src/components/Cases/Filters/FilterDetail/FilterDetail.tsx
@@ -2,6 +2,7 @@ import { match } from 'ts-pattern';
 
 import { type CasesFilterName } from '../filters';
 import { CasesDateRangeFilter } from './CasesDateRangeFilter';
+import { CasesExcludeAssignedFilter } from './CasesExcludeAssignedFilter';
 import { CasesSnoozedFilter } from './CasesSnoozedFilter';
 import { StatusesFilter } from './StatusesFilter';
 
@@ -10,5 +11,6 @@ export const FilterDetail = ({ filterName }: { filterName: CasesFilterName }) =>
     .with('dateRange', () => <CasesDateRangeFilter />)
     .with('statuses', () => <StatusesFilter />)
     .with('includeSnoozed', () => <CasesSnoozedFilter />)
+    .with('excludeAssigned', () => <CasesExcludeAssignedFilter />)
     .exhaustive();
 };

--- a/packages/app-builder/src/components/Cases/Filters/filters.ts
+++ b/packages/app-builder/src/components/Cases/Filters/filters.ts
@@ -11,6 +11,10 @@ export const casesFilterNames = [
 
 export type CasesFilterName = (typeof casesFilterNames)[number];
 
+export const casesSimpleFilterNames = ['includeSnoozed', 'excludeAssigned', 'statuses'] as const;
+
+export type CasesSimpleFilterName = (typeof casesSimpleFilterNames)[number];
+
 export const getFilterIcon = (filterName: CasesFilterName) =>
   match<CasesFilterName, IconName>(filterName)
     .with('dateRange', () => 'calendar-month')

--- a/packages/app-builder/src/components/Cases/Filters/filters.ts
+++ b/packages/app-builder/src/components/Cases/Filters/filters.ts
@@ -14,7 +14,7 @@ export type CasesFilterName = (typeof casesFilterNames)[number];
 export const getFilterIcon = (filterName: CasesFilterName) =>
   match<CasesFilterName, IconName>(filterName)
     .with('dateRange', () => 'calendar-month')
-    .with('statuses', () => 'category')
+    .with('statuses', () => 'checked')
     .with('includeSnoozed', () => 'snooze')
     .with('excludeAssigned', () => 'person')
     .exhaustive();
@@ -22,7 +22,7 @@ export const getFilterIcon = (filterName: CasesFilterName) =>
 export const getFilterTKey = (filterName: CasesFilterName) =>
   match<CasesFilterName, ParseKeys<['cases']>>(filterName)
     .with('dateRange', () => 'cases:case.date')
-    .with('statuses', () => 'cases:case.status')
+    .with('statuses', () => 'cases:filter.closed_only.label')
     .with('includeSnoozed', () => 'cases:filter.include_snoozed.label')
     .with('excludeAssigned', () => 'cases:filter.exclude_assigned.label')
     .exhaustive();

--- a/packages/app-builder/src/components/Cases/Filters/filters.ts
+++ b/packages/app-builder/src/components/Cases/Filters/filters.ts
@@ -2,7 +2,12 @@ import { type ParseKeys } from 'i18next';
 import { match } from 'ts-pattern';
 import { type IconName } from 'ui-icons';
 
-export const casesFilterNames = ['dateRange', 'statuses', 'includeSnoozed'] as const;
+export const casesFilterNames = [
+  'dateRange',
+  'statuses',
+  'includeSnoozed',
+  'excludeAssigned',
+] as const;
 
 export type CasesFilterName = (typeof casesFilterNames)[number];
 
@@ -11,6 +16,7 @@ export const getFilterIcon = (filterName: CasesFilterName) =>
     .with('dateRange', () => 'calendar-month')
     .with('statuses', () => 'category')
     .with('includeSnoozed', () => 'snooze')
+    .with('excludeAssigned', () => 'person')
     .exhaustive();
 
 export const getFilterTKey = (filterName: CasesFilterName) =>
@@ -18,4 +24,5 @@ export const getFilterTKey = (filterName: CasesFilterName) =>
     .with('dateRange', () => 'cases:case.date')
     .with('statuses', () => 'cases:case.status')
     .with('includeSnoozed', () => 'cases:filter.include_snoozed.label')
+    .with('excludeAssigned', () => 'cases:filter.exclude_assigned.label')
     .exhaustive();

--- a/packages/app-builder/src/components/Cases/Filters/filters.ts
+++ b/packages/app-builder/src/components/Cases/Filters/filters.ts
@@ -2,7 +2,7 @@ import { type ParseKeys } from 'i18next';
 import { match } from 'ts-pattern';
 import { type IconName } from 'ui-icons';
 
-export const casesFilterNames = ['dateRange', 'statuses'] as const;
+export const casesFilterNames = ['dateRange', 'statuses', 'includeSnoozed'] as const;
 
 export type CasesFilterName = (typeof casesFilterNames)[number];
 
@@ -10,10 +10,12 @@ export const getFilterIcon = (filterName: CasesFilterName) =>
   match<CasesFilterName, IconName>(filterName)
     .with('dateRange', () => 'calendar-month')
     .with('statuses', () => 'category')
+    .with('includeSnoozed', () => 'snooze')
     .exhaustive();
 
 export const getFilterTKey = (filterName: CasesFilterName) =>
   match<CasesFilterName, ParseKeys<['cases']>>(filterName)
     .with('dateRange', () => 'cases:case.date')
     .with('statuses', () => 'cases:case.status')
+    .with('includeSnoozed', () => 'cases:filter.include_snoozed.label')
     .exhaustive();

--- a/packages/app-builder/src/components/Filters/SimpleFilter.tsx
+++ b/packages/app-builder/src/components/Filters/SimpleFilter.tsx
@@ -1,0 +1,16 @@
+import clsx from 'clsx';
+import { type ComponentPropsWithoutRef } from 'react';
+
+export function SimpleFilter({ className, ...props }: ComponentPropsWithoutRef<'div'>) {
+  return (
+    <div className="bg-purple-98 flex h-10 flex-row items-center rounded">
+      <div
+        className={clsx(
+          'text-purple-65 flex h-full flex-row items-center gap-1 rounded px-2',
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -193,5 +193,6 @@
   "case_detail.history.event_detail.decision_reviewed": "قرار تمت مراجعته إلى <Status /> بواسطة <Actor>{{Actor}}</Actor>",
   "case_detail.history.event_detail.rule_snooze_created": "القاعدة snoozed بواسطة <Actor>{{Actor}}</Actor>",
   "filter.include_snoozed.label": "عرض المؤجّلة",
-  "filter.exclude_assigned.label": "استثناء المعيّنة"
+  "filter.exclude_assigned.label": "استثناء المعيّنة",
+  "filter.closed_only.label": "المغلقة فقط"
 }

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -192,5 +192,6 @@
   "required_actions.review_screening_hits": "مراجعة عربات الفحص ({{count}})",
   "case_detail.history.event_detail.decision_reviewed": "قرار تمت مراجعته إلى <Status /> بواسطة <Actor>{{Actor}}</Actor>",
   "case_detail.history.event_detail.rule_snooze_created": "القاعدة snoozed بواسطة <Actor>{{Actor}}</Actor>",
-  "filter.include_snoozed.label": "عرض المؤجّلة"
+  "filter.include_snoozed.label": "عرض المؤجّلة",
+  "filter.exclude_assigned.label": "استثناء المعيّنة"
 }

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -191,5 +191,6 @@
   "required_actions.no_more_pending_sanction_checks": "لا مزيد من الشيكات العقوبات المعلقة",
   "required_actions.review_screening_hits": "مراجعة عربات الفحص ({{count}})",
   "case_detail.history.event_detail.decision_reviewed": "قرار تمت مراجعته إلى <Status /> بواسطة <Actor>{{Actor}}</Actor>",
-  "case_detail.history.event_detail.rule_snooze_created": "القاعدة snoozed بواسطة <Actor>{{Actor}}</Actor>"
+  "case_detail.history.event_detail.rule_snooze_created": "القاعدة snoozed بواسطة <Actor>{{Actor}}</Actor>",
+  "filter.include_snoozed.label": "عرض المؤجّلة"
 }

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -192,7 +192,7 @@
   "required_actions.review_screening_hits": "مراجعة عربات الفحص ({{count}})",
   "case_detail.history.event_detail.decision_reviewed": "قرار تمت مراجعته إلى <Status /> بواسطة <Actor>{{Actor}}</Actor>",
   "case_detail.history.event_detail.rule_snooze_created": "القاعدة snoozed بواسطة <Actor>{{Actor}}</Actor>",
-  "filter.include_snoozed.label": "عرض المؤجّلة",
-  "filter.exclude_assigned.label": "استثناء المعيّنة",
+  "filter.include_snoozed.label": "تضمين المؤجّلين",
+  "filter.exclude_assigned.label": "غير المكلّفين فقط",
   "filter.closed_only.label": "المغلقة فقط"
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -193,5 +193,6 @@
   "required_actions.no_more_pending_sanction_checks": "No more pending sanction checks",
   "required_actions.decide_final_status": "Decide final status",
   "filter.include_snoozed.label": "Include snoozed",
-  "filter.exclude_assigned.label": "Exclude assigned"
+  "filter.exclude_assigned.label": "Exclude assigned",
+  "filter.closed_only.label": "Closed only"
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -191,5 +191,6 @@
   "escalate-button.forbidden.hint.admin": "There is no escalation inbox set.",
   "required_actions.review_screening_hits": "Review screening hits ({{count}})",
   "required_actions.no_more_pending_sanction_checks": "No more pending sanction checks",
-  "required_actions.decide_final_status": "Decide final status"
+  "required_actions.decide_final_status": "Decide final status",
+  "filter.include_snoozed.label": "Include snoozed"
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -192,5 +192,6 @@
   "required_actions.review_screening_hits": "Review screening hits ({{count}})",
   "required_actions.no_more_pending_sanction_checks": "No more pending sanction checks",
   "required_actions.decide_final_status": "Decide final status",
-  "filter.include_snoozed.label": "Include snoozed"
+  "filter.include_snoozed.label": "Include snoozed",
+  "filter.exclude_assigned.label": "Exclude assigned"
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -193,6 +193,6 @@
   "required_actions.no_more_pending_sanction_checks": "No more pending sanction checks",
   "required_actions.decide_final_status": "Decide final status",
   "filter.include_snoozed.label": "Include snoozed",
-  "filter.exclude_assigned.label": "Exclude assigned",
+  "filter.exclude_assigned.label": "Unassigned only",
   "filter.closed_only.label": "Closed only"
 }

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -192,5 +192,6 @@
   "required_actions.review_screening_hits": "Filtrage de sanctions ({{count}})",
   "case_detail.history.event_detail.decision_reviewed": "Décision examinée à <Statut /> par <Actor>{{actor}}</Actor>",
   "case_detail.history.event_detail.rule_snooze_created": "Règle désactivée par <Actor>{{actor}}</Actor>",
-  "filter.include_snoozed.label": "Inclure les mis en veille"
+  "filter.include_snoozed.label": "Inclure les mis en veille",
+  "filter.exclude_assigned.label": "Exclure les assignées"
 }

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -191,5 +191,6 @@
   "required_actions.no_more_pending_sanction_checks": "Filtrage de sanction terminé",
   "required_actions.review_screening_hits": "Filtrage de sanctions ({{count}})",
   "case_detail.history.event_detail.decision_reviewed": "Décision examinée à <Statut /> par <Actor>{{actor}}</Actor>",
-  "case_detail.history.event_detail.rule_snooze_created": "Règle désactivée par <Actor>{{actor}}</Actor>"
+  "case_detail.history.event_detail.rule_snooze_created": "Règle désactivée par <Actor>{{actor}}</Actor>",
+  "filter.include_snoozed.label": "Inclure les mis en veille"
 }

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -192,7 +192,7 @@
   "required_actions.review_screening_hits": "Filtrage de sanctions ({{count}})",
   "case_detail.history.event_detail.decision_reviewed": "Décision examinée à <Statut /> par <Actor>{{actor}}</Actor>",
   "case_detail.history.event_detail.rule_snooze_created": "Règle désactivée par <Actor>{{actor}}</Actor>",
-  "filter.include_snoozed.label": "Inclure les mis en veille",
-  "filter.exclude_assigned.label": "Exclure les assignées",
-  "filter.closed_only.label": "Résolu uniquement"
+  "filter.include_snoozed.label": "Voir les rappels",
+  "filter.exclude_assigned.label": "Non assignés",
+  "filter.closed_only.label": "Investigations résolues"
 }

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -193,5 +193,6 @@
   "case_detail.history.event_detail.decision_reviewed": "Décision examinée à <Statut /> par <Actor>{{actor}}</Actor>",
   "case_detail.history.event_detail.rule_snooze_created": "Règle désactivée par <Actor>{{actor}}</Actor>",
   "filter.include_snoozed.label": "Inclure les mis en veille",
-  "filter.exclude_assigned.label": "Exclure les assignées"
+  "filter.exclude_assigned.label": "Exclure les assignées",
+  "filter.closed_only.label": "Résolu uniquement"
 }

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -4,13 +4,9 @@ import { CaseRightPanel } from '@app-builder/components/Cases/CaseRightPanel';
 import {
   type CasesFilters,
   CasesFiltersBar,
-  CasesFiltersMenu,
   CasesFiltersProvider,
   casesFiltersSchema,
 } from '@app-builder/components/Cases/Filters';
-import { casesFilterNames } from '@app-builder/components/Cases/Filters/filters';
-import { FiltersButton } from '@app-builder/components/Filters';
-import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { useCursorPaginatedFetcher } from '@app-builder/hooks/useCursorPaginatedFetcher';
 import { isForbiddenHttpError, isNotFoundHttpError } from '@app-builder/models';
 import { type Case, type CaseStatus } from '@app-builder/models/cases';
@@ -28,7 +24,7 @@ import qs from 'qs';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { omit } from 'remeda';
-import { Button, Checkbox, Input } from 'ui-design-system';
+import { Button, Input } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 import { MY_INBOX_ID } from './_index';
@@ -45,7 +41,7 @@ export const buildQueryParams = (
   return {
     statuses: filters.statuses ?? [],
     name: filters.name,
-    snoozed: filters.snoozed,
+    includeSnoozed: filters.includeSnoozed,
     excludeAssigned: filters.excludeAssigned,
     dateRange: filters.dateRange
       ? filters.dateRange.type === 'static'
@@ -145,35 +141,6 @@ const SearchByName = ({
   );
 };
 
-const ToggleFilter = ({
-  onCheckedChange,
-  field,
-  label,
-  value,
-}: {
-  field: 'excludeAssigned' | 'includeSnoozed' | 'closedOnly';
-  label: string;
-  value: boolean;
-  onCheckedChange: (state: boolean) => void;
-}) => {
-  return (
-    <div className="flex gap-2 p-2">
-      <Checkbox
-        id={field}
-        defaultChecked={value}
-        onCheckedChange={(state) => {
-          if (state !== 'indeterminate') {
-            onCheckedChange(state);
-          }
-        }}
-      />
-      <FormLabel name="field" className="font-medium">
-        {label}
-      </FormLabel>
-    </div>
-  );
-};
-
 export default function Cases() {
   const { t } = useTranslation(casesI18n);
   const {
@@ -262,38 +229,8 @@ export default function Cases() {
                       navigateCasesList({ ...filters, name: value });
                     }}
                   />
-                  <ToggleFilter
-                    field="includeSnoozed"
-                    value={filters.snoozed ?? false}
-                    label={t('cases:include_snoozed')}
-                    onCheckedChange={(snoozed) => {
-                      navigateCasesList({ ...filters, snoozed });
-                    }}
-                  />
-                  <ToggleFilter
-                    field="excludeAssigned"
-                    value={filters.excludeAssigned ?? false}
-                    label={t('cases:exclude_assigned')}
-                    onCheckedChange={(excludeAssigned) => {
-                      navigateCasesList({ ...filters, excludeAssigned });
-                    }}
-                  />
-                  <ToggleFilter
-                    field="closedOnly"
-                    value={filters.statuses?.includes('closed') ?? false}
-                    label={t('cases:closed_only')}
-                    onCheckedChange={(closedOnly) => {
-                      navigateCasesList({
-                        ...filters,
-                        statuses: closedOnly ? ['closed'] : [],
-                      });
-                    }}
-                  />
                 </div>
                 <div className="flex gap-4">
-                  <CasesFiltersMenu filterNames={casesFilterNames}>
-                    <FiltersButton />
-                  </CasesFiltersMenu>
                   <CaseRightPanel.Trigger asChild data={{ inboxId }}>
                     <Button>
                       <Icon icon="plus" className="size-5" />

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -144,28 +144,30 @@ const SearchByName = ({
   );
 };
 
-const ToggleSnoozed = ({
+const ToggleInclude = ({
   onCheckedChange,
-  snoozed,
+  field,
+  label,
+  value,
 }: {
-  snoozed: boolean;
+  field: 'assigned' | 'snoozed';
+  label: string;
+  value: boolean;
   onCheckedChange: (state: boolean) => void;
 }) => {
-  const { t } = useTranslation(['cases']);
-
   return (
     <div className="flex gap-2 p-2">
       <Checkbox
-        id="snoozed"
-        defaultChecked={snoozed}
+        id={field}
+        defaultChecked={value}
         onCheckedChange={(state) => {
           if (state !== 'indeterminate') {
             onCheckedChange(state);
           }
         }}
       />
-      <FormLabel name="snoozed" className="font-medium">
-        {t('cases:include_snoozed')}
+      <FormLabel name="field" className="font-medium">
+        {label}
       </FormLabel>
     </div>
   );
@@ -259,8 +261,10 @@ export default function Cases() {
                       navigateCasesList({ ...filters, name: value });
                     }}
                   />
-                  <ToggleSnoozed
-                    snoozed={filters.snoozed ?? false}
+                  <ToggleInclude
+                    field="snoozed"
+                    value={filters.snoozed ?? false}
+                    label={t('cases:include_snoozed')}
                     onCheckedChange={(snoozed) => {
                       navigateCasesList({ ...filters, snoozed });
                     }}

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -46,6 +46,7 @@ export const buildQueryParams = (
     statuses: filters.statuses ?? [],
     name: filters.name,
     snoozed: filters.snoozed,
+    assigned: filters.assigned,
     dateRange: filters.dateRange
       ? filters.dateRange.type === 'static'
         ? {
@@ -144,7 +145,7 @@ const SearchByName = ({
   );
 };
 
-const ToggleInclude = ({
+const ToggleFilter = ({
   onCheckedChange,
   field,
   label,
@@ -261,12 +262,20 @@ export default function Cases() {
                       navigateCasesList({ ...filters, name: value });
                     }}
                   />
-                  <ToggleInclude
+                  <ToggleFilter
                     field="snoozed"
                     value={filters.snoozed ?? false}
                     label={t('cases:include_snoozed')}
                     onCheckedChange={(snoozed) => {
                       navigateCasesList({ ...filters, snoozed });
+                    }}
+                  />
+                  <ToggleFilter
+                    field="assigned"
+                    value={filters.assigned ?? false}
+                    label={t('cases:include_assigned')}
+                    onCheckedChange={(assigned) => {
+                      navigateCasesList({ ...filters, assigned });
                     }}
                   />
                 </div>

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -46,7 +46,7 @@ export const buildQueryParams = (
     statuses: filters.statuses ?? [],
     name: filters.name,
     snoozed: filters.snoozed,
-    assigned: filters.assigned,
+    excludeAssigned: filters.excludeAssigned,
     dateRange: filters.dateRange
       ? filters.dateRange.type === 'static'
         ? {
@@ -151,7 +151,7 @@ const ToggleFilter = ({
   label,
   value,
 }: {
-  field: 'assigned' | 'snoozed';
+  field: 'excludeAssigned' | 'includeSnoozed';
   label: string;
   value: boolean;
   onCheckedChange: (state: boolean) => void;
@@ -263,7 +263,7 @@ export default function Cases() {
                     }}
                   />
                   <ToggleFilter
-                    field="snoozed"
+                    field="includeSnoozed"
                     value={filters.snoozed ?? false}
                     label={t('cases:include_snoozed')}
                     onCheckedChange={(snoozed) => {
@@ -271,11 +271,11 @@ export default function Cases() {
                     }}
                   />
                   <ToggleFilter
-                    field="assigned"
-                    value={filters.assigned ?? false}
-                    label={t('cases:include_assigned')}
-                    onCheckedChange={(assigned) => {
-                      navigateCasesList({ ...filters, assigned });
+                    field="excludeAssigned"
+                    value={filters.excludeAssigned ?? false}
+                    label={t('cases:exclude_assigned')}
+                    onCheckedChange={(excludeAssigned) => {
+                      navigateCasesList({ ...filters, excludeAssigned });
                     }}
                   />
                 </div>

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -151,7 +151,7 @@ const ToggleFilter = ({
   label,
   value,
 }: {
-  field: 'excludeAssigned' | 'includeSnoozed';
+  field: 'excludeAssigned' | 'includeSnoozed' | 'closedOnly';
   label: string;
   value: boolean;
   onCheckedChange: (state: boolean) => void;
@@ -276,6 +276,17 @@ export default function Cases() {
                     label={t('cases:exclude_assigned')}
                     onCheckedChange={(excludeAssigned) => {
                       navigateCasesList({ ...filters, excludeAssigned });
+                    }}
+                  />
+                  <ToggleFilter
+                    field="closedOnly"
+                    value={filters.statuses?.includes('closed') ?? false}
+                    label={t('cases:closed_only')}
+                    onCheckedChange={(closedOnly) => {
+                      navigateCasesList({
+                        ...filters,
+                        statuses: closedOnly ? ['closed'] : [],
+                      });
                     }}
                   />
                 </div>

--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -239,7 +239,7 @@ export default function Cases() {
                   </CaseRightPanel.Trigger>
                 </div>
               </div>
-              <CasesFiltersBar />
+              <CasesFiltersBar excludedFilters={!inboxId ? ['excludeAssigned'] : undefined} />
               <CasesList
                 key={inboxId}
                 cases={cases}

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -50,6 +50,13 @@
         schema:
           type: boolean
           default: false
+      - name: exclude_assigned
+        description: Exclude cases that are assigned
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
       - name: assignee_id
         description: Include cases that are assigned to a specific user
         in: query

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1164,7 +1164,7 @@ export function createDecision(createDecisionBody: CreateDecisionBody, opts?: Oa
 /**
  * List cases
  */
-export function listCases({ status, inboxId, startDate, endDate, sorting, name, offsetId, limit, order, includeSnoozed, assigneeId }: {
+export function listCases({ status, inboxId, startDate, endDate, sorting, name, offsetId, limit, order, includeSnoozed, excludeAssigned, assigneeId }: {
     status?: CaseStatusDto[];
     inboxId?: string[];
     startDate?: string;
@@ -1175,6 +1175,7 @@ export function listCases({ status, inboxId, startDate, endDate, sorting, name, 
     limit?: number;
     order?: "ASC" | "DESC";
     includeSnoozed?: boolean;
+    excludeAssigned?: boolean;
     assigneeId?: string;
 } = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
@@ -1199,6 +1200,7 @@ export function listCases({ status, inboxId, startDate, endDate, sorting, name, 
         limit,
         order,
         include_snoozed: includeSnoozed,
+        exclude_assigned: excludeAssigned,
         assignee_id: assigneeId
     }))}`, {
         ...opts


### PR DESCRIPTION
🛠 Rework of the Inboxes Page Filters UI

Changes:
 - Removed the first headline containing filter information and consolidated all filter-related UI into the second headline.
 - The second headline is now always visible.
 - Introduced a new SimpleFilter entity and component for filters that don’t require additional settings.
 - When no filters are applied, a “Filters” button is shown on the left side of the filter bar.
When filters are active, a “New filter” button appears after the list of applied filters instead.