### PR TITLE
KYC enrichment in case

### DIFF
--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -101,6 +101,8 @@ paths:
     $ref: ./marblecore-api/cases.yml#/~1cases~1{caseId}~1review~1{reviewId}~1feedback
   /cases/{caseId}/data_for_investigation:
     $ref: ./marblecore-api/cases.yml#/~1cases~1{caseId}~1data_for_investigation
+  /cases/{caseId}/enrich_kyc:
+    $ref: ./marblecore-api/cases.yml#/~1cases~1{caseId}~1enrich_kyc
 
   # SUSPICIOUS ACTIVITY REPORTS
 

--- a/packages/marble-api/openapis/marblecore-api/_schemas.yml
+++ b/packages/marble-api/openapis/marblecore-api/_schemas.yml
@@ -151,6 +151,10 @@ FloatFieldStatisticsDto:
   $ref: ingestion.yml#/components/schemas/FloatFieldStatisticsDto
 TimestampFieldStatisticsDto:
   $ref: ingestion.yml#/components/schemas/TimestampFieldStatisticsDto
+KYCAnalysisDto:
+  $ref: cases.yml#/components/schemas/KYCAnalysisDto
+GroundingCitationDto:
+  $ref: cases.yml#/components/schemas/GroundingCitationDto
 
 # SUSPICIOUS ACTIVITY REPORTS
 

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -834,6 +834,38 @@
               format: binary
       '401':
         $ref: 'components.yml#/responses/401'
+/cases/{caseId}/enrich_kyc:
+  post:
+    tags:
+      - Cases
+    summary: Enrich the pivot object of the case with KYC data (if present)
+    operationId: enrichPivotObjectOfCaseWithKyc
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: caseId
+        description: ID of the case
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '200':
+        description: Analysis of the pivot object of the case with KYC data
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                results:
+                  type: array
+                  items: 
+                    $ref: '#/components/schemas/KYCAnalysisDto'
+      '401':
+        $ref: 'components.yml#/responses/401'
+      '403':
+        $ref: 'components.yml#/responses/403'
 
 components:
   schemas:
@@ -1553,3 +1585,43 @@ components:
       enum: ['ok', 'ko']
       description: The reaction to the review, can be null if not set or removed
       nullable: true
+
+    GroundingCitationDto:
+      type: object
+      required:
+        - title
+        - domain
+        - url
+        - date
+      properties:
+        title:
+          type: string
+          description: Title of the source
+        domain:
+          type: string
+          description: Domain of the source (not used for now)
+        url:
+          type: string
+          description: URL of the source
+        date:
+          type: string
+          format: date-time
+          description: Date of the source
+    KYCAnalysisDto:
+      type: object
+      required:
+        - analysis
+        - entity_name
+        - citations
+      properties:
+        analysis:
+          type: string
+          description: Output of LLM analysis on a pivot object
+        entity_name:
+          type: string
+          description: Name of the entity on which the pivot value is found.
+        citations:
+          type: array
+          description: List of source used in the analysis. The analysis uses anchors ([1][2]), these anchors are used to justify the analysis and the index follow the list order
+          items:
+            $ref: '#/components/schemas/GroundingCitationDto'

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -455,6 +455,24 @@ export type CaseReviewDto = {
     version: string;
     review: CaseReviewContentDto;
 };
+export type GroundingCitationDto = {
+    /** Title of the source */
+    title: string;
+    /** Domain of the source (not used for now) */
+    domain: string;
+    /** URL of the source */
+    url: string;
+    /** Date of the source */
+    date: string;
+};
+export type KycAnalysisDto = {
+    /** Output of LLM analysis on a pivot object */
+    analysis: string;
+    /** Name of the entity on which the pivot value is found. */
+    entity_name: string;
+    /** List of source used in the analysis. The analysis uses anchors ([1][2]), these anchors are used to justify the analysis and the index follow the list order */
+    citations: GroundingCitationDto[];
+};
 export type SuspiciousActivityReportDto = {
     id: string;
     status: "pending" | "completed";
@@ -1969,6 +1987,26 @@ export function downloadCaseData(caseId: string, opts?: Oazapfts.RequestOpts) {
         data: string;
     }>(`/cases/${encodeURIComponent(caseId)}/data_for_investigation`, {
         ...opts
+    }));
+}
+/**
+ * Enrich the pivot object of the case with KYC data (if present)
+ */
+export function enrichPivotObjectOfCaseWithKyc(caseId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: {
+            results?: KycAnalysisDto[];
+        };
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    }>(`/cases/${encodeURIComponent(caseId)}/enrich_kyc`, {
+        ...opts,
+        method: "POST"
     }));
 }
 /**


### PR DESCRIPTION
This pull request introduces a new API endpoint for enriching case data with KYC (Know Your Customer) analysis and adds supporting schema definitions to the Marble API. The main changes focus on extending the API to support KYC enrichment and providing the necessary data structures for the response.

### API Additions

* Added a new endpoint `/cases/{caseId}/enrich_kyc` to the API, allowing clients to enrich the pivot object of a case with KYC data if present. The endpoint returns an array of KYC analysis results. [[1]](diffhunk://#diff-963b87ef05c0ce68eb1bfe918763408aa2af4ae6a8dec97501fb911338484b8bR104-R105) [[2]](diffhunk://#diff-a8730fc82f48a0b94ce5f1c23c4b0d175b065f84a458089a07abea88e2c618f8R837-R868)

### Schema Updates

* Introduced the `KYCAnalysisDto` schema, which contains fields for the analysis output, entity name, and a list of citations justifying the analysis. [[1]](diffhunk://#diff-be35820400d31a35ebf0d9b58fe0241e996472cb0b67091616593abf63c5aaa9R154-R157) [[2]](diffhunk://#diff-a8730fc82f48a0b94ce5f1c23c4b0d175b065f84a458089a07abea88e2c618f8R1588-R1627)
* Added the `GroundingCitationDto` schema, representing a citation with title, domain, URL, and date, used to justify KYC analyses. [[1]](diffhunk://#diff-be35820400d31a35ebf0d9b58fe0241e996472cb0b67091616593abf63c5aaa9R154-R157) [[2]](diffhunk://#diff-a8730fc82f48a0b94ce5f1c23c4b0d175b065f84a458089a07abea88e2c618f8R1588-R1627)