### PR TITLE
chore(dependabot): Enable beta ecosystems support

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   # Root workspace dependencies
   - package-ecosystem: "bun"


### PR DESCRIPTION
Dependabot currently does not update the Bun lockfile in its bump PRs.
This PR enables enable-beta-ecosystems: true in the Dependabot configuration, which allows Bun lockfiles to be updated automatically.

Source: https://github.com/dependabot/dependabot-core/issues/6528#issuecomment-3001386217