### PR TITLE
refactor:  use named export in Code component

### DIFF
--- a/packages/app-builder/src/components/Data/PivotDetails.tsx
+++ b/packages/app-builder/src/components/Data/PivotDetails.tsx
@@ -1,7 +1,7 @@
 import { type Pivot } from '@app-builder/models/data-model';
 import { getPivotDisplayValue } from '@app-builder/services/data/pivot';
-import Code from 'packages/ui-design-system/src/Code/Code';
 import { Trans, useTranslation } from 'react-i18next';
+import { Code } from 'ui-design-system';
 
 import { dataI18n } from './data-i18n';
 

--- a/packages/app-builder/src/routes/ressources+/data+/create-pivot.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/create-pivot.tsx
@@ -12,11 +12,10 @@ import { initServerServices } from '@app-builder/services/init.server';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, json } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
-import Code from 'packages/ui-design-system/src/Code/Code';
 import { useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
-import { Modal } from 'ui-design-system';
+import { Code, Modal } from 'ui-design-system';
 import { z } from 'zod';
 
 import { SelectField } from './create-pivot/selectField';

--- a/packages/app-builder/src/routes/ressources+/data+/create-pivot/SelectLinkPath.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/create-pivot/SelectLinkPath.tsx
@@ -3,10 +3,9 @@ import { type TableModel } from '@app-builder/models/data-model';
 import { type LinkPivotOption } from '@app-builder/services/data/pivot';
 import { handleSubmit } from '@app-builder/utils/form';
 import { useForm, useStore } from '@tanstack/react-form';
-import Code from 'packages/ui-design-system/src/Code/Code';
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Button, MenuCommand } from 'ui-design-system';
+import { Button, Code, MenuCommand } from 'ui-design-system';
 
 export function SelectLinkPath({
   pivotOptions,

--- a/packages/app-builder/src/routes/ressources+/data+/create-pivot/SelectTargetEntity.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/create-pivot/SelectTargetEntity.tsx
@@ -5,10 +5,9 @@ import { pivotValuesDocHref } from '@app-builder/services/documentation-href';
 import { handleSubmit } from '@app-builder/utils/form';
 import * as Sentry from '@sentry/remix';
 import { useForm, useStore } from '@tanstack/react-form';
-import Code from 'packages/ui-design-system/src/Code/Code';
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Button, MenuCommand, Modal } from 'ui-design-system';
+import { Button, Code, MenuCommand, Modal } from 'ui-design-system';
 
 export function SelectTargetEntity({
   pivotOptions,

--- a/packages/app-builder/src/routes/ressources+/data+/create-pivot/ValidateSelfPivot.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/create-pivot/ValidateSelfPivot.tsx
@@ -1,8 +1,7 @@
 import { type TableModel } from '@app-builder/models/data-model';
 import { type FieldPivotOption } from '@app-builder/services/data/pivot';
-import Code from 'packages/ui-design-system/src/Code/Code';
 import { Trans, useTranslation } from 'react-i18next';
-import { Button } from 'ui-design-system';
+import { Button, Code } from 'ui-design-system';
 
 export function ValidateSelfPivot({
   pivotOption,

--- a/packages/app-builder/src/routes/ressources+/data+/create-pivot/selectField.tsx
+++ b/packages/app-builder/src/routes/ressources+/data+/create-pivot/selectField.tsx
@@ -3,10 +3,9 @@ import type { TableModel } from '@app-builder/models/data-model';
 import { type FieldPivotOption } from '@app-builder/services/data/pivot';
 import { handleSubmit } from '@app-builder/utils/form';
 import { useForm, useStore } from '@tanstack/react-form';
-import Code from 'packages/ui-design-system/src/Code/Code';
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Button, MenuCommand, Modal } from 'ui-design-system';
+import { Button, Code, MenuCommand, Modal } from 'ui-design-system';
 
 export function SelectField({
   pivotOptions,

--- a/packages/ui-design-system/src/Code/Code.stories.tsx
+++ b/packages/ui-design-system/src/Code/Code.stories.tsx
@@ -2,7 +2,7 @@
 
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import Code from './Code';
+import { Code } from './Code';
 
 const meta: Meta<typeof Code> = {
   title: 'Code',

--- a/packages/ui-design-system/src/Code/Code.tsx
+++ b/packages/ui-design-system/src/Code/Code.tsx
@@ -4,8 +4,6 @@ interface CodeProps {
   children?: React.ReactNode;
 }
 
-const Code: React.FC<CodeProps> = ({ children }) => (
+export const Code: React.FC<CodeProps> = ({ children }) => (
   <span className="bg-grey-90 rounded-md px-[.2em] py-[.1em]">{children}</span>
 );
-
-export default Code;


### PR DESCRIPTION
Unifies import style across the codebase by switching from default to named exports for the Code component.
Simplifies imports for improved consistency and maintainability.