### PR TITLE
fix(screening): allow no_hit screening to have no request

### DIFF
--- a/packages/app-builder/src/components/Sanctions/SanctionReview.tsx
+++ b/packages/app-builder/src/components/Sanctions/SanctionReview.tsx
@@ -3,6 +3,7 @@ import {
   isSanctionCheckError,
   isSanctionCheckReviewCompleted,
   type SanctionCheck,
+  SanctionCheckSuccess,
 } from '@app-builder/models/sanction-check';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,7 +53,7 @@ export function SanctionReviewSection({
           .when(isSanctionCheckError, (sc) => <SanctionCheckErrors sanctionCheck={sc} />)
           .when(
             (sc) => sc.status === 'in_review' && sc.partial,
-            (sc) => (
+            (sc: SanctionCheckSuccess) => (
               <div className="text-s bg-red-95 text-red-47 flex items-center gap-2 rounded p-2">
                 <Icon icon="error" className="size-5 shrink-0" />
                 {t('sanctions:callout.needs_refine', {

--- a/packages/app-builder/src/models/sanction-check.ts
+++ b/packages/app-builder/src/models/sanction-check.ts
@@ -158,12 +158,16 @@ export type SanctionCheckError = BaseSanctionCheck & {
   request: SanctionCheckRequest | null;
   errorCodes: SanctionCheckErrorDto['error_codes'];
 };
+export type SanctionCheckNoHit = BaseSanctionCheck & {
+  status: 'no_hit';
+  request: SanctionCheckRequest | null;
+};
 export type SanctionCheckSuccess = BaseSanctionCheck & {
-  status: Exclude<SanctionCheckStatus, 'error'>;
+  status: Exclude<SanctionCheckStatus, 'error | no_hit'>;
   request: SanctionCheckRequest;
 };
 
-export type SanctionCheck = SanctionCheckError | SanctionCheckSuccess;
+export type SanctionCheck = SanctionCheckError | SanctionCheckSuccess | SanctionCheckNoHit;
 
 export function adaptSanctionCheck(dto: SanctionCheckDto): SanctionCheck {
   const baseSanctionCheck: BaseSanctionCheck = {
@@ -181,6 +185,14 @@ export function adaptSanctionCheck(dto: SanctionCheckDto): SanctionCheck {
       status: dto.status,
       request: dto.request ? adaptSanctionCheckRequest(dto.request) : null,
       errorCodes: dto.error_codes,
+    };
+  }
+
+  if (dto.status === 'no_hit') {
+    return {
+      ...baseSanctionCheck,
+      status: dto.status,
+      request: dto.request ? adaptSanctionCheckRequest(dto.request) : null,
     };
   }
 

--- a/packages/marble-api/openapis/marblecore-api/sanction-checks.yml
+++ b/packages/marble-api/openapis/marblecore-api/sanction-checks.yml
@@ -294,6 +294,7 @@ components:
       type: object
       anyOf:
         - $ref: '#/components/schemas/SanctionCheckSuccessDto'
+        - $ref: '#/components/schemas/SanctionCheckNoHitDto'
         - $ref: '#/components/schemas/SanctionCheckErrorDto'
     SanctionCheckSuccessDto:
       type: object
@@ -322,7 +323,44 @@ components:
           format: uuid
         status:
           type: string
-          enum: ['in_review', 'confirmed_hit', 'no_hit']
+          enum: ['in_review', 'confirmed_hit']
+        request:
+          $ref: '#/components/schemas/SanctionCheckRequestDto'
+        partial:
+          type: boolean
+        is_manual:
+          type: boolean
+        matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/SanctionCheckMatchDto'
+    SanctionCheckNoHitDto:
+      type: object
+      required:
+        - id
+        - config
+        - decision_id
+        - status
+        - partial
+        - is_manual
+        - matches
+      properties:
+        id:
+          type: string
+          format: uuid
+        config:
+          type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+        decision_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: ['no_hit']
         request:
           $ref: '#/components/schemas/SanctionCheckRequestDto'
         partial:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -785,7 +785,7 @@ export type SanctionCheckSuccessDto = {
         name: string;
     };
     decision_id: string;
-    status: "in_review" | "confirmed_hit" | "no_hit";
+    status: "in_review" | "confirmed_hit";
     request: SanctionCheckRequestDto;
     partial: boolean;
     is_manual: boolean;
@@ -804,7 +804,18 @@ export type SanctionCheckErrorDto = {
     matches: SanctionCheckMatchDto[];
     error_codes: "all_fields_null_or_empty"[];
 };
-export type SanctionCheckDto = SanctionCheckSuccessDto | SanctionCheckErrorDto;
+export type SanctionCheckDto = SanctionCheckSuccessDto | {
+    id: string;
+    config: {
+        name: string;
+    };
+    decision_id: string;
+    status: "no_hit";
+    request?: SanctionCheckRequestDto;
+    partial: boolean;
+    is_manual: boolean;
+    matches: SanctionCheckMatchDto[];
+} | SanctionCheckErrorDto;
 export type OpenSanctionsCatalogDataset = {
     name: string;
     title: string;


### PR DESCRIPTION
With trigger bail out from the sanction it is possible to have screenings with a status of "no_hit" but no request.