### PR TITLE
feat(ingestion): increase upload limit to 50MB

### DIFF
--- a/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
+++ b/packages/app-builder/src/routes/_builder+/upload+/$objectType.tsx
@@ -26,6 +26,9 @@ import { ClientOnly } from 'remix-utils/client-only';
 import { Button, Modal, Table, useVirtualTable } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
+const MAX_FILE_SIZE_MB = 50;
+const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
+
 export const handle = {
   i18n: ['common', 'upload'] satisfies Namespace,
 };
@@ -150,6 +153,7 @@ const UploadForm = ({ objectType }: { objectType: string }) => {
     },
     accept: { 'text/*': ['.csv'] },
     multiple: false,
+    maxSize: MAX_FILE_SIZE,
   });
 
   return (

--- a/packages/app-builder/src/routes/ressources+/ingestion+/upload.$objectType.tsx
+++ b/packages/app-builder/src/routes/ressources+/ingestion+/upload.$objectType.tsx
@@ -10,7 +10,7 @@ import {
 import { tryit } from 'radash';
 import invariant from 'tiny-invariant';
 
-const MAX_FILE_SIZE_MB = 20;
+const MAX_FILE_SIZE_MB = 50;
 const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {


### PR DESCRIPTION
- Increase Ingestion upload max file size to 50MB
- Add the same limit on the frontend to avoir reaching the Remix backend uselessly