### PR TITLE
feat(case-auto-assignment): improve translations

### DIFF
--- a/packages/app-builder/src/components/Settings/UnavailableBanner.tsx
+++ b/packages/app-builder/src/components/Settings/UnavailableBanner.tsx
@@ -1,8 +1,12 @@
 import { useUnavailabilitySettings } from '@app-builder/queries/personal-settings';
+import { formatDate } from 'date-fns';
+import { fr } from 'date-fns/locale';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Icon } from 'ui-icons';
 
 export function UnavailableBanner() {
+  const { t } = useTranslation(['settings']);
   const { query: unavailabilityQuery } = useUnavailabilitySettings();
 
   const [isOpen, setIsOpen] = useState(true);
@@ -21,7 +25,13 @@ export function UnavailableBanner() {
           <span className="inline-flex p-1 me-3 text-grey-100 rounded-full w-6 h-6 items-center justify-center">
             <Icon icon="account-circle-off" className="size-5" />
           </span>
-          <span className="font-semibold text-grey-100">You are set offline.</span>
+          <span className="font-semibold text-grey-100">
+            {t('unavailableBanner.caption', {
+              date: formatDate(unavailabilityQuery.data?.until!, 'dd/MM/yyyy', {
+                locale: fr,
+              }),
+            })}
+          </span>
         </p>
       </div>
       <div className="flex items-center">

--- a/packages/app-builder/src/locales/ar/settings.json
+++ b/packages/app-builder/src/locales/ar/settings.json
@@ -89,6 +89,7 @@
   "tags.target.case": "قضية",
   "tags.target.object": "هدف",
   "tags.update_tag": "تحديث الإشارة",
+  "unavailableBanner.caption": "أنت حاليا معين كغير متاح حتى {{date}}.",
   "users": "المستخدمين",
   "users.delete_user": "حذف المستخدم",
   "users.delete_user.content": "أنت على وشك حذف هذا المستخدم. هذه العملية غير قابلة للتراجع، هل ترغب في المتابعة؟",

--- a/packages/app-builder/src/locales/en/settings.json
+++ b/packages/app-builder/src/locales/en/settings.json
@@ -89,6 +89,7 @@
   "tags.target.case": "Case",
   "tags.target.object": "Object",
   "tags.update_tag": "Update tag",
+  "unavailableBanner.caption": "You are currently set unavailable until the {{date}}.",
   "users": "Users",
   "users.delete_user": "Delete user",
   "users.delete_user.content": "You are about to delete this user. This action is irreversible, do you want to proceed ?",

--- a/packages/app-builder/src/locales/fr/settings.json
+++ b/packages/app-builder/src/locales/fr/settings.json
@@ -89,6 +89,7 @@
   "tags.target.case": "Investigation",
   "tags.target.object": "Objet",
   "tags.update_tag": "Mettre à jour le label",
+  "unavailableBanner.caption": "Vous êtes actuellement défini comme indisponible jusqu'au {{date}}.",
   "users": "Utilisateurs",
   "users.delete_user": "Supprimer un utilisateur",
   "users.delete_user.content": "Vous êtes sur le point de supprimer cet utilisateur. \nCette action est irréversible, souhaitez-vous continuer ?",


### PR DESCRIPTION
add missing translation on unavailability banner : 
<img width="891" height="248" alt="image" src="https://github.com/user-attachments/assets/b28e5514-56a7-48ef-b392-d3fb6395a79a" />
