### PR TITLE
fix(ui-design-system): cast sharedTailwindConfig to Config type in tailwind config

### DIFF
--- a/packages/ui-design-system/tailwind.config.ts
+++ b/packages/ui-design-system/tailwind.config.ts
@@ -3,6 +3,6 @@ import type { Config } from 'tailwindcss';
 import sharedTailwindConfig from '../tailwind-preset/src/tailwind.config';
 
 export default {
-  presets: [sharedTailwindConfig],
+  presets: [sharedTailwindConfig as unknown as Config],
   content: ['./src/**/*.{ts,tsx,html}'],
 } satisfies Config;


### PR DESCRIPTION
To prevent type mismatch