### PR TITLE
feat(case manager): handle navigation creating pending status MAR-1027

### DIFF
--- a/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotNavigationOptions.tsx
+++ b/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotNavigationOptions.tsx
@@ -53,6 +53,7 @@ export function PivotNavigationOptions({
                       {navigationOptions.length > 1 ? ` (${navOption.orderingFieldName})` : null}
                     </div>
                     <Button
+                      disabled={navOption.status === 'pending'}
                       size="small"
                       variant="secondary"
                       onClick={() => {
@@ -69,8 +70,14 @@ export function PivotNavigationOptions({
                       }}
                       className="flex items-center gap-1"
                     >
-                      {t('cases:case_detail.pivot_panel.explore')}
-                      <Icon icon="arrow-up-right" className="size-4" />
+                      {navOption.status === 'pending'
+                        ? t('cases:case_detail.pivot_panel.explore_waiting_creation')
+                        : t('cases:case_detail.pivot_panel.explore')}
+                      {navOption.status === 'pending' ? (
+                        <Icon icon="spinner" className="size-4 animate-spin" />
+                      ) : (
+                        <Icon icon="arrow-up-right" className="size-4" />
+                      )}
                     </Button>
                   </Fragment>
                 ))}

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -200,5 +200,6 @@
   "annotations.popover.annotate.title": "علق",
   "required_actions.see_screening_hits": "انظر أغاني الفحص ({{count}})",
   "case_detail.history.event_type.entity_annotated": "التعليقات التوضيحية",
-  "case_detail.history.event_detail.entity_annotated": "قام <Actor>{{actor}}</Actor> بشرح <ObjectType>{{objectType}}</ObjectType> باستخدام <Type>{{type}}</Type>"
+  "case_detail.history.event_detail.entity_annotated": "قام <Actor>{{actor}}</Actor> بشرح <ObjectType>{{objectType}}</ObjectType> باستخدام <Type>{{type}}</Type>",
+  "case_detail.pivot_panel.explore_waiting_creation": "الانتظار الخلق"
 }

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -107,6 +107,7 @@
   "case_detail.pivot_panel.less_data": "View less",
   "case_detail.pivot_panel.more_data": "View more",
   "case_detail.pivot_panel.explore": "Explore data",
+  "case_detail.pivot_panel.explore_waiting_creation": "Still indexing data",
   "case_detail.pivot_panel.case_history": "Client cases history",
   "case_detail.pivot_panel.breadcrumb_client": "Client {{clientName}}",
   "case_detail.pivot_panel.breadcrumb_explore": "Explore data",

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -200,5 +200,6 @@
   "annotations.popover.annotate.title": "Annoter",
   "required_actions.see_screening_hits": "Voir les sanctions ({{count}})",
   "case_detail.history.event_detail.entity_annotated": "<Actor>{{actor}}</Actor> a annoté <ObjectType>{{objectType}}</ObjectType> avec un <Type>{{type}}</Type>",
-  "case_detail.history.event_type.entity_annotated": "Annotation"
+  "case_detail.history.event_type.entity_annotated": "Annotation",
+  "case_detail.pivot_panel.explore_waiting_creation": "Donnée en cours d'indexation"
 }


### PR DESCRIPTION
Display a waiting creation button if the index status is pending:
<img width="284" alt="image" src="https://github.com/user-attachments/assets/927541ab-ffea-48cf-9496-bf0300b0a85a" />
