### PR TITLE
keep "+" while decoding email param

### DIFF
--- a/packages/app-builder/src/routes/_auth+/create-password.tsx
+++ b/packages/app-builder/src/routes/_auth+/create-password.tsx
@@ -12,7 +12,9 @@ export const handle = {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  const prefilledEmail = url.searchParams.get('email');
+  // Handle email parameter manually to preserve literal '+' characters
+  const emailParam = url.searchParams.toString().match(/email=([^&]*)/)?.[1];
+  const prefilledEmail = emailParam ? decodeURIComponent(emailParam.replace(/\+/g, '%2B')) : null;
 
   return { prefilledEmail };
 }

--- a/packages/app-builder/src/routes/_auth+/sign-in-email.tsx
+++ b/packages/app-builder/src/routes/_auth+/sign-in-email.tsx
@@ -40,7 +40,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     : (session.get('authError')?.message as AuthErrors);
 
   const url = new URL(request.url);
-  const prefilledEmail = url.searchParams.get('email');
+  // Handle email parameter manually to preserve literal '+' characters
+  const emailParam = url.searchParams.toString().match(/email=([^&]*)/)?.[1];
+  const prefilledEmail = emailParam ? decodeURIComponent(emailParam.replace(/\+/g, '%2B')) : null;
 
   return Response.json(
     {

--- a/packages/app-builder/src/routes/_auth+/sign-in.tsx
+++ b/packages/app-builder/src/routes/_auth+/sign-in.tsx
@@ -34,7 +34,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
 
   const isSsoEnabled = appConfig && appConfig.features.sso;
-  const prefilledEmail = url.searchParams.get('email') ?? '';
+  // Handle email parameter manually to preserve literal '+' characters
+  const emailParam = url.searchParams.toString().match(/email=([^&]*)/)?.[1];
+  const prefilledEmail = emailParam ? decodeURIComponent(emailParam.replace(/\+/g, '%2B')) : '';
 
   if (!isSsoEnabled || prefilledEmail) {
     return redirect(getRoute('/sign-in-email') + `?email=${encodeURIComponent(prefilledEmail)}`);


### PR DESCRIPTION
Keep the "+" in the email received in query param, which may not have been properly encoded if received from the firebase email template.