### PR TITLE
fix nudge display on settings/webhooks

### DIFF
--- a/packages/app-builder/src/components/Navigation.tsx
+++ b/packages/app-builder/src/components/Navigation.tsx
@@ -14,6 +14,7 @@ export interface SidebarLinkProps {
   labelTKey: ParseKeys<['navigation']>;
   to: string;
   children?: React.ReactNode;
+  className?: string;
 }
 
 export const sidebarLink = cva(
@@ -31,11 +32,11 @@ export const sidebarLink = cva(
   },
 );
 
-export function SidebarLink({ Icon, labelTKey, to, children }: SidebarLinkProps) {
+export function SidebarLink({ Icon, labelTKey, to, children, className }: SidebarLinkProps) {
   const { t } = useTranslation(navigationI18n);
 
   return (
-    <NavLink className={({ isActive }) => sidebarLink({ isActive })} to={to}>
+    <NavLink className={({ isActive }) => sidebarLink({ isActive, className })} to={to}>
       <Icon className="size-6 shrink-0" />
       <span className="line-clamp-1 text-start opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
         {t(labelTKey)}

--- a/packages/app-builder/src/components/Nudge.tsx
+++ b/packages/app-builder/src/components/Nudge.tsx
@@ -4,6 +4,7 @@ import {
   HoverCardPortal,
   HoverCardTrigger,
 } from '@radix-ui/react-hover-card';
+import { cva } from 'class-variance-authority';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
@@ -19,6 +20,35 @@ type NudgeProps = {
   collapsed?: boolean;
 };
 
+const triggerClassName = cva('flex items-center justify-center text-white ', {
+  variants: {
+    kind: {
+      test: 'bg-purple-65',
+      restricted: 'bg-purple-82',
+      missing_configuration: 'bg-yellow-50',
+    },
+    collapsed: {
+      true: 'absolute top-v2-sm right-v2-sm translate-x-[50%] -translate-y-[50%] rounded-full',
+      false: 'rounded-sm size-6',
+    },
+  },
+  defaultVariants: {
+    collapsed: false,
+  },
+});
+
+const iconClassName = cva('', {
+  variants: {
+    collapsed: {
+      true: 'size-2.5',
+      false: 'size-3',
+    },
+  },
+  defaultVariants: {
+    collapsed: false,
+  },
+});
+
 export const Nudge = ({
   content,
   link,
@@ -28,111 +58,20 @@ export const Nudge = ({
   collapsed = false,
 }: NudgeProps) => {
   const { t } = useTranslation(['common']);
-
-  // When collapsed, render a small circular indicator
-  if (collapsed) {
-    return (
-      <HoverCard>
-        <HoverCardTrigger
-          tabIndex={-1}
-          className={cn(
-            'absolute -top-0.5 -right-0.5 flex h-1 w-1 items-center justify-center rounded-full',
-            { 'bg-purple-65': kind === 'test' },
-            { 'bg-purple-82': kind === 'restricted' },
-            { 'bg-yellow-50': kind === 'missing_configuration' },
-            className,
-          )}
-        >
+  return (
+    <HoverCard>
+      <HoverCardTrigger tabIndex={-1} asChild>
+        <span className={triggerClassName({ kind, collapsed, className })}>
           <Icon
             icon={match<typeof kind, IconName>(kind)
               .with('restricted', () => 'lock')
               .with('test', () => 'unlock-right')
               .with('missing_configuration', () => 'warning')
               .exhaustive()}
-            className="size-2 text-white"
+            className={iconClassName({ collapsed, className: iconClass })}
             aria-hidden
           />
-        </HoverCardTrigger>
-        <HoverCardPortal>
-          <HoverCardContent
-            side="right"
-            align="start"
-            sideOffset={8}
-            alignOffset={-8}
-            className={cn(
-              'bg-grey-100 z-50 flex w-60 flex-col items-center gap-6 rounded-sm border p-4 pointer-events-auto shadow-lg',
-              {
-                'border-purple-82': kind !== 'missing_configuration',
-                'border-yellow-50': kind === 'missing_configuration',
-              },
-            )}
-          >
-            <span className="text-m font-bold">
-              {match<typeof kind, string>(kind)
-                .with('missing_configuration', () => t('common:missing_configuration_title'))
-                .otherwise(() => t('common:premium'))}
-            </span>
-            <div className="flex w-full flex-col items-center gap-2">
-              <p className="text-s w-full text-center font-medium">
-                {match<typeof kind, string>(kind)
-                  .with('missing_configuration', () => t('common:missing_configuration'))
-                  .otherwise(() => content)}
-              </p>
-              {link ? (
-                <a
-                  className="text-s text-purple-65 inline-block w-full text-center hover:underline"
-                  target="_blank"
-                  rel="noreferrer"
-                  href={link}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {t('common:check_on_docs')}
-                </a>
-              ) : null}
-            </div>
-            {kind !== 'missing_configuration' ? (
-              <a
-                className={CtaClassName({
-                  variant: 'primary',
-                  color: 'purple',
-                  className: 'mt-4 text-center',
-                })}
-                href="https://checkmarble.com/upgrade"
-                target="_blank"
-                rel="noreferrer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {t('common:upgrade')}
-              </a>
-            ) : null}
-          </HoverCardContent>
-        </HoverCardPortal>
-      </HoverCard>
-    );
-  }
-
-  // Default expanded state
-  return (
-    <HoverCard>
-      <HoverCardTrigger
-        tabIndex={-1}
-        className={cn(
-          'text-grey-100 flex flex-row items-center justify-center rounded-sm',
-          { 'bg-purple-65': kind === 'test' },
-          { 'bg-purple-82': kind === 'restricted' },
-          { 'bg-yellow-50': kind === 'missing_configuration' },
-          className,
-        )}
-      >
-        <Icon
-          icon={match<typeof kind, IconName>(kind)
-            .with('restricted', () => 'lock')
-            .with('test', () => 'unlock-right')
-            .with('missing_configuration', () => 'warning')
-            .exhaustive()}
-          className={cn('size-3.5', iconClass)}
-          aria-hidden
-        />
+        </span>
       </HoverCardTrigger>
       <HoverCardPortal>
         <HoverCardContent
@@ -147,6 +86,7 @@ export const Nudge = ({
               'border-yellow-50': kind === 'missing_configuration',
             },
           )}
+          onClick={(e) => e.stopPropagation()}
         >
           <span className="text-m font-bold">
             {match<typeof kind, string>(kind)

--- a/packages/app-builder/src/components/Nudge.tsx
+++ b/packages/app-builder/src/components/Nudge.tsx
@@ -16,11 +16,102 @@ type NudgeProps = {
   iconClass?: string;
   link?: string;
   kind?: Exclude<FeatureAccessLevelDto, 'allowed'>;
+  collapsed?: boolean;
 };
 
-export const Nudge = ({ content, link, className, kind = 'restricted', iconClass }: NudgeProps) => {
+export const Nudge = ({
+  content,
+  link,
+  className,
+  kind = 'restricted',
+  iconClass,
+  collapsed = false,
+}: NudgeProps) => {
   const { t } = useTranslation(['common']);
 
+  // When collapsed, render a small circular indicator
+  if (collapsed) {
+    return (
+      <HoverCard>
+        <HoverCardTrigger
+          tabIndex={-1}
+          className={cn(
+            'absolute -top-0.5 -right-0.5 flex h-1 w-1 items-center justify-center rounded-full',
+            { 'bg-purple-65': kind === 'test' },
+            { 'bg-purple-82': kind === 'restricted' },
+            { 'bg-yellow-50': kind === 'missing_configuration' },
+            className,
+          )}
+        >
+          <Icon
+            icon={match<typeof kind, IconName>(kind)
+              .with('restricted', () => 'lock')
+              .with('test', () => 'unlock-right')
+              .with('missing_configuration', () => 'warning')
+              .exhaustive()}
+            className="size-2 text-white"
+            aria-hidden
+          />
+        </HoverCardTrigger>
+        <HoverCardPortal>
+          <HoverCardContent
+            side="right"
+            align="start"
+            sideOffset={8}
+            alignOffset={-8}
+            className={cn(
+              'bg-grey-100 z-50 flex w-60 flex-col items-center gap-6 rounded-sm border p-4 pointer-events-auto shadow-lg',
+              {
+                'border-purple-82': kind !== 'missing_configuration',
+                'border-yellow-50': kind === 'missing_configuration',
+              },
+            )}
+          >
+            <span className="text-m font-bold">
+              {match<typeof kind, string>(kind)
+                .with('missing_configuration', () => t('common:missing_configuration_title'))
+                .otherwise(() => t('common:premium'))}
+            </span>
+            <div className="flex w-full flex-col items-center gap-2">
+              <p className="text-s w-full text-center font-medium">
+                {match<typeof kind, string>(kind)
+                  .with('missing_configuration', () => t('common:missing_configuration'))
+                  .otherwise(() => content)}
+              </p>
+              {link ? (
+                <a
+                  className="text-s text-purple-65 inline-block w-full text-center hover:underline"
+                  target="_blank"
+                  rel="noreferrer"
+                  href={link}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {t('common:check_on_docs')}
+                </a>
+              ) : null}
+            </div>
+            {kind !== 'missing_configuration' ? (
+              <a
+                className={CtaClassName({
+                  variant: 'primary',
+                  color: 'purple',
+                  className: 'mt-4 text-center',
+                })}
+                href="https://checkmarble.com/upgrade"
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {t('common:upgrade')}
+              </a>
+            ) : null}
+          </HoverCardContent>
+        </HoverCardPortal>
+      </HoverCard>
+    );
+  }
+
+  // Default expanded state
   return (
     <HoverCard>
       <HoverCardTrigger

--- a/packages/app-builder/src/routes/_builder+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/_layout.tsx
@@ -169,50 +169,29 @@ export default function Builder() {
                               )
                               .with('restricted', () => (
                                 <div className="text-grey-80 relative flex gap-2 p-2">
-                                  <div className="relative">
-                                    <Icon icon="analytics" className="size-6 shrink-0" />
-                                    {!leftSidebarSharp.value.expanded && (
-                                      <Nudge
-                                        collapsed
-                                        className="size-6"
-                                        content={t('navigation:analytics.nudge')}
-                                      />
-                                    )}
-                                  </div>
+                                  <Icon icon="analytics" className="size-6 shrink-0" />
                                   <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
                                     {t('navigation:analytics')}
                                   </span>
-                                  {leftSidebarSharp.value.expanded && (
-                                    <Nudge
-                                      className="size-6"
-                                      content={t('navigation:analytics.nudge')}
-                                    />
-                                  )}
+                                  <Nudge
+                                    collapsed={!leftSidebarSharp.value.expanded}
+                                    className="size-6"
+                                    content={t('navigation:analytics.nudge')}
+                                  />
                                 </div>
                               ))
                               .with('missing_configuration', () => (
                                 <div className="text-grey-80 relative flex gap-2 p-2">
-                                  <div className="relative">
-                                    <Icon icon="analytics" className="size-6 shrink-0" />
-                                    {!leftSidebarSharp.value.expanded && (
-                                      <Nudge
-                                        collapsed
-                                        kind="missing_configuration"
-                                        className="size-6"
-                                        content={t('navigation:analytics.nudge')}
-                                      />
-                                    )}
-                                  </div>
+                                  <Icon icon="analytics" className="size-6 shrink-0" />
                                   <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
                                     {t('navigation:analytics')}
                                   </span>
-                                  {leftSidebarSharp.value.expanded && (
-                                    <Nudge
-                                      kind="missing_configuration"
-                                      className="size-6"
-                                      content={t('navigation:analytics.nudge')}
-                                    />
-                                  )}
+                                  <Nudge
+                                    collapsed={!leftSidebarSharp.value.expanded}
+                                    kind="missing_configuration"
+                                    className="size-6"
+                                    content={t('navigation:analytics.nudge')}
+                                  />
                                 </div>
                               ))
                               .with('test', () =>
@@ -220,27 +199,15 @@ export default function Builder() {
                                   <SidebarLink
                                     labelTKey="navigation:analytics"
                                     to={getRoute('/analytics')}
-                                    Icon={(props) => (
-                                      <div className="relative">
-                                        <Icon icon="analytics" {...props} />
-                                        {!leftSidebarSharp.value.expanded && (
-                                          <Nudge
-                                            collapsed
-                                            className="size-6"
-                                            content={t('navigation:analytics.nudge')}
-                                            kind="test"
-                                          />
-                                        )}
-                                      </div>
-                                    )}
+                                    className="relative"
+                                    Icon={(props) => <Icon icon="analytics" {...props} />}
                                   >
-                                    {leftSidebarSharp.value.expanded && (
-                                      <Nudge
-                                        className="size-6"
-                                        content={t('navigation:analytics.nudge')}
-                                        kind="test"
-                                      />
-                                    )}
+                                    <Nudge
+                                      collapsed={!leftSidebarSharp.value.expanded}
+                                      className="size-6"
+                                      content={t('navigation:analytics.nudge')}
+                                      kind="test"
+                                    />
                                   </SidebarLink>
                                 ) : null,
                               )

--- a/packages/app-builder/src/routes/_builder+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/_layout.tsx
@@ -122,7 +122,7 @@ export default function Builder() {
                           role={user.role}
                           orgOrPartnerName={organization.name}
                           isAutoAssignmentAvailable={featuresAccess.isAutoAssignmentAvailable}
-                        ></UserInfo>
+                        />
                       </div>
                       <nav className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-2">
                         <ul className="flex flex-col gap-2">
@@ -169,27 +169,50 @@ export default function Builder() {
                               )
                               .with('restricted', () => (
                                 <div className="text-grey-80 relative flex gap-2 p-2">
-                                  <Icon icon="analytics" className="size-6 shrink-0" />
+                                  <div className="relative">
+                                    <Icon icon="analytics" className="size-6 shrink-0" />
+                                    {!leftSidebarSharp.value.expanded && (
+                                      <Nudge
+                                        collapsed
+                                        className="size-6"
+                                        content={t('navigation:analytics.nudge')}
+                                      />
+                                    )}
+                                  </div>
                                   <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
                                     {t('navigation:analytics')}
                                   </span>
-                                  <Nudge
-                                    className="size-6"
-                                    content={t('navigation:analytics.nudge')}
-                                  />
+                                  {leftSidebarSharp.value.expanded && (
+                                    <Nudge
+                                      className="size-6"
+                                      content={t('navigation:analytics.nudge')}
+                                    />
+                                  )}
                                 </div>
                               ))
                               .with('missing_configuration', () => (
                                 <div className="text-grey-80 relative flex gap-2 p-2">
-                                  <Icon icon="analytics" className="size-6 shrink-0" />
+                                  <div className="relative">
+                                    <Icon icon="analytics" className="size-6 shrink-0" />
+                                    {!leftSidebarSharp.value.expanded && (
+                                      <Nudge
+                                        collapsed
+                                        kind="missing_configuration"
+                                        className="size-6"
+                                        content={t('navigation:analytics.nudge')}
+                                      />
+                                    )}
+                                  </div>
                                   <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
                                     {t('navigation:analytics')}
                                   </span>
-                                  <Nudge
-                                    kind="missing_configuration"
-                                    className="size-6"
-                                    content={t('navigation:analytics.nudge')}
-                                  />
+                                  {leftSidebarSharp.value.expanded && (
+                                    <Nudge
+                                      kind="missing_configuration"
+                                      className="size-6"
+                                      content={t('navigation:analytics.nudge')}
+                                    />
+                                  )}
                                 </div>
                               ))
                               .with('test', () =>
@@ -197,13 +220,27 @@ export default function Builder() {
                                   <SidebarLink
                                     labelTKey="navigation:analytics"
                                     to={getRoute('/analytics')}
-                                    Icon={(props) => <Icon icon="analytics" {...props} />}
+                                    Icon={(props) => (
+                                      <div className="relative">
+                                        <Icon icon="analytics" {...props} />
+                                        {!leftSidebarSharp.value.expanded && (
+                                          <Nudge
+                                            collapsed
+                                            className="size-6"
+                                            content={t('navigation:analytics.nudge')}
+                                            kind="test"
+                                          />
+                                        )}
+                                      </div>
+                                    )}
                                   >
-                                    <Nudge
-                                      className="size-6"
-                                      content={t('navigation:analytics.nudge')}
-                                      kind="test"
-                                    />
+                                    {leftSidebarSharp.value.expanded && (
+                                      <Nudge
+                                        className="size-6"
+                                        content={t('navigation:analytics.nudge')}
+                                        kind="test"
+                                      />
+                                    )}
                                   </SidebarLink>
                                 ) : null,
                               )

--- a/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
+++ b/packages/app-builder/src/routes/_builder+/settings+/_layout.tsx
@@ -9,7 +9,6 @@ import { type CurrentUser, isAdmin } from '@app-builder/models';
 import { type Inbox } from '@app-builder/models/inbox';
 import {
   canAccessInboxesSettings,
-  isAccessible,
   isReadApiKeyAvailable,
   isReadTagAvailable,
   isReadUserAvailable,
@@ -22,6 +21,7 @@ import clsx from 'clsx';
 import { type Namespace } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
+import { match } from 'ts-pattern';
 import { Icon } from 'ui-icons';
 
 export const handle = {
@@ -141,18 +141,85 @@ export default function Settings() {
                     <p className="font-bold">{t(`settings:${section}`)}</p>
                   </div>
                   <ul className="flex flex-col gap-1 pb-6">
-                    {settings.map((setting) =>
-                      setting.title === 'webhooks' && !isAccessible(entitlements.webhooks) ? (
-                        <span
-                          key={setting.title}
-                          className="text-s bg-grey-100 text-grey-80 inline-flex w-full gap-2 p-2 font-medium first-letter:capitalize"
-                        >
-                          {t(`settings:${setting.title}`)}
-                          {entitlements.webhooks !== 'allowed' ? (
-                            <Nudge content="" kind="restricted" className="size-5" />
-                          ) : null}
-                        </span>
-                      ) : (
+                    {settings.map((setting) => {
+                      if (setting.title === 'webhooks') {
+                        return match(entitlements.webhooks)
+                          .with('allowed', () => (
+                            <NavLink
+                              key={setting.title}
+                              className={({ isActive }) =>
+                                clsx(
+                                  'text-s flex w-full cursor-pointer flex-row rounded-sm p-2 font-medium first-letter:capitalize',
+                                  isActive
+                                    ? 'bg-purple-96 text-purple-65'
+                                    : 'bg-grey-100 text-grey-00 hover:bg-purple-96 hover:text-purple-65',
+                                )
+                              }
+                              to={setting.to}
+                            >
+                              {t(`settings:${setting.title}`)}
+                            </NavLink>
+                          ))
+                          .with('restricted', () => (
+                            <div
+                              key={setting.title}
+                              className="text-s bg-grey-100 text-grey-80 relative flex w-full justify-between items-center p-2 font-medium first-letter:capitalize min-w-full"
+                            >
+                              <span className="flex-shrink-0">
+                                {t(`settings:${setting.title}`)}
+                              </span>
+                              <div className="flex-1"></div>
+                              <Nudge
+                                className="size-6 flex-shrink-0"
+                                content={t('settings:webhooks.nudge')}
+                              />
+                            </div>
+                          ))
+                          .with('missing_configuration', () => (
+                            <div
+                              key={setting.title}
+                              className="text-s bg-grey-100 text-grey-80 relative flex w-full justify-between items-center p-2 font-medium first-letter:capitalize min-w-full"
+                            >
+                              <span className="flex-shrink-0">
+                                {t(`settings:${setting.title}`)}
+                              </span>
+                              <div className="flex-1"></div>
+                              <Nudge
+                                kind="missing_configuration"
+                                className="size-6 flex-shrink-0"
+                                content=""
+                              />
+                            </div>
+                          ))
+                          .with('test', () => (
+                            <div className="relative">
+                              <NavLink
+                                key={setting.title}
+                                to={setting.to}
+                                className={({ isActive }) =>
+                                  clsx(
+                                    'text-s relative flex w-full justify-between items-center p-2 font-medium first-letter:capitalize min-w-full cursor-pointer rounded-sm transition-colors',
+                                    isActive
+                                      ? 'bg-purple-96 text-purple-65'
+                                      : 'bg-grey-100 text-grey-00 hover:bg-purple-96 hover:text-purple-65',
+                                  )
+                                }
+                              >
+                                <span className="flex-shrink-0">
+                                  {t(`settings:${setting.title}`)}
+                                </span>
+                                <Nudge
+                                  className="size-6 shrink-0"
+                                  content={t('settings:webhooks.nudge')}
+                                  kind="test"
+                                />
+                              </NavLink>
+                            </div>
+                          ))
+                          .exhaustive();
+                      }
+
+                      return (
                         <NavLink
                           key={setting.title}
                           className={({ isActive }) =>
@@ -167,8 +234,8 @@ export default function Settings() {
                         >
                           {t(`settings:${setting.title}`)}
                         </NavLink>
-                      ),
-                    )}
+                      );
+                    })}
                   </ul>
                 </nav>
               );


### PR DESCRIPTION
## Issues
- "nudge" button is invisible if the side bar is folded (which should increasingly be its default status)
- "webhooks" nudge button in setting was not handling all the cases where it should be displayed
- "upgrade" button link in the hover did not do anything on click, only on "ctrl+click"

## Attempts
- I tried to make the nudge a miniature when the side bar is folded. I managed to make something that feels about right on the initial render, but the icon shifts back over the analytics page logo on the client re-render. I wasn't able to fix this.
- on the webhooks setting page, the nudge logo flickers around when we refresh the page, if the webhooks setting page is selected

server render:
<img width="104" height="75" alt="Capture d’écran 2025-09-05 à 11 36 00" src="https://github.com/user-attachments/assets/96dab8b5-2345-40a9-b4ce-b089488c329b" />
client render:
<img width="96" height="81" alt="Capture d’écran 2025-09-05 à 11 32 44" src="https://github.com/user-attachments/assets/dbd9a255-e518-40f2-83eb-f5326a6e33de" />


Some of the changes in this PR have been made with cursor, handle with care (especially the css)