### PR TITLE
feat: Improves layout and wrapping for match card content

### DIFF
--- a/packages/app-builder/src/components/Sanctions/MatchCard.tsx
+++ b/packages/app-builder/src/components/Sanctions/MatchCard.tsx
@@ -48,11 +48,11 @@ export const MatchCard = ({ match, readonly, unreviewable, defaultOpen }: MatchC
                 <span>{t(`sanctions:entity.schema.${entitySchema}`)}</span>
                 <Tag color="grey">
                   {t('sanctions:match.similarity', {
-                    percent: Math.round(match.payload.score * 100),
+                    percent: Math.round(entity.score * 100),
                   })}
                 </Tag>
                 <span className="col-span-full flex w-full flex-wrap gap-1">
-                  {match.payload.properties['topics']?.map((topic) => (
+                  {entity.properties['topics']?.map((topic) => (
                     <TopicTag key={`${match.id}-${topic}`} topic={topic} />
                   ))}
                 </span>

--- a/packages/app-builder/src/components/Sanctions/MatchCard.tsx
+++ b/packages/app-builder/src/components/Sanctions/MatchCard.tsx
@@ -43,7 +43,7 @@ export const MatchCard = ({ match, readonly, unreviewable, defaultOpen }: MatchC
                 aria-hidden
                 className="size-5 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180 group-data-[initial]:rotate-180 rtl:-rotate-90 rtl:group-aria-expanded:-rotate-180 rtl:group-data-[initial]:-rotate-180"
               />
-              <div className="text-s flex items-center gap-2">
+              <div className="text-s flex flex-wrap items-center gap-x-2 gap-y-1">
                 <span className="font-semibold">{entity.caption}</span>
                 <span>{t(`sanctions:entity.schema.${entitySchema}`)}</span>
                 <Tag color="grey">
@@ -61,7 +61,7 @@ export const MatchCard = ({ match, readonly, unreviewable, defaultOpen }: MatchC
                 <EnrichMatchButton matchId={match.id} />
               </div>
             ) : null}
-            <div className="inline-flex h-8">
+            <div className="inline-flex h-8 text-nowrap">
               {unreviewable ? (
                 <Tag border="square" color="grey">
                   {t('sanctions:match.not_reviewable')}

--- a/packages/app-builder/src/components/Sanctions/MatchCard.tsx
+++ b/packages/app-builder/src/components/Sanctions/MatchCard.tsx
@@ -51,9 +51,11 @@ export const MatchCard = ({ match, readonly, unreviewable, defaultOpen }: MatchC
                     percent: Math.round(match.payload.score * 100),
                   })}
                 </Tag>
-                {match.payload.properties['topics']?.map((topic) => (
-                  <TopicTag key={`${match.id}-${topic}`} topic={topic} />
-                ))}
+                <span className="col-span-full flex w-full flex-wrap gap-1">
+                  {match.payload.properties['topics']?.map((topic) => (
+                    <TopicTag key={`${match.id}-${topic}`} topic={topic} />
+                  ))}
+                </span>
               </div>
             </CollapsibleV2.Title>
             {!match.enriched ? (

--- a/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/decisions+/$decisionId.tsx
@@ -37,7 +37,7 @@ import { Icon } from 'ui-icons';
 import * as z from 'zod';
 
 export const handle = {
-  i18n: ['common', 'navigation', ...decisionsI18n] satisfies Namespace,
+  i18n: ['common', 'navigation', 'screeningTopics', ...decisionsI18n] satisfies Namespace,
   BreadCrumbs: [
     ({ isLast }: BreadCrumbProps) => {
       const { t } = useTranslation(['decisions']);


### PR DESCRIPTION
Display tags on two lines if needed.
**Before:**
<img width="736" alt="image" src="https://github.com/user-attachments/assets/351ba98c-2fb5-4d5f-a81d-644184bb6c90" />

**After:**
![image](https://github.com/user-attachments/assets/66bbfb3b-1648-4400-9bb9-b3690283c312)

