### PR TITLE
fix(menu): prevent unwanted main menu toggling behavior

### DIFF
--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
@@ -19,6 +19,8 @@ import {
 import { initServerServices } from '@app-builder/services/init.server';
 import { badRequest } from '@app-builder/utils/http/http-responses';
 import { parseIdParamSafe } from '@app-builder/utils/input-validation';
+import { getPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookie-read.server';
+import { setPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookies-write';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { type LoaderFunctionArgs, redirect, type SerializeFrom } from '@remix-run/node';
@@ -198,6 +200,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     decisionsPromise,
     rulesByPivotPromise,
     entitlements,
+    isMenuExpanded: getPreferencesCookie(request, 'menuExpd'),
   });
 };
 
@@ -256,6 +259,7 @@ export default function CaseManagerIndexPage() {
     pivotObjects,
     currentUser,
     nextCaseId,
+    isMenuExpanded,
   } = useLoaderData<typeof loader>();
   const { t } = useTranslation(casesI18n);
   const navigate = useNavigate();
@@ -266,8 +270,11 @@ export default function CaseManagerIndexPage() {
   );
 
   useEffect(() => {
-    leftSidebarSharp.actions.setExpanded(false);
-  }, [leftSidebarSharp]);
+    if (isMenuExpanded) {
+      leftSidebarSharp.actions.setExpanded(false);
+      setPreferencesCookie('menuExpd', false);
+    }
+  }, [isMenuExpanded, leftSidebarSharp]);
 
   return (
     <Page.Main>


### PR DESCRIPTION
The Case Manager page forces the main menu to fold on load to maximize space for case data.
Previously, this was done unconditionally, ignoring the user’s display preference stored in a cookie.

This caused inconsistent behavior—such as unexpected menu toggling—especially when the user refreshed the page.

With this change:
	•	The menu is folded only if it was previously open.
	•	This override is persisted in the cookie to maintain consistency across navigation and page refreshes.
	•	If the menu was already folded, no changes are made.