### PR TITLE
fix(build): use legacy pnpm deploy behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
       export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) && \
       pnpm --filter=app-builder run build
 ENV NODE_ENV=production
-RUN pnpm --filter=app-builder --prod deploy /prod/app-builder
+RUN pnpm --legacy --filter=app-builder --prod deploy /prod/app-builder
 
 FROM gcr.io/distroless/nodejs22-debian12 AS app-builder
 ENV NODE_ENV=production

--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -7,7 +7,7 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter=app-builder run build
-RUN pnpm --filter=app-builder --prod deploy /prod/app-builder
+RUN pnpm --legacy --filter=app-builder --prod deploy /prod/app-builder
 
 FROM gcr.io/distroless/nodejs22-debian12 AS app-builder
 ENV PORT=${PORT:-8080}


### PR DESCRIPTION
> By default, the deploy command only works with workspaces that have the inject-workspace-packages setting set to true. If you want to use deploy without "injected dependencies", use the --legacy flag or set force-legacy-deploy to true.

https://pnpm.io/cli/deploy