### PR TITLE
fix(workflows): disable assign to any inbox option

### DIFF
--- a/packages/app-builder/src/components/Workflows/ActionSelector.tsx
+++ b/packages/app-builder/src/components/Workflows/ActionSelector.tsx
@@ -242,7 +242,7 @@ export function ActionSelector({ action, onChange }: ActionSelectorProps) {
                 onSelectedInboxIdChange={handleInboxSelect}
                 inboxes={inboxesQuery.data || []}
                 isCreateInboxAvailable={isCreateInboxAvailable}
-                withAnyInboxAvailable={true}
+                withAnyInboxAvailable={false}
                 isAnyInboxSelected={action && 'params' in action ? action.params?.anyInbox : false}
               />
             </div>


### PR DESCRIPTION
Temporarily disable the "assign case to any available inbox" options