### PR TITLE
fix(biome): Remove biome from code generators

### DIFF
--- a/packages/app-builder/package.json
+++ b/packages/app-builder/package.json
@@ -17,7 +17,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@biomejs/js-api": "^2.0.3",
     "@remix-run/dev": "^2.16.8",
     "@segment/analytics-next": "^1.78.1",
     "@sentry/cli": "^2.42.3",
@@ -125,8 +124,5 @@
     "uuid": "^11.1.0",
     "zod": "^3.24.2",
     "zustand": "^5.0.3"
-  },
-  "peerDependencies": {
-    "@biomejs/wasm-nodejs": "^2.1.1"
   }
 }

--- a/packages/app-builder/scripts/generateRoutes.ts
+++ b/packages/app-builder/scripts/generateRoutes.ts
@@ -2,12 +2,7 @@ import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { routes } from '@app-builder/utils/routes/routes';
-// import { Biome } from '@biomejs/js-api/nodejs';
 import ora from 'ora';
-
-// const biome = new Biome();
-
-// const { projectKey } = biome.openProject();
 
 const outTypesFile = join(process.cwd(), '/src/utils/routes/types.ts');
 
@@ -50,24 +45,6 @@ async function buildTypesFile(routes: readonly Route[]) {
     const RouteID = `export type RouteID = ${getRoutesIds(routes)
       .map((routeId) => `'${routeId}'`)
       .join(' | ')};`;
-
-    // const formatted = biome.formatContent(
-    //   projectKey,
-    //   `
-    //     ${RoutePath}
-
-    //     ${RouteID}
-    //   `,
-    //   {
-    //     filePath: outTypesFile,
-    //   },
-    // );
-    // const result = biome.lintContent(projectKey, formatted.content, {
-    //   filePath: outTypesFile,
-    //   fixFileMode: 'safeAndUnsafeFixes',
-    // });
-
-    // console.info('result', result.content);
     await writeFile(
       outTypesFile,
       `
@@ -87,7 +64,6 @@ async function buildTypesFile(routes: readonly Route[]) {
 async function main() {
   try {
     await buildTypesFile(routes);
-    // biome.shutdown();
   } catch (error) {
     console.error('\n', error);
     process.exit(1);

--- a/packages/ui-icons/package.json
+++ b/packages/ui-icons/package.json
@@ -10,7 +10,6 @@
     "generate-icons": "tsx scripts/generate.ts && biome check --write ./src/generated"
   },
   "devDependencies": {
-    "@biomejs/js-api": "^2.0.3",
     "@types/node": "22.13.10",
     "@types/react": "18.3.11",
     "@types/svg-sprite": "^0.0.39",
@@ -22,7 +21,6 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "@biomejs/wasm-nodejs": "^2.1.1",
     "react": "18.3.1"
   }
 }

--- a/packages/ui-icons/scripts/generate.ts
+++ b/packages/ui-icons/scripts/generate.ts
@@ -2,17 +2,12 @@ import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import type { Stream } from 'node:stream';
 
-// import { Biome } from '@biomejs/js-api/nodejs';
 import ora from 'ora';
 import SVGSpriter from 'svg-sprite';
 
 const OUT_DIR = join(process.cwd(), '/src/generated');
 const IN_ICONS_DIR = join(process.cwd(), '/svgs/icons/');
 const IN_LOGOS_DIR = join(process.cwd(), '/svgs/logos');
-
-// const biome = new Biome();
-
-// const { projectKey } = biome.openProject(process.cwd());
 
 async function buildIconTypeFile(svgFileNames: string[]) {
   const icons = svgFileNames.map((file) => basename(file, '.svg'));
@@ -21,12 +16,6 @@ async function buildIconTypeFile(svgFileNames: string[]) {
     export const iconNames = [ ${icons.map((icon) => `"${icon}",`).join('')} ] as const;
     export type IconName = typeof iconNames[number];
   `;
-  // const formatted = biome.formatContent(projectKey, output, {
-  //   filePath: `${OUT_DIR}/icon-names.ts`,
-  // });
-  // const result = biome.lintContent(projectKey, formatted.content, {
-  //   filePath: `${OUT_DIR}/icon-names.ts`,
-  // });
 
   await writeFile(join(OUT_DIR, 'icon-names.ts'), output);
 }
@@ -79,14 +68,6 @@ async function buildLogoTypeFile(svgFileNames: string[]) {
     export const logoNames = [${logos.map((logo) => `"${logo}",`).join('')}] as const;
     export type LogoName = typeof logoNames[number];
   `;
-
-  // const formatted = biome.formatContent(projectKey, output, {
-  //   filePath: `${OUT_DIR}/logo-names.ts`,
-  // });
-
-  // const result = biome.lintContent(projectKey, formatted.content, {
-  //   filePath: `${OUT_DIR}/logo-names.ts`,
-  // });
 
   await writeFile(join(OUT_DIR, 'logo-names.ts'), output);
 }
@@ -159,7 +140,6 @@ async function main() {
     await mkdir(OUT_DIR);
 
     await generateIcons();
-    // biome.shutdown();
   } catch (error) {
     console.error('\n', error);
     process.exit(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       '@ariakit/react':
         specifier: ^0.4.15
         version: 0.4.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@biomejs/wasm-nodejs':
-        specifier: ^2.1.1
-        version: 2.1.1
       '@dagrejs/dagre':
         specifier: ^1.1.4
         version: 1.1.4
@@ -304,9 +301,6 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@18.3.11)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     devDependencies:
-      '@biomejs/js-api':
-        specifier: ^2.0.3
-        version: 2.0.3(@biomejs/wasm-nodejs@2.1.1)
       '@remix-run/dev':
         specifier: ^2.16.8
         version: 2.16.8(@remix-run/react@2.16.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2))(@remix-run/serve@2.16.5(typescript@5.8.2))(@types/node@22.13.10)(babel-plugin-macros@3.1.0)(jiti@1.21.7)(tsx@4.19.3)(typescript@5.8.2)(vite@6.3.4(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0))(yaml@2.7.0)
@@ -618,14 +612,7 @@ importers:
         version: 6.3.4(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.0)
 
   packages/ui-icons:
-    dependencies:
-      '@biomejs/wasm-nodejs':
-        specifier: ^2.1.1
-        version: 2.1.1
     devDependencies:
-      '@biomejs/js-api':
-        specifier: ^2.0.3
-        version: 2.0.3(@biomejs/wasm-nodejs@2.1.1)
       '@types/node':
         specifier: 22.13.10
         version: 22.13.10
@@ -908,23 +895,6 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@biomejs/js-api@2.0.3':
-    resolution: {integrity: sha512-fg4hGhg1LtohDqLdG9uggROlVsydcuFwZhPoUOTi9+bkvGMULDKL9dEP5iN6++CIA/AN0T20U82rLYuaxc+VDQ==}
-    peerDependencies:
-      '@biomejs/wasm-bundler': ^2.1.1
-      '@biomejs/wasm-nodejs': ^2.1.1
-      '@biomejs/wasm-web': ^2.1.1
-    peerDependenciesMeta:
-      '@biomejs/wasm-bundler':
-        optional: true
-      '@biomejs/wasm-nodejs':
-        optional: true
-      '@biomejs/wasm-web':
-        optional: true
-
-  '@biomejs/wasm-nodejs@2.1.1':
-    resolution: {integrity: sha512-b/1ZTcHBuX/5yBdOfl9WmwJmlkK/GSQlFUPYshY0oBtg8E3zzh+5DMtjCYP7LPjJuHHRrfMkgsez8Mf9Ol/xUg==}
 
   '@bkrem/react-transition-group@1.3.5':
     resolution: {integrity: sha512-lbBYhC42sxAeFEopxzd9oWdkkV0zirO5E9WyeOBxOrpXsf7m30Aj8vnbayZxFOwD9pvUQ2Pheb1gO79s0Qap3Q==}
@@ -8932,12 +8902,6 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.1.1':
     optional: true
-
-  '@biomejs/js-api@2.0.3(@biomejs/wasm-nodejs@2.1.1)':
-    optionalDependencies:
-      '@biomejs/wasm-nodejs': 2.1.1
-
-  '@biomejs/wasm-nodejs@2.1.1': {}
 
   '@bkrem/react-transition-group@1.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
Biome JS API does not read our configuration properly.
As a result the generated TypeScript files from app-builder (route types) and ui-icons (icons and logo names) are not well formatted and won't pass the format checks.

After some investigation it seems like the formatter and linter from Biome JS API work without discovering our config files.
In order to not spend too much time on this, the format and lint tasks have been moved out of the file generator scripts and are now called by the system at the npm script level.