### PR TITLE
hide "remind me later" button for closed cases

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseDetails.tsx
+++ b/packages/app-builder/src/components/Cases/CaseDetails.tsx
@@ -90,9 +90,11 @@ export const CaseDetails = ({
           <EditCaseName name={detail.name} id={detail.id} />
           <div className="flex shrink-0 items-center gap-2">
             {detail.status !== 'closed' ? (
-              <EscalateCase id={detail.id} inboxId={detail.inboxId} />
+              <>
+                <EscalateCase id={detail.id} inboxId={detail.inboxId} />
+                <SnoozeCase caseId={detail.id} snoozeUntil={detail.snoozedUntil} />
+              </>
             ) : null}
-            <SnoozeCase caseId={detail.id} snoozeUntil={detail.snoozedUntil} />
             {detail.status !== 'closed' ? (
               <CloseCase id={detail.id} />
             ) : (


### PR DESCRIPTION
Small UX improvements. "Remind me later" makes no sense on a closed case (was already handled for "escalate")