### PR TITLE
fix(cases): filter out closed cases when no statuses are provided

### DIFF
--- a/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/inboxes.$inboxId.tsx
@@ -9,7 +9,7 @@ import {
 } from '@app-builder/components/Cases/Filters';
 import { useCursorPaginatedFetcher } from '@app-builder/hooks/useCursorPaginatedFetcher';
 import { isForbiddenHttpError, isNotFoundHttpError } from '@app-builder/models';
-import { type Case, type CaseStatus } from '@app-builder/models/cases';
+import { type Case, type CaseStatus, caseStatuses } from '@app-builder/models/cases';
 import { type PaginatedResponse, type PaginationParams } from '@app-builder/models/pagination';
 import { type CaseFilters } from '@app-builder/repositories/CaseRepository';
 import { initServerServices } from '@app-builder/services/init.server';
@@ -91,7 +91,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     ...parsedQuery.data,
     ...parsedPaginationQuery.data,
     ...(inboxId && { inboxIds: [inboxId] }),
-    statuses: parsedQuery.data.statuses as CaseStatus[] | undefined,
+    // If no statuses filter is provided, we filter out closed cases
+    statuses:
+      (parsedQuery.data.statuses as CaseStatus[]) ??
+      caseStatuses.filter((status) => status !== 'closed'),
     ...(!inboxId && { assigneeId: user.actorIdentity.userId }),
   };
 


### PR DESCRIPTION
Add a fallback statuses filter (all except “resolved”) when no filter is selected.
Currently, only the “resolved” (closed) filter is available.

With this change:
 - If no status filter is applied, the list defaults to all cases except resolved.
 - If the “resolved” filter is selected, only resolved cases are shown.