### PR TITLE
chore: update Biome config schema version

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
The `biome migrate` command was missing in the previous #950 PR.

`Biome check` command spotted the mismatch :
```
biome check
biome.json:2:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ The configuration schema version does not match the CLI version 2.0.5

    1 │ {
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │   "vcs": {
    4 │     "enabled": true,

  ℹ   Expected:                     2.0.5
      Found:                        2.0.0


  ℹ Run the command biome migrate to migrate the configuration file.


Checked 879 files in 105ms. No fixes applied.
Found 1 warning.
```