### PR TITLE
refactor(navigate): remove simple uses of useNavigate from remix for useAgnosticNavigation

### DIFF
--- a/packages/app-builder/src/components/Auth/SendEmailVerification.tsx
+++ b/packages/app-builder/src/components/Auth/SendEmailVerification.tsx
@@ -1,3 +1,4 @@
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import {
   NetworkRequestFailed,
   TooManyRequest,
@@ -5,7 +6,6 @@ import {
 } from '@app-builder/services/auth/auth.client';
 import { useClientServices } from '@app-builder/services/init.client';
 import { getRoute } from '@app-builder/utils/routes';
-import { useNavigate } from '@remix-run/react';
 import * as Sentry from '@sentry/remix';
 import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
@@ -44,7 +44,7 @@ function ClientSendEmailVerificationButton() {
     clientServices.authenticationClientService,
   );
 
-  const navigate = useNavigate();
+  const navigate = useAgnosticNavigation();
   async function onSendClick() {
     try {
       const logout = () => navigate(getRoute('/ressources/auth/logout'));

--- a/packages/app-builder/src/components/Auth/SignInWithEmailAndPassword.tsx
+++ b/packages/app-builder/src/components/Auth/SignInWithEmailAndPassword.tsx
@@ -1,3 +1,4 @@
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import {
   EmailUnverified,
   InvalidLoginCredentials,
@@ -10,7 +11,7 @@ import { useClientServices } from '@app-builder/services/init.client';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { getRoute } from '@app-builder/utils/routes';
 import { sleep } from '@app-builder/utils/sleep';
-import { Link, useNavigate } from '@remix-run/react';
+import { Link } from '@remix-run/react';
 import * as Sentry from '@sentry/remix';
 import { useForm } from '@tanstack/react-form';
 import toast from 'react-hot-toast';
@@ -18,7 +19,6 @@ import { useTranslation } from 'react-i18next';
 import { useHydrated } from 'remix-utils/use-hydrated';
 import { Button } from 'ui-design-system';
 import * as z from 'zod/v4';
-
 import { FormErrorOrDescription } from '../Form/Tanstack/FormErrorOrDescription';
 import { FormInput } from '../Form/Tanstack/FormInput';
 import { FormLabel } from '../Form/Tanstack/FormLabel';
@@ -46,7 +46,7 @@ export function SignInWithEmailAndPassword({
 }) {
   const { t } = useTranslation(['auth', 'common']);
   const clientServices = useClientServices();
-  const navigate = useNavigate();
+  const navigate = useAgnosticNavigation();
   const hydrated = useHydrated();
 
   const emailAndPasswordSignIn = useEmailAndPasswordSignIn(

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId+/_index.tsx
@@ -12,6 +12,7 @@ import { SnoozePanel } from '@app-builder/components/CaseManager/SnoozePanel/Sno
 import { CaseDetails } from '@app-builder/components/Cases/CaseDetails';
 import { DataModelExplorerProvider } from '@app-builder/components/DataModelExplorer/Provider';
 import { LeftSidebarSharpFactory } from '@app-builder/components/Layout/LeftSidebar';
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import {
   type DataModelWithTableOptions,
   mergeDataModelWithTableOptions,
@@ -314,7 +315,7 @@ export default function CaseManagerIndexPage() {
     mostRecentReview,
   } = useLoaderData<typeof loader>();
   const { t } = useTranslation(casesI18n);
-  const navigate = useNavigate();
+  const navigate = useAgnosticNavigation();
   const leftSidebarSharp = LeftSidebarSharpFactory.useSharp();
   const [selectedDecision, selectDecision] = useState<string | null>(null);
   const [drawerContentMode, setDrawerContentMode] = useState<'pivot' | 'decision' | 'snooze'>(

--- a/packages/app-builder/src/routes/_builder+/cases+/$caseId+/d+/$decisionId+/screenings+/$screeningId+/hits.tsx
+++ b/packages/app-builder/src/routes/_builder+/cases+/$caseId+/d+/$decisionId+/screenings+/$screeningId+/hits.tsx
@@ -5,13 +5,13 @@ import { CaseDetailTriggerObject } from '@app-builder/components/Decisions/Trigg
 import { FormatData } from '@app-builder/components/FormatData';
 import { SanctionReviewSection } from '@app-builder/components/Sanctions/SanctionReview';
 import { sanctionsI18n } from '@app-builder/components/Sanctions/sanctions-i18n';
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import { usePivotValues } from '@app-builder/hooks/decisions/usePivotValues';
 import { type SanctionCheck, SanctionCheckQuery } from '@app-builder/models/sanction-check';
 import { useFormatLanguage } from '@app-builder/utils/format';
 import { parseUnknownData } from '@app-builder/utils/parse';
 import { getRoute } from '@app-builder/utils/routes';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
-import { useNavigate } from '@remix-run/react';
 import { Fragment, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
@@ -26,7 +26,7 @@ export default function CaseSanctionsHitsPage() {
     tableName: string;
     objectId: string;
   } | null>(null);
-  const navigate = useNavigate();
+  const navigate = useAgnosticNavigation();
 
   return (
     <div className="bg-grey-100 border-grey-90 grid grid-cols-[max-content_2fr_1fr_repeat(3,max-content)] gap-x-6 gap-y-2 rounded-md border">

--- a/packages/app-builder/src/routes/_builder+/data+/view.tsx
+++ b/packages/app-builder/src/routes/_builder+/data+/view.tsx
@@ -1,10 +1,11 @@
 import { Page, TabLink } from '@app-builder/components';
 import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
 import { dataI18n } from '@app-builder/components/Data/data-i18n';
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import { useDataModel } from '@app-builder/services/data/data-model';
 import { getRoute } from '@app-builder/utils/routes';
 import { type RoutePath } from '@app-builder/utils/routes/types';
-import { Outlet, useMatch, useNavigate } from '@remix-run/react';
+import { Outlet, useMatch } from '@remix-run/react';
 import { type Namespace } from 'i18next';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -30,7 +31,7 @@ export default function DataSearchPage() {
   const { t } = useTranslation(handle.i18n);
   const dataModel = useDataModel();
   const match = useMatch('/data/view/:tableName/:objectId' as RoutePath);
-  const navigate = useNavigate();
+  const navigate = useAgnosticNavigation();
 
   const [tableName, setTableName] = useState(match?.params.tableName ?? '');
   const [objectId, setObjectId] = useState(match?.params.objectId ?? '');

--- a/packages/app-builder/src/routes/ressources+/auth+/refresh.tsx
+++ b/packages/app-builder/src/routes/ressources+/auth+/refresh.tsx
@@ -1,10 +1,10 @@
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import { useRefreshTokenMutation } from '@app-builder/queries/auth/refresh-token';
 import { useClientServices } from '@app-builder/services/init.client';
 import { initServerServices } from '@app-builder/services/init.server';
 import { useInterval, useVisibilityChange } from '@app-builder/utils/hooks';
 import { getRoute } from '@app-builder/utils/routes';
 import { type ActionFunctionArgs, redirect } from '@remix-run/node';
-import { useNavigate } from '@remix-run/react';
 import { useAuthenticityToken } from 'remix-utils/csrf/react';
 
 export function loader() {
@@ -27,7 +27,7 @@ export function useRefreshToken() {
   const refreshTokenMutation = useRefreshTokenMutation();
   const csrf = useAuthenticityToken();
   const visibilityState = useVisibilityChange();
-  const navigate = useNavigate();
+  const navigate = useAgnosticNavigation();
   const clientServices = useClientServices();
 
   useInterval(


### PR DESCRIPTION
Remove most uses of useNavigate in view to move away from remix.

Non removed useNavigate include:
- Go back: The one using -1 as a parameters
- The ones with object passed as a param