### PR TITLE
fix: data prepare button is disabled when there already are indexes being created

### DIFF
--- a/packages/app-builder/src/components/Scenario/Iteration/Actions/PrepareScenarioVersion.tsx
+++ b/packages/app-builder/src/components/Scenario/Iteration/Actions/PrepareScenarioVersion.tsx
@@ -29,37 +29,41 @@ export function PrepareScenarioVersion({
     setOpen(false);
   };
 
-  const button = (
-    <Button className="flex-1" variant="primary" disabled={!iteration.isValid}>
-      <Icon icon="queue-list" className="size-6" />
-      {t('scenarios:deployment_modal.prepare.button')}
-    </Button>
-  );
-
   if (!iteration.isValid) {
     return (
       <Tooltip.Default
         className="text-xs"
         content={t('scenarios:deployment_modal.prepare.validation_error')}
       >
-        {button}
+        <Button className="flex-1" variant="primary" disabled color="red">
+          <Icon icon="queue-list" className="size-6" />
+          {t('scenarios:deployment_modal.prepare.button')}
+        </Button>
       </Tooltip.Default>
     );
   }
-  if (isPreparationServiceOccupied) {
+  if (!isPreparationServiceOccupied) {
     return (
       <Tooltip.Default
         className="text-xs"
         content={t('scenarios:deployment_modal.prepare.preparation_service_occupied')}
       >
-        {button}
+        <Button className="flex-1" variant="primary" disabled>
+          <Icon icon="queue-list" className="size-6" />
+          {t('scenarios:deployment_modal.prepare.button')}
+        </Button>
       </Tooltip.Default>
     );
   }
 
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>
-      <Modal.Trigger asChild>{button}</Modal.Trigger>
+      <Modal.Trigger asChild>
+        <Button className="flex-1" variant="primary">
+          <Icon icon="queue-list" className="size-6" />
+          {t('scenarios:deployment_modal.prepare.button')}
+        </Button>
+      </Modal.Trigger>
       <Modal.Content>
         <PrepareScenarioVersionContent
           scenarioId={scenarioId}


### PR DESCRIPTION
Up to some time in the past, we were displaying a disabled "prepare" button if there were already indexes being created.
Somehow this got lost and we now display an active button, that calls the backend which is noop, with only a tooltip (that no one can ever see).
This PR fixes this issue.