### PR TITLE
feat(KYC): add custom instructions field to KYC enrichment settings

### DIFF
--- a/packages/marble-api/openapis/marblecore-api/ai.yml
+++ b/packages/marble-api/openapis/marblecore-api/ai.yml
@@ -74,6 +74,10 @@ components:
         enabled:
           type: boolean
           description: By default, the KYC enrichment is disabled and the user has to enable it manually.
+        custom_instructions:
+          type: string
+          nullable: true
+          description: Organization specific instructions for the KYC enrichment (guideline, format, etc.). Null if there is no instruction.
     CaseReviewSettingDto:
       type: object
       required:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1325,6 +1325,8 @@ export type KycEnrichmentSettingDto = {
     search_context_size?: ("low" | "medium" | "high") | null;
     /** By default, the KYC enrichment is disabled and the user has to enable it manually. */
     enabled: boolean;
+    /** Organization specific instructions for the KYC enrichment (guideline, format, etc.). Null if there is no instruction. */
+    custom_instructions?: string | null;
 };
 export type CaseReviewSettingDto = {
     /** The description of the organization to give more context to the AI case review */


### PR DESCRIPTION
- Introduced a new field `custom_instructions` in the KYC enrichment settings to allow organization-specific guidelines and formats.
- Updated OpenAPI and TypeScript definitions to reflect this change.