### PR TITLE
feat(data-model): Hide not linked rows

### DIFF
--- a/packages/app-builder/src/locales/ar/data.json
+++ b/packages/app-builder/src/locales/ar/data.json
@@ -72,5 +72,6 @@
   "create_navigation_option.labels.to": "ل",
   "create_navigation_option.placeholders.ordered_by": "اختار حقل",
   "create_navigation_option.title": "إنشاء خيار التنقل",
-  "create_navigation_option.explanation_text": "حدد الحقل المستخدم لفرز البيانات بشكل افتراضي. \nيمكن أن يكون حسب التاريخ ، الاسم ... للكائنات التي تحتوي على الكثير من البيانات ، مثل المعاملات ، نوصي باستخدام تاريخ حدث الحدث."
+  "create_navigation_option.explanation_text": "حدد الحقل المستخدم لفرز البيانات بشكل افتراضي. \nيمكن أن يكون حسب التاريخ ، الاسم ... للكائنات التي تحتوي على الكثير من البيانات ، مثل المعاملات ، نوصي باستخدام تاريخ حدث الحدث.",
+  "table.no_linked_fields.label": "لا حقول مرتبطة"
 }

--- a/packages/app-builder/src/locales/en/data.json
+++ b/packages/app-builder/src/locales/en/data.json
@@ -72,5 +72,6 @@
   "create_navigation_option.labels.to": "To",
   "create_navigation_option.labels.ordered_by": "Ordered by",
   "create_navigation_option.placeholders.ordered_by": "Chose a field",
-  "create_navigation_option.explanation_text": "Select the field used for sorting the data by default. It can be by date, name... For objects containing a lot of data, like transactions, we recommend using the date the event happened."
+  "create_navigation_option.explanation_text": "Select the field used for sorting the data by default. It can be by date, name... For objects containing a lot of data, like transactions, we recommend using the date the event happened.",
+  "table.no_linked_fields.label": "No linked fields"
 }

--- a/packages/app-builder/src/locales/fr/data.json
+++ b/packages/app-builder/src/locales/fr/data.json
@@ -72,5 +72,6 @@
   "create_navigation_option.labels.to": "Vers",
   "create_navigation_option.labels.ordered_by": "Ordonnés par",
   "create_navigation_option.placeholders.ordered_by": "Choisissez un champs",
-  "create_navigation_option.explanation_text": "Sélectionnez le champ utilisé pour trier les données par défaut. Cela peut être par date, nom... Pour les objets contenant beaucoup de données, comme les transactions, nous vous recommandons d'utiliser la date à laquelle l'événement s'est produit."
+  "create_navigation_option.explanation_text": "Sélectionnez le champ utilisé pour trier les données par défaut. Cela peut être par date, nom... Pour les objets contenant beaucoup de données, comme les transactions, nous vous recommandons d'utiliser la date à laquelle l'événement s'est produit.",
+  "table.no_linked_fields.label": "Pas de champs liés"
 }


### PR DESCRIPTION
Hide unlinked fields in table model view by default

Introduces a filter to display only fields with links in the table model node, improving focus on relevant data relationships. Adds a toggle to show or hide unlinked fields and displays a message when no linked fields are present. Enhances usability for users working with complex data models.