### PR TITLE
Add OpenAPI spec for IP whitelisting.

### DIFF
--- a/packages/marble-api/openapis/marblecore-api/admin.yml
+++ b/packages/marble-api/openapis/marblecore-api/admin.yml
@@ -471,6 +471,10 @@ components:
         auto_assign_queue_limit:
           type: number
           description: Maximum number of assignable cases for a user
+        allowed_networks:
+          type: array
+          items:
+            type: string
     CreateOrganizationBodyDto:
       type: object
       required:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1143,6 +1143,7 @@ export type OrganizationDto = {
     sanctions_limit?: number;
     /** Maximum number of assignable cases for a user */
     auto_assign_queue_limit?: number;
+    allowed_networks?: string[];
 };
 export type CreateOrganizationBodyDto = {
     name: string;


### PR DESCRIPTION
This adds the management endpoint for IP whitelisting.

As further information:

 - The `x-real-ip` header should be used to provide the client's IP address during development. The header should also be forwarded to the backend in all requests.
 - A disallowed request will have the `x-marble-global-error: disallowed-network` header set.

cc @ChibiBlasphem 