### PR TITLE
feat(ai): add AI settings endpoint and related schemas to marblecore API

### DIFF
--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -346,6 +346,11 @@ paths:
   /settings/me/unavailable:
     $ref: ./marblecore-api/users.yml#/~1settings~1me~1unavailable
 
+  # AI
+
+  /settings/ai:
+    $ref: ./marblecore-api/ai.yml#/~1settings~1ai
+
 components:
   securitySchemes:
     $ref: marblecore-api/_common.yml#/securitySchemes

--- a/packages/marble-api/openapis/marblecore-api/_schemas.yml
+++ b/packages/marble-api/openapis/marblecore-api/_schemas.yml
@@ -448,3 +448,14 @@ WorkflowActionCase:
 
 PersonalSettingsUnavailableDto:
   $ref: users.yml#/components/schemas/PersonalSettingsUnavailableDto
+
+# AI
+
+KycEnrichmentSettingDto:
+  $ref: ai.yml#/components/schemas/KycEnrichmentSettingDto
+CaseReviewSettingDto:
+  $ref: ai.yml#/components/schemas/CaseReviewSettingDto
+AISettingsDto:
+  $ref: ai.yml#/components/schemas/AISettingsDto
+UpsertAISettingsDto:
+  $ref: ai.yml#/components/schemas/UpsertAISettingsDto

--- a/packages/marble-api/openapis/marblecore-api/ai.yml
+++ b/packages/marble-api/openapis/marblecore-api/ai.yml
@@ -68,6 +68,9 @@ components:
             - low
             - medium
             - high
+        enabled:
+          type: boolean
+          description: By default, the KYC enrichment is disabled and the user has to enable it manually.
     CaseReviewSettingDto:
       type: object
       properties:

--- a/packages/marble-api/openapis/marblecore-api/ai.yml
+++ b/packages/marble-api/openapis/marblecore-api/ai.yml
@@ -85,29 +85,16 @@ components:
       type: object
       required:
         - org_id
-        - created_at
-        - updated_at
-        - kyc_enrichment_setting
-        - case_review_setting
       properties:
         org_id:
           type: string
           format: uuid
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
         kyc_enrichment_setting:
           $ref: "#/components/schemas/KycEnrichmentSettingDto"
         case_review_setting:
           $ref: "#/components/schemas/CaseReviewSettingDto"
     UpsertAISettingsDto:
       type: object
-      required:
-        - kyc_enrichment_setting
-        - case_review_setting
       properties:
         kyc_enrichment_setting:
           $ref: "#/components/schemas/KycEnrichmentSettingDto"

--- a/packages/marble-api/openapis/marblecore-api/ai.yml
+++ b/packages/marble-api/openapis/marblecore-api/ai.yml
@@ -1,0 +1,115 @@
+/settings/ai:
+  get:
+    tags:
+      - AI settings
+    summary: Get the current AI settings
+    operationId: getAISettings
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: Current AI settings for an organization
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AISettingsDto"
+      "401":
+        $ref: "components.yml#/responses/401"
+      "403":
+        $ref: "components.yml#/responses/403"
+      "404":
+        description: The organization has no AI settings
+  put:
+    tags:
+      - AI settings
+    summary: Upsert AI settings for an organization
+    operationId: upsertAISettings
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UpsertAISettingsDto"
+    responses:
+      "200":
+        description: AI settings upserted
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AISettingsDto"
+      "401":
+        $ref: "components.yml#/responses/401"
+      "403":
+        $ref: "components.yml#/responses/403"
+
+components:
+  schemas:
+    KycEnrichmentSettingDto:
+      type: object
+      properties:
+        model:
+          type: string
+          description: The model to use for KYC enrichment (sonar or sonar-pro)
+        domain_filter:
+          type: array
+          description: The domains to filter the KYC enrichment for, we can filter in or out (by adding - to the domain) by providing a list of domains or a list of domains to exclude, but can not mix both.
+          example:
+            - "societe.com"
+            - "google.org"
+            - "wikipedia.org"
+          items:
+            type: string
+        search_context_size:
+          type: string
+          description: The search context for Perplexity
+          enum:
+            - low
+            - medium
+            - high
+    CaseReviewSettingDto:
+      type: object
+      properties:
+        org_description:
+          type: string
+          description: The description of the organization to give more context to the AI case review
+        language:
+          type: string
+          description: The language of the report to be generated
+        structure:
+          type: string
+          description: Instruction for the AI to follow when generating the report
+
+    AISettingsDto:
+      type: object
+      required:
+        - org_id
+        - created_at
+        - updated_at
+        - kyc_enrichment_setting
+        - case_review_setting
+      properties:
+        org_id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        kyc_enrichment_setting:
+          $ref: "#/components/schemas/KycEnrichmentSettingDto"
+        case_review_setting:
+          $ref: "#/components/schemas/CaseReviewSettingDto"
+    UpsertAISettingsDto:
+      type: object
+      required:
+        - kyc_enrichment_setting
+        - case_review_setting
+      properties:
+        kyc_enrichment_setting:
+          $ref: "#/components/schemas/KycEnrichmentSettingDto"
+        case_review_setting:
+          $ref: "#/components/schemas/CaseReviewSettingDto"

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1325,14 +1325,12 @@ export type CaseReviewSettingDto = {
 };
 export type AiSettingsDto = {
     org_id: string;
-    created_at: string;
-    updated_at: string;
-    kyc_enrichment_setting: KycEnrichmentSettingDto;
-    case_review_setting: CaseReviewSettingDto;
+    kyc_enrichment_setting?: KycEnrichmentSettingDto;
+    case_review_setting?: CaseReviewSettingDto;
 };
 export type UpsertAiSettingsDto = {
-    kyc_enrichment_setting: KycEnrichmentSettingDto;
-    case_review_setting: CaseReviewSettingDto;
+    kyc_enrichment_setting?: KycEnrichmentSettingDto;
+    case_review_setting?: CaseReviewSettingDto;
 };
 /**
  * Get an access token

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1307,6 +1307,33 @@ export type WorkflowRuleDetailDto = WorkflowRuleDto & {
 export type PersonalSettingsUnavailableDto = {
     until: string;
 };
+export type KycEnrichmentSettingDto = {
+    /** The model to use for KYC enrichment (sonar or sonar-pro) */
+    model?: string;
+    /** The domains to filter the KYC enrichment for, we can filter in or out (by adding - to the domain) by providing a list of domains or a list of domains to exclude, but can not mix both. */
+    domain_filter?: string[];
+    /** The search context for Perplexity */
+    search_context_size?: "low" | "medium" | "high";
+};
+export type CaseReviewSettingDto = {
+    /** The description of the organization to give more context to the AI case review */
+    org_description?: string;
+    /** The language of the report to be generated */
+    language?: string;
+    /** Instruction for the AI to follow when generating the report */
+    structure?: string;
+};
+export type AiSettingsDto = {
+    org_id: string;
+    created_at: string;
+    updated_at: string;
+    kyc_enrichment_setting: KycEnrichmentSettingDto;
+    case_review_setting: CaseReviewSettingDto;
+};
+export type UpsertAiSettingsDto = {
+    kyc_enrichment_setting: KycEnrichmentSettingDto;
+    case_review_setting: CaseReviewSettingDto;
+};
 /**
  * Get an access token
  */
@@ -4735,4 +4762,42 @@ export function cancelUnavailability(opts?: Oazapfts.RequestOpts) {
         ...opts,
         method: "DELETE"
     }));
+}
+/**
+ * Get the current AI settings
+ */
+export function getAiSettings(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: AiSettingsDto;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    } | {
+        status: 404;
+    }>("/settings/ai", {
+        ...opts
+    }));
+}
+/**
+ * Upsert AI settings for an organization
+ */
+export function upsertAiSettings(upsertAiSettingsDto: UpsertAiSettingsDto, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: AiSettingsDto;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    }>("/settings/ai", oazapfts.json({
+        ...opts,
+        method: "PUT",
+        body: upsertAiSettingsDto
+    })));
 }

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1314,6 +1314,8 @@ export type KycEnrichmentSettingDto = {
     domain_filter?: string[];
     /** The search context for Perplexity */
     search_context_size?: "low" | "medium" | "high";
+    /** By default, the KYC enrichment is disabled and the user has to enable it manually. */
+    enabled?: boolean;
 };
 export type CaseReviewSettingDto = {
     /** The description of the organization to give more context to the AI case review */


### PR DESCRIPTION
This pull request introduces a new set of API endpoints and schema definitions to support organization-level AI settings in the Marble API. The changes add the ability to get and update AI-related configuration via `/settings/ai`, and define the necessary data structures for these settings.

### New AI Settings API

* Added the `/settings/ai` endpoint to the OpenAPI specification, enabling GET and PUT operations for organization AI settings. [[1]](diffhunk://#diff-963b87ef05c0ce68eb1bfe918763408aa2af4ae6a8dec97501fb911338484b8bR347-R351) [[2]](diffhunk://#diff-caad7b7de69bd6b95117468aaf81c86cc14aba5382343531d7d61b338f712d9dR1-R105)

### Schema Additions for AI Settings

* Defined new schemas in `ai.yml` for `KycEnrichmentSettingDto`, `CaseReviewSettingDto`, `AISettingsDto`, and `UpsertAISettingsDto`, specifying the structure of AI settings and their components.
* Registered these new schemas in the shared `_schemas.yml` file for use across the API.