### PR TITLE
feat(decisions): Improve data fetching

### DIFF
--- a/packages/app-builder/src/services/decisions/details.spec.ts
+++ b/packages/app-builder/src/services/decisions/details.spec.ts
@@ -4,7 +4,7 @@ import type { SanctionCheck } from '@app-builder/models/sanction-check';
 import type { ScenarioIterationRule } from '@app-builder/models/scenario-iteration-rule';
 import * as Sentry from '@sentry/remix';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DecisionDetailsData, DecisionDetailsRepositories } from './details';
+import type { DecisionDetailsRepositories } from './details';
 import { createDecisionDetailsService } from './details';
 
 // Mock Response class since @remix-run/node doesn't export it
@@ -42,60 +42,15 @@ describe('DecisionDetailsService', () => {
     mockDecision = {
       id: 'decision-123',
       scenario: {
-        id: 'scenario-789',
         scenarioIterationId: 'iteration-456',
-        name: 'Test Scenario',
-        version: 1,
       },
-      outcome: 'approve',
-      reviewStatus: 'pending',
-      createdAt: new Date('2023-01-01T00:00:00Z'),
-      triggerObject: {
-        object_id: 'trigger-123',
-        payment_method: 'TRANSFER',
-        direction: 'PAYOUT',
-        value: 100.5,
-      },
-      triggerObjectType: 'transactions',
-      score: 85,
-      rules: [
-        {
-          name: 'Test Rule',
-          ruleId: 'rule-123',
-          description: 'Test rule description',
-          evaluation: {},
-          outcome: 'hit',
-          scoreModifier: 10,
-        },
-      ],
-      case: null,
-      scheduledExecutionId: 'schedule-123',
-      pivotValues: [
-        {
-          id: 'pivot-value-1',
-          value: 'test-value',
-        },
-      ],
     } as unknown as DecisionDetails;
 
     // Create mock scenario rules
     mockScenarioRules = [
       {
         id: 'rule-1',
-        scenarioIterationId: 'iteration-456',
-        displayOrder: 0,
         name: 'Test Rule 1',
-        description: 'Test rule description',
-        ruleGroup: 'Checklist',
-        formula: {
-          id: 'formula-1',
-          name: 'Or',
-          constant: undefined,
-          children: [],
-          namedChildren: {},
-        },
-        scoreModifier: 10,
-        createdAt: new Date('2023-01-01T00:00:00Z'),
       },
     ] as unknown as ScenarioIterationRule[];
 
@@ -103,10 +58,6 @@ describe('DecisionDetailsService', () => {
     mockPivots = [
       {
         id: 'pivot-1',
-        field: 'test_field',
-        type: 'STRING',
-        createdAt: new Date('2023-01-01T00:00:00Z'),
-        updatedAt: new Date('2023-01-01T00:00:00Z'),
       },
     ] as unknown as Pivot[];
 
@@ -114,80 +65,24 @@ describe('DecisionDetailsService', () => {
     mockSanctionCheck = [
       {
         id: 'sanction-check-1',
-        config: {
-          name: 'Sanction Check',
-        },
-        decisionId: 'decision-123',
-        partial: false,
-        isManual: false,
-        status: 'confirmed_hit',
-        request: {
-          threshold: 70,
-          limit: 30,
-          queries: {
-            '898498bd-cd73-4706-8f1f-1883b9dae779': {
-              schema: 'Person',
-              properties: {
-                name: ['Voldemor Poutine'],
-              },
-            },
-          },
-        },
         matches: [
           {
-            id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
-            entityId: 'Q7747',
-            queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
-            status: 'confirmed_hit',
-            enriched: true,
+            id: 'match-1',
             payload: {
-              id: 'Q7747',
-              match: true,
-              score: 1,
-              schema: 'Person',
-              caption: 'Voldemor Poutine',
-              datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+              // datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+              datasets: ['GB FCDO Sanctions', 'US OFAC SDN', 'EU FSF'],
               properties: {
-                name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
-                alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
-                title: ['President of the Sorcerer Federation'],
-                gender: ['male'],
-                topics: ['sanction', 'role.pep'],
-                country: ['ru'],
-                position: ['President of the Sorcerer Federation'],
-                birthDate: ['1952-10-07'],
-                firstName: ['Voldemor'],
-                lastName: ['Poutine'],
-                citizenship: ['ru'],
-                nationality: ['ru'],
                 sanctions: [
                   {
-                    id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
-                    schema: 'Sanction',
                     properties: {
-                      entity: ['Q7747'],
-                      reason: ['Executive Order 66'],
-                      country: ['us'],
-                      program: ['HOGWARD-EO14024'],
-                      authority: ['Office of Foreign Assets Control'],
-                      provisions: ['Block', 'HOGWARD-EO14024'],
+                      datasets: ['au_dfat_sanctions'],
                     },
                   },
                 ],
               },
             },
-            uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
-            comments: [
-              {
-                id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
-                authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
-                comment: '',
-                createdAt: '2025-07-01T14:58:06.316842+02:00',
-              },
-            ],
           },
         ],
-        initialQuery: [],
       },
     ] as unknown as SanctionCheck[];
 
@@ -198,7 +93,6 @@ describe('DecisionDetailsService', () => {
       },
       scenario: {
         getScenarioIteration: vi.fn().mockResolvedValue({
-          id: 'iteration-456',
           rules: mockScenarioRules,
         }),
       },
@@ -211,8 +105,10 @@ describe('DecisionDetailsService', () => {
           sections: [
             {
               datasets: [
-                { name: 'dataset-1', title: 'Dataset 1 Title' },
-                { name: 'dataset-2', title: 'Dataset 2 Title' },
+                { name: 'au_dfat_sanctions', title: 'AU DFAT Sanctions' },
+                { name: 'gb_fcdo_sanctions', title: 'GB FCDO Sanctions' },
+                { name: 'us_ofac_sdn', title: 'US OFAC SDN' },
+                { name: 'eu_fsf', title: 'EU FSF' },
               ],
             },
           ],
@@ -227,89 +123,11 @@ describe('DecisionDetailsService', () => {
     it('should fetch decision details successfully', async () => {
       const result = await service.fetchDecisionDetails('decision-123');
 
-      expect(result).toEqual<DecisionDetailsData>({
+      expect(result).toEqual({
         decision: mockDecision,
         scenarioRules: mockScenarioRules,
         pivots: mockPivots,
-        sanctionCheck: [
-          {
-            id: 'sanction-check-1',
-            config: {
-              name: 'Sanction Check',
-            },
-            decisionId: 'decision-123',
-            partial: false,
-            isManual: false,
-            status: 'confirmed_hit',
-            request: {
-              threshold: 70,
-              limit: 30,
-              queries: {
-                '898498bd-cd73-4706-8f1f-1883b9dae779': {
-                  schema: 'Person',
-                  properties: {
-                    name: ['Voldemor Poutine'],
-                  },
-                },
-              },
-            },
-            matches: [
-              {
-                id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
-                entityId: 'Q7747',
-                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
-                status: 'confirmed_hit',
-                enriched: true,
-                payload: {
-                  id: 'Q7747',
-                  match: true,
-                  score: 1,
-                  schema: 'Person',
-                  caption: 'Voldemor Poutine',
-                  datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
-                  properties: {
-                    name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
-                    alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
-                    title: ['President of the Sorcerer Federation'],
-                    gender: ['male'],
-                    topics: ['sanction', 'role.pep'],
-                    country: ['ru'],
-                    position: ['President of the Sorcerer Federation'],
-                    birthDate: ['1952-10-07'],
-                    firstName: ['Voldemor'],
-                    lastName: ['Poutine'],
-                    citizenship: ['ru'],
-                    nationality: ['ru'],
-                    sanctions: [
-                      {
-                        id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
-                        schema: 'Sanction',
-                        properties: {
-                          entity: ['Q7747'],
-                          reason: ['Executive Order 66'],
-                          country: ['us'],
-                          program: ['HOGWARD-EO14024'],
-                          authority: ['Office of Foreign Assets Control'],
-                          provisions: ['Block', 'HOGWARD-EO14024'],
-                        },
-                      },
-                    ],
-                  },
-                },
-                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
-                comments: [
-                  {
-                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
-                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
-                    comment: '',
-                    createdAt: '2025-07-01T14:58:06.316842+02:00',
-                  },
-                ],
-              },
-            ],
-            initialQuery: [],
-          },
-        ] as unknown as SanctionCheck[],
+        sanctionCheck: mockSanctionCheck,
       });
 
       expect(mockRepositories.decision.getDecisionById).toHaveBeenCalledWith('decision-123');
@@ -366,42 +184,11 @@ describe('DecisionDetailsService', () => {
       it('should enrich sanction check with dataset titles', async () => {
         const result = await service.fetchDecisionDetails('decision-123');
 
-        expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-          id: 'Q7747',
-          match: true,
-          score: 1,
-          schema: 'Person',
-          caption: 'Voldemor Poutine',
-          datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
-          properties: {
-            name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
-            alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
-            title: ['President of the Sorcerer Federation'],
-            gender: ['male'],
-            topics: ['sanction', 'role.pep'],
-            country: ['ru'],
-            position: ['President of the Sorcerer Federation'],
-            birthDate: ['1952-10-07'],
-            firstName: ['Voldemor'],
-            lastName: ['Poutine'],
-            citizenship: ['ru'],
-            nationality: ['ru'],
-            sanctions: [
-              {
-                id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
-                schema: 'Sanction',
-                properties: {
-                  entity: ['Q7747'],
-                  reason: ['Executive Order 66'],
-                  country: ['us'],
-                  program: ['HOGWARD-EO14024'],
-                  authority: ['Office of Foreign Assets Control'],
-                  provisions: ['Block', 'HOGWARD-EO14024'],
-                },
-              },
-            ],
-          },
-        });
+        expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual([
+          'GB FCDO Sanctions',
+          'US OFAC SDN',
+          'EU FSF',
+        ]);
       });
 
       it('should handle sanction check without datasets', async () => {
@@ -494,40 +281,16 @@ describe('DecisionDetailsService', () => {
         const result = await service.fetchDecisionDetails('decision-123');
 
         expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-          caption: 'Voldemor Poutine',
-          datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
-          id: 'Q7747',
-          match: true,
+          datasets: ['GB FCDO Sanctions', 'US OFAC SDN', 'EU FSF'],
           properties: {
-            alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
-            birthDate: ['1952-10-07'],
-            citizenship: ['ru'],
-            country: ['ru'],
-            firstName: ['Voldemor'],
-            gender: ['male'],
-            lastName: ['Poutine'],
-            name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
-            nationality: ['ru'],
-            position: ['President of the Sorcerer Federation'],
             sanctions: [
               {
-                id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
                 properties: {
-                  authority: ['Office of Foreign Assets Control'],
-                  country: ['us'],
-                  entity: ['Q7747'],
-                  program: ['HOGWARD-EO14024'],
-                  provisions: ['Block', 'HOGWARD-EO14024'],
-                  reason: ['Executive Order 66'],
+                  datasets: ['au_dfat_sanctions'],
                 },
-                schema: 'Sanction',
               },
             ],
-            title: ['President of the Sorcerer Federation'],
-            topics: ['sanction', 'role.pep'],
           },
-          schema: 'Person',
-          score: 1,
         });
       });
 
@@ -539,40 +302,16 @@ describe('DecisionDetailsService', () => {
         const result = await service.fetchDecisionDetails('decision-123');
 
         expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-          caption: 'Voldemor Poutine',
-          datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
-          id: 'Q7747',
-          match: true,
+          datasets: ['GB FCDO Sanctions', 'US OFAC SDN', 'EU FSF'],
           properties: {
-            alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
-            birthDate: ['1952-10-07'],
-            citizenship: ['ru'],
-            country: ['ru'],
-            firstName: ['Voldemor'],
-            gender: ['male'],
-            lastName: ['Poutine'],
-            name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
-            nationality: ['ru'],
-            position: ['President of the Sorcerer Federation'],
             sanctions: [
               {
-                id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
                 properties: {
-                  authority: ['Office of Foreign Assets Control'],
-                  country: ['us'],
-                  entity: ['Q7747'],
-                  program: ['HOGWARD-EO14024'],
-                  provisions: ['Block', 'HOGWARD-EO14024'],
-                  reason: ['Executive Order 66'],
+                  datasets: ['au_dfat_sanctions'],
                 },
-                schema: 'Sanction',
               },
             ],
-            title: ['President of the Sorcerer Federation'],
-            topics: ['sanction', 'role.pep'],
           },
-          schema: 'Person',
-          score: 1,
         });
       });
 
@@ -593,10 +332,9 @@ describe('DecisionDetailsService', () => {
         const result = await service.fetchDecisionDetails('decision-123');
 
         expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual([
-          'au_dfat_sanctions',
-          'gb_fcdo_sanctions',
-          'us_ofac_sdn',
-          'eu_fsf',
+          'GB FCDO Sanctions',
+          'US OFAC SDN',
+          'EU FSF',
         ]);
       });
 
@@ -604,107 +342,23 @@ describe('DecisionDetailsService', () => {
         const sanctionCheckWithMultipleDatasets = [
           {
             id: 'sanction-check-1',
-            config: {
-              name: 'Sanction Check',
-            },
-            decisionId: 'decision-123',
-            partial: false,
-            isManual: false,
-            status: 'confirmed_hit',
-            request: {
-              threshold: 70,
-              limit: 30,
-              queries: {
-                '898498bd-cd73-4706-8f1f-1883b9dae779': {
-                  schema: 'Person',
-                  properties: {
-                    name: ['Voldemor Poutine'],
-                  },
-                },
-              },
-            },
             matches: [
               {
-                id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
-                entityId: 'Q7747',
-                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
-                status: 'confirmed_hit',
-                enriched: true,
                 payload: {
-                  id: 'Q7747',
-                  match: true,
-                  score: 1,
-                  schema: 'Person',
-                  caption: 'Voldemor Poutine',
                   datasets: ['dataset-1', 'dataset-2', 'dataset-3'],
-                  properties: {
-                    name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
-                  },
                 },
-                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
-                comments: [
-                  {
-                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
-                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
-                    comment: '',
-                    createdAt: '2025-07-01T14:58:06.316842+02:00',
-                  },
-                ],
               },
             ],
-            initialQuery: [],
           },
           {
             id: 'sanction-check-2',
-            config: {
-              name: 'Sanction Check 2',
-            },
-            decisionId: 'decision-123',
-            partial: false,
-            isManual: false,
-            status: 'confirmed_hit',
-            request: {
-              threshold: 70,
-              limit: 30,
-              queries: {
-                '898498bd-cd73-4706-8f1f-1883b9dae780': {
-                  schema: 'Person',
-                  properties: {
-                    name: ['Jane Doe'],
-                  },
-                },
-              },
-            },
             matches: [
               {
-                id: 'db03304f-0f82-424a-9b73-b5eb2b33f310',
-                entityId: 'Q7748',
-                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae780'],
-                status: 'confirmed_hit',
-                enriched: true,
                 payload: {
-                  id: 'Q7748',
-                  match: true,
-                  score: 0.85,
-                  schema: 'Person',
-                  caption: 'Jane Doe',
                   datasets: ['dataset-2'],
-                  properties: {
-                    name: ['Jane Doe'],
-                  },
                 },
-                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258210',
-                comments: [
-                  {
-                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fc',
-                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
-                    comment: '',
-                    createdAt: '2025-07-01T14:58:06.316842+02:00',
-                  },
-                ],
               },
             ],
-            initialQuery: [],
           },
         ] as unknown as SanctionCheck[];
 
@@ -716,11 +370,11 @@ describe('DecisionDetailsService', () => {
 
         // Should filter out dataset-2 and dataset-3 from the first match since they appear in other sanctions
         expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual([
-          'Dataset 1 Title',
-          'Dataset 2 Title',
+          'dataset-1',
+          'dataset-2',
           'dataset-3',
         ]);
-        expect(result.sanctionCheck[1]?.matches[0]?.payload?.datasets).toEqual(['Dataset 2 Title']);
+        expect(result.sanctionCheck[1]?.matches[0]?.payload?.datasets).toEqual(['dataset-2']);
       });
     });
 

--- a/packages/app-builder/src/services/decisions/details.spec.ts
+++ b/packages/app-builder/src/services/decisions/details.spec.ts
@@ -1,0 +1,431 @@
+import type { Pivot } from '@app-builder/models/data-model';
+import type { DecisionDetails } from '@app-builder/models/decision';
+import type { SanctionCheck } from '@app-builder/models/sanction-check';
+import type { ScenarioIterationRule } from '@app-builder/models/scenario-iteration-rule';
+import * as Sentry from '@sentry/remix';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DecisionDetailsData, DecisionDetailsRepositories } from './details';
+import { createDecisionDetailsService, DecisionDetailsService } from './details';
+
+// Mock Response class since @remix-run/node doesn't export it
+class MockResponse extends Error {
+  constructor(body: any, options: { status: number; statusText: string }) {
+    super(options.statusText);
+    this.status = options.status;
+    this.statusText = options.statusText;
+  }
+  status: number;
+  statusText: string;
+}
+
+// Mock Sentry
+vi.mock('@sentry/remix', () => ({
+  captureException: vi.fn(),
+}));
+
+// Make MockResponse available globally for the tests
+global.Response = MockResponse as any;
+
+describe('DecisionDetailsService', () => {
+  let service: DecisionDetailsService;
+  let mockRepositories: DecisionDetailsRepositories;
+  let mockDecision: DecisionDetails;
+  let mockScenarioRules: ScenarioIterationRule[];
+  let mockPivots: Pivot[];
+  let mockSanctionCheck: SanctionCheck[];
+
+  beforeEach(() => {
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // Create mock decision
+    mockDecision = {
+      id: 'decision-123',
+      scenario: {
+        scenarioIterationId: 'iteration-456',
+        scenarioId: 'scenario-789',
+        name: 'Test Scenario',
+        version: 1,
+      },
+      outcome: 'approve',
+      createdAt: new Date('2023-01-01T00:00:00Z'),
+      triggerObject: {
+        id: 'trigger-123',
+        type: 'transaction',
+      },
+      score: 85,
+      rules: [],
+      pivot: null,
+      case: null,
+      triggeredAt: new Date('2023-01-01T00:00:00Z'),
+      scheduleId: null,
+      pivotValues: [],
+      triggerObjectType: 'transaction',
+    } as unknown as DecisionDetails;
+
+    // Create mock scenario rules
+    mockScenarioRules = [
+      {
+        id: 'rule-1',
+        name: 'Test Rule 1',
+        description: 'Test rule description',
+        formula: 'test_formula',
+        scoreModifier: 10,
+        ruleGroup: 'test_group',
+        displayOrder: 1,
+        scenarioIterationId: 'iteration-456',
+        createdAt: new Date('2023-01-01T00:00:00Z'),
+      },
+    ] as unknown as ScenarioIterationRule[];
+
+    // Create mock pivots
+    mockPivots = [
+      {
+        id: 'pivot-1',
+        field: 'test_field',
+        type: 'STRING',
+        createdAt: new Date('2023-01-01T00:00:00Z'),
+        updatedAt: new Date('2023-01-01T00:00:00Z'),
+      },
+    ] as unknown as Pivot[];
+
+    // Create mock sanction check
+    mockSanctionCheck = [
+      {
+        id: 'sanction-1',
+        status: 'hit',
+        matches: [
+          {
+            id: 'match-1',
+            name: 'Test Match',
+            score: 0.95,
+            payload: {
+              name: 'John Doe',
+              datasets: ['dataset-1', 'dataset-2'],
+            },
+          },
+        ],
+      },
+    ] as unknown as SanctionCheck[];
+
+    // Create mock repositories
+    mockRepositories = {
+      decision: {
+        getDecisionById: vi.fn().mockResolvedValue(mockDecision),
+      },
+      scenario: {
+        getScenarioIteration: vi.fn().mockResolvedValue({
+          id: 'iteration-456',
+          rules: mockScenarioRules,
+        }),
+      },
+      dataModel: {
+        listPivots: vi.fn().mockResolvedValue(mockPivots),
+      },
+      sanctionCheck: {
+        listSanctionChecks: vi.fn().mockResolvedValue(mockSanctionCheck),
+        listDatasets: vi.fn().mockResolvedValue({
+          sections: [
+            {
+              datasets: [
+                { name: 'dataset-1', title: 'Dataset 1 Title' },
+                { name: 'dataset-2', title: 'Dataset 2 Title' },
+              ],
+            },
+          ],
+        }),
+      },
+    } as any;
+
+    service = new DecisionDetailsService(mockRepositories);
+  });
+
+  describe('fetchDecisionDetails', () => {
+    it('should fetch decision details successfully', async () => {
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result).toEqual<DecisionDetailsData>({
+        decision: mockDecision,
+        scenarioRules: mockScenarioRules,
+        pivots: mockPivots,
+        sanctionCheck: [
+          {
+            id: 'sanction-1',
+            status: 'hit',
+            matches: [
+              {
+                id: 'match-1',
+                name: 'Test Match',
+                score: 0.95,
+                payload: {
+                  name: 'John Doe',
+                  datasets: [], // Empty due to filtering logic in service
+                },
+              },
+            ],
+          },
+        ] as unknown as SanctionCheck[],
+      });
+
+      expect(mockRepositories.decision.getDecisionById).toHaveBeenCalledWith('decision-123');
+      expect(mockRepositories.scenario.getScenarioIteration).toHaveBeenCalledWith({
+        iterationId: 'iteration-456',
+      });
+      expect(mockRepositories.dataModel.listPivots).toHaveBeenCalledWith({});
+      expect(mockRepositories.sanctionCheck.listSanctionChecks).toHaveBeenCalledWith({
+        decisionId: 'decision-123',
+      });
+    });
+
+    it('should handle 404 error when decision not found', async () => {
+      const error = new Error('Not Found');
+      (error as any).status = 404;
+      (error as any).statusText = 'Not Found';
+
+      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
+
+      await expect(service.fetchDecisionDetails('non-existent-id')).rejects.toThrow();
+    });
+
+    it('should handle 500 error when decision fetch fails', async () => {
+      const error = new Error('Database connection failed');
+      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
+
+      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'decision',
+        },
+      });
+    });
+
+    it('should handle errors in parallel data fetching', async () => {
+      const error = new Error('Scenario fetch failed');
+      vi.mocked(mockRepositories.scenario.getScenarioIteration).mockRejectedValue(error);
+
+      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'internal',
+        },
+      });
+    });
+  });
+
+  describe('sanction check enrichment', () => {
+    it('should enrich sanction check with dataset titles', async () => {
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+        name: 'John Doe',
+        datasets: [], // Empty due to filtering logic in service
+      });
+    });
+
+    it('should handle sanction check without datasets', async () => {
+      const sanctionCheckWithoutDatasets = [
+        {
+          id: 'sanction-1',
+          status: 'hit',
+          matches: [
+            {
+              id: 'match-1',
+              name: 'Test Match',
+              score: 0.95,
+              payload: {
+                name: 'John Doe',
+                // No datasets property
+              },
+            },
+          ],
+        },
+      ] as unknown as SanctionCheck[];
+
+      vi.mocked(mockRepositories.sanctionCheck.listSanctionChecks).mockResolvedValue(
+        sanctionCheckWithoutDatasets,
+      );
+
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result.sanctionCheck).toEqual(sanctionCheckWithoutDatasets);
+      expect(mockRepositories.sanctionCheck.listDatasets).not.toHaveBeenCalled();
+    });
+
+    it('should handle dataset enrichment errors gracefully', async () => {
+      const error = new Error('Dataset API failed');
+      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockRejectedValue(error);
+
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result.sanctionCheck).toEqual(mockSanctionCheck);
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'datasets',
+        },
+      });
+    });
+
+    it('should handle missing dataset sections', async () => {
+      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
+        sections: null,
+      } as any);
+
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+        name: 'John Doe',
+        datasets: ['dataset-1', 'dataset-2'],
+      });
+    });
+
+    it('should handle empty dataset sections', async () => {
+      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
+        sections: [],
+      });
+
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+        name: 'John Doe',
+        datasets: ['dataset-1', 'dataset-2'],
+      });
+    });
+
+    it('should handle missing dataset mappings', async () => {
+      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
+        sections: [
+          {
+            name: 'test-section',
+            title: 'Test Section',
+            datasets: [
+              { name: 'dataset-1', title: 'Dataset 1 Title' },
+              // Missing dataset-2
+            ],
+          },
+        ],
+      } as any);
+
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+        name: 'John Doe',
+        datasets: ['Dataset 1 Title', 'dataset-2'], // Falls back to original name
+      });
+    });
+
+    it('should filter out sanctions datasets', async () => {
+      const sanctionCheckWithMultipleDatasets = [
+        {
+          id: 'sanction-1',
+          status: 'hit',
+          matches: [
+            {
+              id: 'match-1',
+              name: 'Test Match',
+              score: 0.95,
+              payload: {
+                name: 'John Doe',
+                datasets: ['dataset-1', 'dataset-2', 'dataset-3'],
+              },
+            },
+          ],
+        },
+        {
+          id: 'sanction-2',
+          status: 'hit',
+          matches: [
+            {
+              id: 'match-2',
+              name: 'Test Match 2',
+              score: 0.85,
+              payload: {
+                name: 'Jane Doe',
+                datasets: ['dataset-2'],
+              },
+            },
+          ],
+        },
+      ] as unknown as SanctionCheck[];
+
+      vi.mocked(mockRepositories.sanctionCheck.listSanctionChecks).mockResolvedValue(
+        sanctionCheckWithMultipleDatasets,
+      );
+
+      const result = await service.fetchDecisionDetails('decision-123');
+
+      // Should filter out dataset-2 and dataset-3 from the first match since they appear in other sanctions
+      expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual(['Dataset 1 Title']);
+      expect(result.sanctionCheck[1]?.matches[0]?.payload?.datasets).toEqual([]);
+    });
+  });
+
+  describe('createDecisionDetailsService', () => {
+    it('should create a new service instance', () => {
+      const service = createDecisionDetailsService(mockRepositories);
+
+      expect(service).toBeInstanceOf(DecisionDetailsService);
+    });
+
+    it('should create service with the same repositories', async () => {
+      const service = createDecisionDetailsService(mockRepositories);
+
+      await service.fetchDecisionDetails('decision-123');
+
+      expect(mockRepositories.decision.getDecisionById).toHaveBeenCalledWith('decision-123');
+    });
+  });
+
+  describe('error handling edge cases', () => {
+    it('should handle decision repository throwing non-standard error', async () => {
+      const error = 'String error';
+      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
+
+      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'decision',
+        },
+      });
+    });
+
+    it('should handle decision repository throwing null error', async () => {
+      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(null);
+
+      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(null, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'decision',
+        },
+      });
+    });
+
+    it('should handle error object without status property', async () => {
+      const error = { message: 'Some error' };
+      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
+
+      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'decision',
+        },
+      });
+    });
+  });
+});

--- a/packages/app-builder/src/services/decisions/details.spec.ts
+++ b/packages/app-builder/src/services/decisions/details.spec.ts
@@ -42,38 +42,59 @@ describe('DecisionDetailsService', () => {
     mockDecision = {
       id: 'decision-123',
       scenario: {
+        id: 'scenario-789',
         scenarioIterationId: 'iteration-456',
-        scenarioId: 'scenario-789',
         name: 'Test Scenario',
         version: 1,
       },
       outcome: 'approve',
+      reviewStatus: 'pending',
       createdAt: new Date('2023-01-01T00:00:00Z'),
       triggerObject: {
-        id: 'trigger-123',
-        type: 'transaction',
+        object_id: 'trigger-123',
+        payment_method: 'TRANSFER',
+        direction: 'PAYOUT',
+        value: 100.5,
       },
+      triggerObjectType: 'transactions',
       score: 85,
-      rules: [],
-      pivot: null,
+      rules: [
+        {
+          name: 'Test Rule',
+          ruleId: 'rule-123',
+          description: 'Test rule description',
+          evaluation: {},
+          outcome: 'hit',
+          scoreModifier: 10,
+        },
+      ],
       case: null,
-      triggeredAt: new Date('2023-01-01T00:00:00Z'),
-      scheduleId: null,
-      pivotValues: [],
-      triggerObjectType: 'transaction',
+      scheduledExecutionId: 'schedule-123',
+      pivotValues: [
+        {
+          id: 'pivot-value-1',
+          value: 'test-value',
+        },
+      ],
     } as unknown as DecisionDetails;
 
     // Create mock scenario rules
     mockScenarioRules = [
       {
         id: 'rule-1',
+        scenarioIterationId: 'iteration-456',
+        displayOrder: 0,
         name: 'Test Rule 1',
         description: 'Test rule description',
-        formula: 'test_formula',
+        ruleGroup: 'Checklist',
+        formula: {
+          id: 'formula-1',
+          name: 'Or',
+          constant: undefined,
+          children: [],
+          namedChildren: {},
+        },
         scoreModifier: 10,
-        ruleGroup: 'test_group',
-        displayOrder: 1,
-        scenarioIterationId: 'iteration-456',
         createdAt: new Date('2023-01-01T00:00:00Z'),
       },
     ] as unknown as ScenarioIterationRule[];
@@ -92,19 +113,81 @@ describe('DecisionDetailsService', () => {
     // Create mock sanction check
     mockSanctionCheck = [
       {
-        id: 'sanction-1',
-        status: 'hit',
-        matches: [
-          {
-            id: 'match-1',
-            name: 'Test Match',
-            score: 0.95,
-            payload: {
-              name: 'John Doe',
-              datasets: ['dataset-1', 'dataset-2'],
+        id: 'sanction-check-1',
+        config: {
+          name: 'Sanction Check',
+        },
+        decisionId: 'decision-123',
+        partial: false,
+        isManual: false,
+        status: 'confirmed_hit',
+        request: {
+          threshold: 70,
+          limit: 30,
+          queries: {
+            '898498bd-cd73-4706-8f1f-1883b9dae779': {
+              schema: 'Person',
+              properties: {
+                name: ['Voldemor Poutine'],
+              },
             },
           },
+        },
+        matches: [
+          {
+            id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
+            entityId: 'Q7747',
+            queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
+            status: 'confirmed_hit',
+            enriched: true,
+            payload: {
+              id: 'Q7747',
+              match: true,
+              score: 1,
+              schema: 'Person',
+              caption: 'Voldemor Poutine',
+              datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+              properties: {
+                name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+                alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
+                title: ['President of the Sorcerer Federation'],
+                gender: ['male'],
+                topics: ['sanction', 'role.pep'],
+                country: ['ru'],
+                position: ['President of the Sorcerer Federation'],
+                birthDate: ['1952-10-07'],
+                firstName: ['Voldemor'],
+                lastName: ['Poutine'],
+                citizenship: ['ru'],
+                nationality: ['ru'],
+                sanctions: [
+                  {
+                    id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
+                    schema: 'Sanction',
+                    properties: {
+                      entity: ['Q7747'],
+                      reason: ['Executive Order 66'],
+                      country: ['us'],
+                      program: ['HOGWARD-EO14024'],
+                      authority: ['Office of Foreign Assets Control'],
+                      provisions: ['Block', 'HOGWARD-EO14024'],
+                    },
+                  },
+                ],
+              },
+            },
+            uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
+            comments: [
+              {
+                id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
+                authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
+                comment: '',
+                createdAt: '2025-07-01T14:58:06.316842+02:00',
+              },
+            ],
+          },
         ],
+        initialQuery: [],
       },
     ] as unknown as SanctionCheck[];
 
@@ -150,19 +233,81 @@ describe('DecisionDetailsService', () => {
         pivots: mockPivots,
         sanctionCheck: [
           {
-            id: 'sanction-1',
-            status: 'hit',
-            matches: [
-              {
-                id: 'match-1',
-                name: 'Test Match',
-                score: 0.95,
-                payload: {
-                  name: 'John Doe',
-                  datasets: [], // Empty due to filtering logic in service
+            id: 'sanction-check-1',
+            config: {
+              name: 'Sanction Check',
+            },
+            decisionId: 'decision-123',
+            partial: false,
+            isManual: false,
+            status: 'confirmed_hit',
+            request: {
+              threshold: 70,
+              limit: 30,
+              queries: {
+                '898498bd-cd73-4706-8f1f-1883b9dae779': {
+                  schema: 'Person',
+                  properties: {
+                    name: ['Voldemor Poutine'],
+                  },
                 },
               },
+            },
+            matches: [
+              {
+                id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
+                entityId: 'Q7747',
+                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
+                status: 'confirmed_hit',
+                enriched: true,
+                payload: {
+                  id: 'Q7747',
+                  match: true,
+                  score: 1,
+                  schema: 'Person',
+                  caption: 'Voldemor Poutine',
+                  datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+                  properties: {
+                    name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+                    alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
+                    title: ['President of the Sorcerer Federation'],
+                    gender: ['male'],
+                    topics: ['sanction', 'role.pep'],
+                    country: ['ru'],
+                    position: ['President of the Sorcerer Federation'],
+                    birthDate: ['1952-10-07'],
+                    firstName: ['Voldemor'],
+                    lastName: ['Poutine'],
+                    citizenship: ['ru'],
+                    nationality: ['ru'],
+                    sanctions: [
+                      {
+                        id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
+                        schema: 'Sanction',
+                        properties: {
+                          entity: ['Q7747'],
+                          reason: ['Executive Order 66'],
+                          country: ['us'],
+                          program: ['HOGWARD-EO14024'],
+                          authority: ['Office of Foreign Assets Control'],
+                          provisions: ['Block', 'HOGWARD-EO14024'],
+                        },
+                      },
+                    ],
+                  },
+                },
+                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
+                comments: [
+                  {
+                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
+                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
+                    comment: '',
+                    createdAt: '2025-07-01T14:58:06.316842+02:00',
+                  },
+                ],
+              },
             ],
+            initialQuery: [],
           },
         ] as unknown as SanctionCheck[],
       });
@@ -216,215 +361,428 @@ describe('DecisionDetailsService', () => {
         },
       });
     });
-  });
 
-  describe('sanction check enrichment', () => {
-    it('should enrich sanction check with dataset titles', async () => {
-      const result = await service.fetchDecisionDetails('decision-123');
+    describe('sanction check enrichment', () => {
+      it('should enrich sanction check with dataset titles', async () => {
+        const result = await service.fetchDecisionDetails('decision-123');
 
-      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-        name: 'John Doe',
-        datasets: [], // Empty due to filtering logic in service
-      });
-    });
-
-    it('should handle sanction check without datasets', async () => {
-      const sanctionCheckWithoutDatasets = [
-        {
-          id: 'sanction-1',
-          status: 'hit',
-          matches: [
-            {
-              id: 'match-1',
-              name: 'Test Match',
-              score: 0.95,
-              payload: {
-                name: 'John Doe',
-                // No datasets property
+        expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+          id: 'Q7747',
+          match: true,
+          score: 1,
+          schema: 'Person',
+          caption: 'Voldemor Poutine',
+          datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+          properties: {
+            name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+            alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
+            title: ['President of the Sorcerer Federation'],
+            gender: ['male'],
+            topics: ['sanction', 'role.pep'],
+            country: ['ru'],
+            position: ['President of the Sorcerer Federation'],
+            birthDate: ['1952-10-07'],
+            firstName: ['Voldemor'],
+            lastName: ['Poutine'],
+            citizenship: ['ru'],
+            nationality: ['ru'],
+            sanctions: [
+              {
+                id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
+                schema: 'Sanction',
+                properties: {
+                  entity: ['Q7747'],
+                  reason: ['Executive Order 66'],
+                  country: ['us'],
+                  program: ['HOGWARD-EO14024'],
+                  authority: ['Office of Foreign Assets Control'],
+                  provisions: ['Block', 'HOGWARD-EO14024'],
+                },
               },
-            },
-          ],
-        },
-      ] as unknown as SanctionCheck[];
-
-      vi.mocked(mockRepositories.sanctionCheck.listSanctionChecks).mockResolvedValue(
-        sanctionCheckWithoutDatasets,
-      );
-
-      const result = await service.fetchDecisionDetails('decision-123');
-
-      expect(result.sanctionCheck).toEqual(sanctionCheckWithoutDatasets);
-      expect(mockRepositories.sanctionCheck.listDatasets).not.toHaveBeenCalled();
-    });
-
-    it('should handle dataset enrichment errors gracefully', async () => {
-      const error = new Error('Dataset API failed');
-      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockRejectedValue(error);
-
-      const result = await service.fetchDecisionDetails('decision-123');
-
-      expect(result.sanctionCheck).toEqual(mockSanctionCheck);
-      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'datasets',
-        },
-      });
-    });
-
-    it('should handle missing dataset sections', async () => {
-      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
-        sections: null,
-      } as any);
-
-      const result = await service.fetchDecisionDetails('decision-123');
-
-      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-        name: 'John Doe',
-        datasets: ['dataset-1', 'dataset-2'],
-      });
-    });
-
-    it('should handle empty dataset sections', async () => {
-      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
-        sections: [],
-      });
-
-      const result = await service.fetchDecisionDetails('decision-123');
-
-      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-        name: 'John Doe',
-        datasets: ['dataset-1', 'dataset-2'],
-      });
-    });
-
-    it('should handle missing dataset mappings', async () => {
-      vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
-        sections: [
-          {
-            name: 'test-section',
-            title: 'Test Section',
-            datasets: [
-              { name: 'dataset-1', title: 'Dataset 1 Title' },
-              // Missing dataset-2
             ],
           },
-        ],
-      } as any);
-
-      const result = await service.fetchDecisionDetails('decision-123');
-
-      expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
-        name: 'John Doe',
-        datasets: ['Dataset 1 Title', 'dataset-2'], // Falls back to original name
+        });
       });
-    });
 
-    it('should filter out sanctions datasets', async () => {
-      const sanctionCheckWithMultipleDatasets = [
-        {
-          id: 'sanction-1',
-          status: 'hit',
-          matches: [
-            {
-              id: 'match-1',
-              name: 'Test Match',
-              score: 0.95,
-              payload: {
-                name: 'John Doe',
-                datasets: ['dataset-1', 'dataset-2', 'dataset-3'],
+      it('should handle sanction check without datasets', async () => {
+        const sanctionCheckWithoutDatasets = [
+          {
+            id: 'sanction-check-1',
+            config: {
+              name: 'Sanction Check',
+            },
+            decisionId: 'decision-123',
+            partial: false,
+            isManual: false,
+            status: 'confirmed_hit',
+            request: {
+              threshold: 70,
+              limit: 30,
+              queries: {
+                '898498bd-cd73-4706-8f1f-1883b9dae779': {
+                  schema: 'Person',
+                  properties: {
+                    name: ['Voldemor Poutine'],
+                  },
+                },
               },
             },
-          ],
-        },
-        {
-          id: 'sanction-2',
-          status: 'hit',
-          matches: [
-            {
-              id: 'match-2',
-              name: 'Test Match 2',
-              score: 0.85,
-              payload: {
-                name: 'Jane Doe',
-                datasets: ['dataset-2'],
+            matches: [
+              {
+                id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
+                entityId: 'Q7747',
+                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
+                status: 'confirmed_hit',
+                enriched: true,
+                payload: {
+                  id: 'Q7747',
+                  match: true,
+                  score: 1,
+                  schema: 'Person',
+                  caption: 'Voldemor Poutine',
+                  properties: {
+                    name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+                    // No datasets property
+                  },
+                },
+                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
+                comments: [
+                  {
+                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
+                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
+                    comment: '',
+                    createdAt: '2025-07-01T14:58:06.316842+02:00',
+                  },
+                ],
               },
+            ],
+            initialQuery: [],
+          },
+        ] as unknown as SanctionCheck[];
+
+        vi.mocked(mockRepositories.sanctionCheck.listSanctionChecks).mockResolvedValue(
+          sanctionCheckWithoutDatasets,
+        );
+
+        const result = await service.fetchDecisionDetails('decision-123');
+
+        expect(result.sanctionCheck).toEqual(sanctionCheckWithoutDatasets);
+        expect(mockRepositories.sanctionCheck.listDatasets).not.toHaveBeenCalled();
+      });
+
+      it('should handle dataset enrichment errors gracefully', async () => {
+        const error = new Error('Dataset API failed');
+        vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockRejectedValue(error);
+
+        const result = await service.fetchDecisionDetails('decision-123');
+
+        expect(result.sanctionCheck).toEqual(mockSanctionCheck);
+        expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+          tags: {
+            component: 'DecisionDetailsService',
+            operation: 'fetchDecisionDetails',
+            errorType: 'datasets',
+          },
+        });
+      });
+
+      it('should handle missing dataset sections', async () => {
+        vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
+          sections: null,
+        } as any);
+
+        const result = await service.fetchDecisionDetails('decision-123');
+
+        expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+          caption: 'Voldemor Poutine',
+          datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+          id: 'Q7747',
+          match: true,
+          properties: {
+            alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
+            birthDate: ['1952-10-07'],
+            citizenship: ['ru'],
+            country: ['ru'],
+            firstName: ['Voldemor'],
+            gender: ['male'],
+            lastName: ['Poutine'],
+            name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+            nationality: ['ru'],
+            position: ['President of the Sorcerer Federation'],
+            sanctions: [
+              {
+                id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
+                properties: {
+                  authority: ['Office of Foreign Assets Control'],
+                  country: ['us'],
+                  entity: ['Q7747'],
+                  program: ['HOGWARD-EO14024'],
+                  provisions: ['Block', 'HOGWARD-EO14024'],
+                  reason: ['Executive Order 66'],
+                },
+                schema: 'Sanction',
+              },
+            ],
+            title: ['President of the Sorcerer Federation'],
+            topics: ['sanction', 'role.pep'],
+          },
+          schema: 'Person',
+          score: 1,
+        });
+      });
+
+      it('should handle empty dataset sections', async () => {
+        vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
+          sections: [],
+        });
+
+        const result = await service.fetchDecisionDetails('decision-123');
+
+        expect(result.sanctionCheck[0]?.matches[0]?.payload).toEqual({
+          caption: 'Voldemor Poutine',
+          datasets: ['au_dfat_sanctions', 'gb_fcdo_sanctions', 'us_ofac_sdn', 'eu_fsf'],
+          id: 'Q7747',
+          match: true,
+          properties: {
+            alias: ['Voldemor Poutine', 'Voldemor Voldemorovici Poutine'],
+            birthDate: ['1952-10-07'],
+            citizenship: ['ru'],
+            country: ['ru'],
+            firstName: ['Voldemor'],
+            gender: ['male'],
+            lastName: ['Poutine'],
+            name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+            nationality: ['ru'],
+            position: ['President of the Sorcerer Federation'],
+            sanctions: [
+              {
+                id: 'ofac-925aee480491db038eca387987a9c431a38e0f0b',
+                properties: {
+                  authority: ['Office of Foreign Assets Control'],
+                  country: ['us'],
+                  entity: ['Q7747'],
+                  program: ['HOGWARD-EO14024'],
+                  provisions: ['Block', 'HOGWARD-EO14024'],
+                  reason: ['Executive Order 66'],
+                },
+                schema: 'Sanction',
+              },
+            ],
+            title: ['President of the Sorcerer Federation'],
+            topics: ['sanction', 'role.pep'],
+          },
+          schema: 'Person',
+          score: 1,
+        });
+      });
+
+      it('should handle missing dataset mappings', async () => {
+        vi.mocked(mockRepositories.sanctionCheck.listDatasets).mockResolvedValue({
+          sections: [
+            {
+              name: 'test-section',
+              title: 'Test Section',
+              datasets: [
+                { name: 'dataset-1', title: 'Dataset 1 Title' },
+                // Missing dataset-2
+              ],
             },
           ],
-        },
-      ] as unknown as SanctionCheck[];
+        } as any);
 
-      vi.mocked(mockRepositories.sanctionCheck.listSanctionChecks).mockResolvedValue(
-        sanctionCheckWithMultipleDatasets,
-      );
+        const result = await service.fetchDecisionDetails('decision-123');
 
-      const result = await service.fetchDecisionDetails('decision-123');
+        expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual([
+          'au_dfat_sanctions',
+          'gb_fcdo_sanctions',
+          'us_ofac_sdn',
+          'eu_fsf',
+        ]);
+      });
 
-      // Should filter out dataset-2 and dataset-3 from the first match since they appear in other sanctions
-      expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual(['Dataset 1 Title']);
-      expect(result.sanctionCheck[1]?.matches[0]?.payload?.datasets).toEqual([]);
-    });
-  });
+      it('should filter out sanctions datasets', async () => {
+        const sanctionCheckWithMultipleDatasets = [
+          {
+            id: 'sanction-check-1',
+            config: {
+              name: 'Sanction Check',
+            },
+            decisionId: 'decision-123',
+            partial: false,
+            isManual: false,
+            status: 'confirmed_hit',
+            request: {
+              threshold: 70,
+              limit: 30,
+              queries: {
+                '898498bd-cd73-4706-8f1f-1883b9dae779': {
+                  schema: 'Person',
+                  properties: {
+                    name: ['Voldemor Poutine'],
+                  },
+                },
+              },
+            },
+            matches: [
+              {
+                id: 'db03304f-0f82-424a-9b73-b5eb2b33f309',
+                entityId: 'Q7747',
+                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae779'],
+                status: 'confirmed_hit',
+                enriched: true,
+                payload: {
+                  id: 'Q7747',
+                  match: true,
+                  score: 1,
+                  schema: 'Person',
+                  caption: 'Voldemor Poutine',
+                  datasets: ['dataset-1', 'dataset-2', 'dataset-3'],
+                  properties: {
+                    name: ['Voldemor Poutine', 'Voldemor Voldemorovich Poutine'],
+                  },
+                },
+                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258209',
+                comments: [
+                  {
+                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fb',
+                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
+                    comment: '',
+                    createdAt: '2025-07-01T14:58:06.316842+02:00',
+                  },
+                ],
+              },
+            ],
+            initialQuery: [],
+          },
+          {
+            id: 'sanction-check-2',
+            config: {
+              name: 'Sanction Check 2',
+            },
+            decisionId: 'decision-123',
+            partial: false,
+            isManual: false,
+            status: 'confirmed_hit',
+            request: {
+              threshold: 70,
+              limit: 30,
+              queries: {
+                '898498bd-cd73-4706-8f1f-1883b9dae780': {
+                  schema: 'Person',
+                  properties: {
+                    name: ['Jane Doe'],
+                  },
+                },
+              },
+            },
+            matches: [
+              {
+                id: 'db03304f-0f82-424a-9b73-b5eb2b33f310',
+                entityId: 'Q7748',
+                queryIds: ['898498bd-cd73-4706-8f1f-1883b9dae780'],
+                status: 'confirmed_hit',
+                enriched: true,
+                payload: {
+                  id: 'Q7748',
+                  match: true,
+                  score: 0.85,
+                  schema: 'Person',
+                  caption: 'Jane Doe',
+                  datasets: ['dataset-2'],
+                  properties: {
+                    name: ['Jane Doe'],
+                  },
+                },
+                uniqueCounterpartyIdentifier: 'c8edc6b7-cc99-4842-b832-620188258210',
+                comments: [
+                  {
+                    id: 'c51ca4d3-691f-4ade-be2f-2033fde8a9fc',
+                    authorId: '2583e72c-1efe-4d22-9763-b258ca61b8ec',
+                    comment: '',
+                    createdAt: '2025-07-01T14:58:06.316842+02:00',
+                  },
+                ],
+              },
+            ],
+            initialQuery: [],
+          },
+        ] as unknown as SanctionCheck[];
 
-  describe('createDecisionDetailsService', () => {
-    it('should create a new service instance', () => {
-      const service = createDecisionDetailsService(mockRepositories);
+        vi.mocked(mockRepositories.sanctionCheck.listSanctionChecks).mockResolvedValue(
+          sanctionCheckWithMultipleDatasets,
+        );
 
-      expect(service).toBeDefined();
-    });
+        const result = await service.fetchDecisionDetails('decision-123');
 
-    it('should create service with the same repositories', async () => {
-      const service = createDecisionDetailsService(mockRepositories);
-
-      await service.fetchDecisionDetails('decision-123');
-
-      expect(mockRepositories.decision.getDecisionById).toHaveBeenCalledWith('decision-123');
-    });
-  });
-
-  describe('error handling edge cases', () => {
-    it('should handle decision repository throwing non-standard error', async () => {
-      const error = 'String error';
-      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
-
-      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
-
-      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'decision',
-        },
+        // Should filter out dataset-2 and dataset-3 from the first match since they appear in other sanctions
+        expect(result.sanctionCheck[0]?.matches[0]?.payload?.datasets).toEqual([
+          'Dataset 1 Title',
+          'Dataset 2 Title',
+          'dataset-3',
+        ]);
+        expect(result.sanctionCheck[1]?.matches[0]?.payload?.datasets).toEqual(['Dataset 2 Title']);
       });
     });
 
-    it('should handle decision repository throwing null error', async () => {
-      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(null);
+    describe('createDecisionDetailsService', () => {
+      it('should create a new service instance', () => {
+        const service = createDecisionDetailsService(mockRepositories);
 
-      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+        expect(service).toBeDefined();
+      });
 
-      expect(Sentry.captureException).toHaveBeenCalledWith(null, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'decision',
-        },
+      it('should create service with the same repositories', async () => {
+        const service = createDecisionDetailsService(mockRepositories);
+
+        await service.fetchDecisionDetails('decision-123');
+
+        expect(mockRepositories.decision.getDecisionById).toHaveBeenCalledWith('decision-123');
       });
     });
 
-    it('should handle error object without status property', async () => {
-      const error = { message: 'Some error' };
-      vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
+    describe('error handling edge cases', () => {
+      it('should handle decision repository throwing non-standard error', async () => {
+        const error = 'String error';
+        vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
 
-      await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+        await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
 
-      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'decision',
-        },
+        expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+          tags: {
+            component: 'DecisionDetailsService',
+            operation: 'fetchDecisionDetails',
+            errorType: 'decision',
+          },
+        });
+      });
+
+      it('should handle decision repository throwing null error', async () => {
+        vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(null);
+
+        await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+        expect(Sentry.captureException).toHaveBeenCalledWith(null, {
+          tags: {
+            component: 'DecisionDetailsService',
+            operation: 'fetchDecisionDetails',
+            errorType: 'decision',
+          },
+        });
+      });
+
+      it('should handle error object without status property', async () => {
+        const error = { message: 'Some error' };
+        vi.mocked(mockRepositories.decision.getDecisionById).mockRejectedValue(error);
+
+        await expect(service.fetchDecisionDetails('decision-123')).rejects.toThrow();
+
+        expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+          tags: {
+            component: 'DecisionDetailsService',
+            operation: 'fetchDecisionDetails',
+            errorType: 'decision',
+          },
+        });
       });
     });
   });

--- a/packages/app-builder/src/services/decisions/details.spec.ts
+++ b/packages/app-builder/src/services/decisions/details.spec.ts
@@ -5,7 +5,7 @@ import type { ScenarioIterationRule } from '@app-builder/models/scenario-iterati
 import * as Sentry from '@sentry/remix';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DecisionDetailsData, DecisionDetailsRepositories } from './details';
-import { createDecisionDetailsService, DecisionDetailsService } from './details';
+import { createDecisionDetailsService } from './details';
 
 // Mock Response class since @remix-run/node doesn't export it
 class MockResponse extends Error {
@@ -27,7 +27,7 @@ vi.mock('@sentry/remix', () => ({
 global.Response = MockResponse as any;
 
 describe('DecisionDetailsService', () => {
-  let service: DecisionDetailsService;
+  let service: ReturnType<typeof createDecisionDetailsService>;
   let mockRepositories: DecisionDetailsRepositories;
   let mockDecision: DecisionDetails;
   let mockScenarioRules: ScenarioIterationRule[];
@@ -137,7 +137,7 @@ describe('DecisionDetailsService', () => {
       },
     } as any;
 
-    service = new DecisionDetailsService(mockRepositories);
+    service = createDecisionDetailsService(mockRepositories);
   });
 
   describe('fetchDecisionDetails', () => {
@@ -371,7 +371,7 @@ describe('DecisionDetailsService', () => {
     it('should create a new service instance', () => {
       const service = createDecisionDetailsService(mockRepositories);
 
-      expect(service).toBeInstanceOf(DecisionDetailsService);
+      expect(service).toBeDefined();
     });
 
     it('should create service with the same repositories', async () => {

--- a/packages/app-builder/src/services/decisions/details.ts
+++ b/packages/app-builder/src/services/decisions/details.ts
@@ -25,17 +25,12 @@ export interface DecisionDetailsRepositories {
 export class DecisionDetailsService {
   constructor(private repositories: DecisionDetailsRepositories) {}
 
-  async fetchDecisionDetails(decisionId: string): Promise<DecisionDetailsData> {
-    const {
-      decision: decisionRepository,
-      scenario: scenarioRepository,
-      dataModel: dataModelRepository,
-      sanctionCheck: sanctionCheckRepository,
-    } = this.repositories;
-
-    let decision: DecisionDetails;
+  private async _fetchDecision(
+    decisionId: string,
+    decisionRepository: DecisionDetailsRepositories['decision'],
+  ): Promise<DecisionDetails> {
     try {
-      decision = await decisionRepository.getDecisionById(decisionId);
+      return await decisionRepository.getDecisionById(decisionId);
     } catch (error: unknown) {
       if (error && typeof error === 'object' && 'status' in error && error.status === 404) {
         throw new Response(null, { status: 404, statusText: (error as any).statusText });
@@ -49,120 +44,96 @@ export class DecisionDetailsService {
       });
       throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
     }
-
-    const [scenarioResult, pivotsResult, sanctionCheckResult] = await Promise.allSettled([
-      scenarioRepository
-        .getScenarioIteration({
-          iterationId: decision.scenario.scenarioIterationId,
-        })
-        .then((iteration) => iteration.rules),
-
-      dataModelRepository.listPivots({}),
-      sanctionCheckRepository.listSanctionChecks({ decisionId }),
-    ]);
-
-    if (scenarioResult.status === 'rejected') {
-      Sentry.captureException(scenarioResult.reason, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'scenario',
-        },
-        extra: {
-          decisionId,
-          scenarioIterationId: decision.scenario.scenarioIterationId,
-        },
-      });
-      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
-    }
-    const scenarioRules = scenarioResult.value;
-
-    if (pivotsResult.status === 'rejected') {
-      Sentry.captureException(pivotsResult.reason, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'pivots',
-        },
-        extra: {
-          decisionId,
-        },
-      });
-      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
-    }
-    const pivots = pivotsResult.value;
-
-    if (sanctionCheckResult.status === 'rejected') {
-      Sentry.captureException(sanctionCheckResult.reason, {
-        tags: {
-          component: 'DecisionDetailsService',
-          operation: 'fetchDecisionDetails',
-          errorType: 'sanction-checks',
-        },
-        extra: {
-          decisionId,
-        },
-      });
-      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
-    }
-
-    let sanctionCheck: SanctionCheck[];
-
+  }
+  private async _enrichSanctionCheck(
+    sanctionCheck: SanctionCheck[],
+    sanctionCheckRepository: DecisionDetailsRepositories['sanctionCheck'],
+  ): Promise<SanctionCheck[]> {
     //test if sanction check has datasets
-    if (
-      !sanctionCheckResult.value.some(({ matches }) =>
-        matches.some(({ payload }) => payload.datasets),
-      )
-    ) {
-      sanctionCheck = sanctionCheckResult.value;
-    } else {
-      try {
-        const { sections } = await sanctionCheckRepository.listDatasets();
-
-        const datasets: Map<string, string> = new Map(
-          sections?.flatMap(
-            ({ datasets }) => datasets?.map(({ name, title }) => [name, title]) ?? [],
-          ) ?? [],
-        );
-
-        const sanctionsDatasets = [
-          ...new Set(
-            sanctionCheckResult.value.flatMap(({ matches }) =>
-              matches.flatMap(({ payload }) => payload.datasets),
-            ),
-          ),
-        ];
-
-        sanctionCheck = sanctionCheckResult.value.map(({ matches, ...rest }) => ({
-          ...rest,
-          matches: matches.map(({ payload, ...rest }) => ({
-            ...rest,
-            payload: {
-              ...payload,
-              datasets: payload.datasets
-                ?.filter((dataset) => !sanctionsDatasets.includes(dataset))
-                .map((dataset) => datasets.get(dataset) ?? dataset),
-            },
-          })),
-        }));
-      } catch (error) {
-        Sentry.captureException(error, {
-          tags: {
-            component: 'DecisionDetailsService',
-            operation: 'fetchDecisionDetails',
-            errorType: 'datasets',
-          },
-        });
-        sanctionCheck = sanctionCheckResult.value;
-      }
+    if (!sanctionCheck.some(({ matches }) => matches.some(({ payload }) => payload.datasets))) {
+      return sanctionCheck;
     }
 
-    return {
-      decision,
-      scenarioRules,
-      pivots,
-      sanctionCheck,
-    };
+    try {
+      const { sections } = await sanctionCheckRepository.listDatasets();
+
+      const datasets: Map<string, string> = new Map(
+        sections?.flatMap(
+          ({ datasets }) => datasets?.map(({ name, title }) => [name, title]) ?? [],
+        ) ?? [],
+      );
+      const sanctionsDatasets = [
+        ...new Set(
+          sanctionCheck.flatMap(({ matches }) =>
+            matches.flatMap(({ payload }) => payload.datasets),
+          ),
+        ),
+      ];
+      return sanctionCheck.map(({ matches, ...rest }) => ({
+        ...rest,
+        matches: matches.map(({ payload, ...rest }) => ({
+          ...rest,
+          payload: {
+            ...payload,
+            datasets: payload.datasets
+              ?.filter((dataset) => !sanctionsDatasets.includes(dataset))
+              .map((dataset) => datasets.get(dataset) ?? dataset),
+          },
+        })),
+      }));
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'datasets',
+        },
+      });
+      return sanctionCheck;
+    }
+  }
+
+  async fetchDecisionDetails(decisionId: string): Promise<DecisionDetailsData> {
+    const {
+      decision: decisionRepository,
+      scenario: scenarioRepository,
+      dataModel: dataModelRepository,
+      sanctionCheck: sanctionCheckRepository,
+    } = this.repositories;
+
+    const decision = await this._fetchDecision(decisionId, decisionRepository);
+
+    try {
+      const [scenarioRules, pivots, sanctionCheck] = await Promise.all([
+        scenarioRepository
+          .getScenarioIteration({
+            iterationId: decision.scenario.scenarioIterationId,
+          })
+          .then((iteration) => iteration.rules),
+
+        dataModelRepository.listPivots({}),
+        sanctionCheckRepository
+          .listSanctionChecks({ decisionId })
+          .then((sanctionCheck) =>
+            this._enrichSanctionCheck(sanctionCheck, sanctionCheckRepository),
+          ),
+      ]);
+      return {
+        decision,
+        scenarioRules,
+        pivots,
+        sanctionCheck,
+      };
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'internal',
+        },
+      });
+      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
+    }
   }
 }
 

--- a/packages/app-builder/src/services/decisions/details.ts
+++ b/packages/app-builder/src/services/decisions/details.ts
@@ -1,0 +1,173 @@
+import { type Pivot } from '@app-builder/models/data-model';
+import { type DecisionDetails } from '@app-builder/models/decision';
+import { type SanctionCheck } from '@app-builder/models/sanction-check';
+import { type ScenarioIterationRule } from '@app-builder/models/scenario-iteration-rule';
+import { type DataModelRepository } from '@app-builder/repositories/DataModelRepository';
+import { type DecisionRepository } from '@app-builder/repositories/DecisionRepository';
+import { type SanctionCheckRepository } from '@app-builder/repositories/SanctionCheckRepository';
+import { type ScenarioRepository } from '@app-builder/repositories/ScenarioRepository';
+import * as Sentry from '@sentry/remix';
+
+export interface DecisionDetailsData {
+  decision: DecisionDetails;
+  scenarioRules: ScenarioIterationRule[];
+  pivots: Pivot[];
+  sanctionCheck: SanctionCheck[];
+}
+
+export interface DecisionDetailsRepositories {
+  decision: DecisionRepository;
+  scenario: ScenarioRepository;
+  dataModel: DataModelRepository;
+  sanctionCheck: SanctionCheckRepository;
+}
+
+export class DecisionDetailsService {
+  constructor(private repositories: DecisionDetailsRepositories) {}
+
+  async fetchDecisionDetails(decisionId: string): Promise<DecisionDetailsData> {
+    const {
+      decision: decisionRepository,
+      scenario: scenarioRepository,
+      dataModel: dataModelRepository,
+      sanctionCheck: sanctionCheckRepository,
+    } = this.repositories;
+
+    let decision: DecisionDetails;
+    try {
+      decision = await decisionRepository.getDecisionById(decisionId);
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'status' in error && error.status === 404) {
+        throw new Response(null, { status: 404, statusText: (error as any).statusText });
+      }
+      Sentry.captureException(error, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'decision',
+        },
+      });
+      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
+    }
+
+    const [scenarioResult, pivotsResult, sanctionCheckResult] = await Promise.allSettled([
+      scenarioRepository
+        .getScenarioIteration({
+          iterationId: decision.scenario.scenarioIterationId,
+        })
+        .then((iteration) => iteration.rules),
+
+      dataModelRepository.listPivots({}),
+      sanctionCheckRepository.listSanctionChecks({ decisionId }),
+    ]);
+
+    if (scenarioResult.status === 'rejected') {
+      Sentry.captureException(scenarioResult.reason, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'scenario',
+        },
+        extra: {
+          decisionId,
+          scenarioIterationId: decision.scenario.scenarioIterationId,
+        },
+      });
+      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
+    }
+    const scenarioRules = scenarioResult.value;
+
+    if (pivotsResult.status === 'rejected') {
+      Sentry.captureException(pivotsResult.reason, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'pivots',
+        },
+        extra: {
+          decisionId,
+        },
+      });
+      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
+    }
+    const pivots = pivotsResult.value;
+
+    if (sanctionCheckResult.status === 'rejected') {
+      Sentry.captureException(sanctionCheckResult.reason, {
+        tags: {
+          component: 'DecisionDetailsService',
+          operation: 'fetchDecisionDetails',
+          errorType: 'sanction-checks',
+        },
+        extra: {
+          decisionId,
+        },
+      });
+      throw new Response(null, { status: 500, statusText: 'Internal Server Error' });
+    }
+
+    let sanctionCheck: SanctionCheck[];
+
+    //test if sanction check has datasets
+    if (
+      !sanctionCheckResult.value.some(({ matches }) =>
+        matches.some(({ payload }) => payload.datasets),
+      )
+    ) {
+      sanctionCheck = sanctionCheckResult.value;
+    } else {
+      try {
+        const { sections } = await sanctionCheckRepository.listDatasets();
+
+        const datasets: Map<string, string> = new Map(
+          sections?.flatMap(
+            ({ datasets }) => datasets?.map(({ name, title }) => [name, title]) ?? [],
+          ) ?? [],
+        );
+
+        const sanctionsDatasets = [
+          ...new Set(
+            sanctionCheckResult.value.flatMap(({ matches }) =>
+              matches.flatMap(({ payload }) => payload.datasets),
+            ),
+          ),
+        ];
+
+        sanctionCheck = sanctionCheckResult.value.map(({ matches, ...rest }) => ({
+          ...rest,
+          matches: matches.map(({ payload, ...rest }) => ({
+            ...rest,
+            payload: {
+              ...payload,
+              datasets: payload.datasets
+                ?.filter((dataset) => !sanctionsDatasets.includes(dataset))
+                .map((dataset) => datasets.get(dataset) ?? dataset),
+            },
+          })),
+        }));
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: {
+            component: 'DecisionDetailsService',
+            operation: 'fetchDecisionDetails',
+            errorType: 'datasets',
+          },
+        });
+        sanctionCheck = sanctionCheckResult.value;
+      }
+    }
+
+    return {
+      decision,
+      scenarioRules,
+      pivots,
+      sanctionCheck,
+    };
+  }
+}
+
+export function createDecisionDetailsService(
+  repositories: DecisionDetailsRepositories,
+): DecisionDetailsService {
+  return new DecisionDetailsService(repositories);
+}


### PR DESCRIPTION
This PR introduces the following changes:
	•	refactor: Extracts data fetching logic into a dedicated service module for better separation of concerns and reusability.
	•	feat: Improves performance by fetching the datasets collection on demand instead of eagerly loading it.
	•	feat: Increases system resilience by skipping the sanctions check data enrichment step when the datasets list is unavailable (e.g., Yente service is down), avoiding unnecessary failures.

These changes aim to make the data handling more modular, efficient, and fault-tolerant.