### PR TITLE
fix(workflows): correct validation for evluate string/numbers AST constant

### DIFF
--- a/packages/app-builder/src/routes/ressources+/workflows+/rule+/$ruleId+/update-rule.server.ts
+++ b/packages/app-builder/src/routes/ressources+/workflows+/rule+/$ruleId+/update-rule.server.ts
@@ -8,7 +8,7 @@ export type ActionsMap = Map<string, WorkflowAction>;
 
 const astNodeSchema: z.ZodTypeAny = z.object({
   id: z.string().optional(),
-  name: z.string().optional(),
+  name: z.string().nullish(),
   constant: z.any().optional(),
   children: z.array(z.lazy(() => astNodeSchema)).optional(),
   namedChildren: z


### PR DESCRIPTION
Constant AST nodes have `null` names. Adapt the Zod schema validation accordingly.