### PR TITLE
feat: add enrichment result in case review DTO

### DIFF
--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -1534,6 +1534,8 @@ components:
               type: string
             pivot_enrichments:
               type: object
+              description: The enrichments of the pivot objects (null if the feature is disabled)
+              nullable: true
               properties:
                 results:
                   type: array

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -1539,7 +1539,7 @@ components:
               properties:
                 results:
                   type: array
-                  items: 
+                  items:
                     $ref: '#/components/schemas/KYCAnalysisDto'
         - anyOf:
           - $ref: '#/components/schemas/CaseReviewOkDto'

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -1532,6 +1532,13 @@ components:
                 $ref: '#/components/schemas/CaseReviewProofDto'
             thought:
               type: string
+            pivot_enrichments:
+              type: object
+              properties:
+                results:
+                  type: array
+                  items: 
+                    $ref: '#/components/schemas/KYCAnalysisDto'
         - anyOf:
           - $ref: '#/components/schemas/CaseReviewOkDto'
           - $ref: '#/components/schemas/CaseReviewNotOkDto'

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -422,9 +422,10 @@ export type CaseReviewContentDto = {
     output: string;
     proofs: CaseReviewProofDto[];
     thought?: string;
+    /** The enrichments of the pivot objects (null if the feature is disabled) */
     pivot_enrichments?: {
         results?: KycAnalysisDto[];
-    };
+    } | null;
 } & (CaseReviewOkDto | CaseReviewNotOkDto);
 export type CaseReviewDto = {
     id: string;

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -392,25 +392,6 @@ export type CaseReviewProofDto = {
     /** The reason why the object was used to justify the review */
     reason: string;
 };
-export type CaseReviewOkDto = {
-    ok: true;
-};
-export type CaseReviewNotOkDto = {
-    ok: false;
-    sanity_check: string;
-};
-export type CaseReviewContentDto = {
-    version: string;
-    output: string;
-    proofs: CaseReviewProofDto[];
-    thought?: string;
-} & (CaseReviewOkDto | CaseReviewNotOkDto);
-export type CaseReviewDto = {
-    id: string;
-    reaction: CaseReviewFeedbackDto;
-    version: string;
-    review: CaseReviewContentDto;
-};
 export type GroundingCitationDto = {
     /** Title of the source */
     title: string;
@@ -428,6 +409,28 @@ export type KycAnalysisDto = {
     entity_name: string;
     /** List of source used in the analysis. The analysis uses anchors ([1][2]), these anchors are used to justify the analysis and the index follow the list order */
     citations: GroundingCitationDto[];
+};
+export type CaseReviewOkDto = {
+    ok: true;
+};
+export type CaseReviewNotOkDto = {
+    ok: false;
+    sanity_check: string;
+};
+export type CaseReviewContentDto = {
+    version: string;
+    output: string;
+    proofs: CaseReviewProofDto[];
+    thought?: string;
+    pivot_enrichments?: {
+        results?: KycAnalysisDto[];
+    };
+} & (CaseReviewOkDto | CaseReviewNotOkDto);
+export type CaseReviewDto = {
+    id: string;
+    reaction: CaseReviewFeedbackDto;
+    version: string;
+    review: CaseReviewContentDto;
 };
 export type SuspiciousActivityReportDto = {
     id: string;


### PR DESCRIPTION
This pull request introduces a new optional field to the case review API response to support pivot object enrichments. The main change is the addition of the `pivot_enrichments` property, which is designed to provide enrichment data for pivot objects when the feature is enabled.

**API schema enhancements:**

* Added a nullable `pivot_enrichments` field of type object to the case review response schema in `cases.yml`, including a `results` property that is an array of `KYCAnalysisDto` objects.