### PR TITLE
fix(screening): display sticky banner under popover elements on CRUD page

### DIFF
--- a/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanctions.$sanctionId.tsx
+++ b/packages/app-builder/src/routes/_builder+/scenarios+/$scenarioId+/i+/$iterationId+/sanctions.$sanctionId.tsx
@@ -296,7 +296,7 @@ export default function SanctionDetail() {
           <form className="relative flex max-w-[800px] flex-col" onSubmit={handleSubmit(form)}>
             <div
               className={cn(
-                'bg-purple-99 sticky top-0 z-[60] flex h-[88px] items-center justify-between gap-4',
+                'bg-purple-99 sticky top-0 z-40 flex h-[88px] items-center justify-between gap-4',
                 {
                   'border-b-grey-90 border-b': !intersection?.isIntersecting,
                 },

--- a/packages/ui-design-system/src/MenuCommand/MenuCommand.tsx
+++ b/packages/ui-design-system/src/MenuCommand/MenuCommand.tsx
@@ -213,7 +213,7 @@ function MenuArrow() {
   return <Icon icon="caret-down" className="size-4 shrink-0" />;
 }
 
-const contentClassname = cva('flex z-50 text-s', {
+const contentClassname = cva('flex z-[99] text-s', {
   variants: {
     hover: {
       true: 'max-h-[min(var(--radix-hover-card-content-available-height),_500px)]',
@@ -227,7 +227,7 @@ const contentClassname = cva('flex z-50 text-s', {
 
 const commandClassname = cva(
   [
-    'flex flex-col z-50 w-full flex-1 overflow-hidden',
+    'flex flex-col z-[99] w-full flex-1 overflow-hidden',
     'bg-grey-100 border-grey-90 rounded border shadow-md outline-none',
     'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
     'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',

--- a/packages/ui-design-system/src/MenuCommand/MenuCommand.tsx
+++ b/packages/ui-design-system/src/MenuCommand/MenuCommand.tsx
@@ -213,7 +213,7 @@ function MenuArrow() {
   return <Icon icon="caret-down" className="size-4 shrink-0" />;
 }
 
-const contentClassname = cva('flex z-[99] text-s', {
+const contentClassname = cva('flex z-50 text-s', {
   variants: {
     hover: {
       true: 'max-h-[min(var(--radix-hover-card-content-available-height),_500px)]',
@@ -227,7 +227,7 @@ const contentClassname = cva('flex z-[99] text-s', {
 
 const commandClassname = cva(
   [
-    'flex flex-col z-[99] w-full flex-1 overflow-hidden',
+    'flex flex-col z-50 w-full flex-1 overflow-hidden',
     'bg-grey-100 border-grey-90 rounded border shadow-md outline-none',
     'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
     'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',

--- a/packages/ui-design-system/src/Modal/Modal.tsx
+++ b/packages/ui-design-system/src/Modal/Modal.tsx
@@ -31,13 +31,13 @@ const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(function Moda
 ) {
   return (
     <Dialog.Portal>
-      <Dialog.Overlay className="animate-overlayShow bg-grey-00/20 fixed inset-0 z-[98] flex items-center justify-center p-4 backdrop-blur-sm" />
+      <Dialog.Overlay className="animate-overlayShow bg-grey-00/20 fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" />
       <Dialog.Content
         ref={ref}
         {...props}
         className={modalContentClassnames({
           size,
-          className: clsx('fixed left-1/2 z-[99] -translate-x-1/2', className),
+          className: clsx('fixed left-1/2 z-50 -translate-x-1/2', className),
         })}
       />
     </Dialog.Portal>


### PR DESCRIPTION
Fixes an issue introduced in PR #909  where the Modal’s z-index is too high, causing the MenuCommand selector to be rendered behind it.

This PR does :
- Revert the z-index changes on Modal component to prevent any regression on the UI.
- Decrease z-index on the sticky banner on sanction check rule CRUD page

### Before
<img width="504" alt="Screenshot 2025-06-19 at 15 50 16" src="https://github.com/user-attachments/assets/49159a4b-9d86-44ad-abf1-22f0203e80d7" />
<img width="964" alt="image" src="https://github.com/user-attachments/assets/a62b6ad8-5317-48b6-bd9c-2a692ef23878" />
---------------------------------------------------------------------------------------

### After
<img width="542" alt="image" src="https://github.com/user-attachments/assets/d02e9964-7a3a-4c34-b8fa-d79e258eea00" />
<img width="967" alt="image" src="https://github.com/user-attachments/assets/b891b9f9-e7ba-4494-b807-783fa657f3e5" />

refs: https://linear.app/marble-eu/issue/MAR-1092
