### PR TITLE
feat: allow single IP in allow list MAR-1234

### DIFF
--- a/packages/app-builder/src/components/Settings/IpWhitelisting/IpWhitelistingSettingsPage.tsx
+++ b/packages/app-builder/src/components/Settings/IpWhitelisting/IpWhitelistingSettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   useUpdateAllowedNetworks,
 } from '@app-builder/queries/settings/organization/update-allowed-networks';
 import { handleSubmit } from '@app-builder/utils/form';
+import { isMutationSuccess } from '@app-builder/utils/http/mutation';
 import { useForm, useStore } from '@tanstack/react-form';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
@@ -30,7 +31,11 @@ export const IpWhitelistingSettingsPage = ({
       allowedNetworks,
     },
     onSubmit: ({ value }) => {
-      updateAllowedNetworksMutation.mutateAsync(value).then(() => {
+      updateAllowedNetworksMutation.mutateAsync(value).then((res) => {
+        if (isMutationSuccess(res)) {
+          // Manually update the form value as the backend registers normalized values of cidr/ips
+          form.setFieldValue('allowedNetworks', res.data.subnets);
+        }
         revalidate();
       });
     },

--- a/packages/app-builder/src/queries/settings/organization/update-allowed-networks.ts
+++ b/packages/app-builder/src/queries/settings/organization/update-allowed-networks.ts
@@ -1,10 +1,11 @@
+import { PromiseMutationResponse } from '@app-builder/utils/http/mutation';
 import { getRoute } from '@app-builder/utils/routes';
 import { uniqueBy } from '@app-builder/utils/schema/helpers/unique-array';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { useMutation } from '@tanstack/react-query';
 import z from 'zod/v4';
 
-export const cidrSchema = z.union([z.cidrv4(), z.cidrv6()]);
+export const cidrSchema = z.union([z.cidrv4(), z.cidrv6(), z.ipv4(), z.ipv6()]);
 
 export const updateAllowedNetworksPayloadSchema = z.object({
   allowedNetworks: uniqueBy(z.array(cidrSchema), (s) => s),
@@ -26,7 +27,7 @@ export const useUpdateAllowedNetworks = (organizationId: string) => {
         body: JSON.stringify(payload),
       });
 
-      return response.json();
+      return response.json() as PromiseMutationResponse<{ subnets: string[] }>;
     },
   });
 };

--- a/packages/app-builder/src/repositories/OrganizationRepository.ts
+++ b/packages/app-builder/src/repositories/OrganizationRepository.ts
@@ -15,7 +15,7 @@ export interface OrganizationRepository {
     organizationId: string;
     changes: OrganizationUpdateInput;
   }): Promise<Organization>;
-  updateAllowedNetworks(organizationId: string, allowedNetworks: string[]): Promise<void>;
+  updateAllowedNetworks(organizationId: string, allowedNetworks: string[]): Promise<string[]>;
 }
 
 export function makeGetOrganizationRepository() {
@@ -53,7 +53,7 @@ export function makeGetOrganizationRepository() {
       return adaptOrganizationDto(organization);
     },
     updateAllowedNetworks: async (organizationId: string, allowedNetworks: string[]) => {
-      await marbleCoreApiClient.updateOrganizationSubnets(organizationId, {
+      return await marbleCoreApiClient.updateOrganizationSubnets(organizationId, {
         subnets: allowedNetworks,
       });
     },

--- a/packages/app-builder/src/routes/ressources+/settings+/organization+/$organizationId.update-allowed-networks.tsx
+++ b/packages/app-builder/src/routes/ressources+/settings+/organization+/$organizationId.update-allowed-networks.tsx
@@ -28,7 +28,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 
   try {
-    await organization.updateAllowedNetworks(organizationId, payload.data.allowedNetworks);
+    const subnets = await organization.updateAllowedNetworks(
+      organizationId,
+      payload.data.allowedNetworks,
+    );
 
     setToastMessage(toastSession, {
       type: 'success',
@@ -36,7 +39,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     });
 
     return Response.json(
-      { success: true },
+      { success: true, data: { subnets } },
       { headers: { 'Set-Cookie': await toastSessionService.commitSession(toastSession) } },
     );
   } catch (error) {

--- a/packages/app-builder/src/utils/http/mutation.ts
+++ b/packages/app-builder/src/utils/http/mutation.ts
@@ -1,0 +1,18 @@
+export type MutationSuccess<Data> = { success: true; data: Data; errors?: undefined };
+export type MutationFailure = { success: false; errors: string[]; data?: undefined };
+export type MutationRedirect = { success?: undefined; redirectTo: string };
+
+export type MutationResponse<Data> = MutationSuccess<Data> | MutationFailure | MutationRedirect;
+export type PromiseMutationResponse<Data> = Promise<MutationResponse<Data>>;
+
+export function isMutationSuccess<Data>(res: MutationResponse<Data>): res is MutationSuccess<Data> {
+  return res.success === true;
+}
+
+export function isMutationFailure<Data>(res: MutationResponse<Data>): res is MutationFailure {
+  return res.success === false;
+}
+
+export function isMutationRedirect<Data>(res: MutationResponse<Data>): res is MutationRedirect {
+  return res.success === undefined && 'redirectTo' in res;
+}

--- a/packages/marble-api/openapis/marblecore-api/admin.yml
+++ b/packages/marble-api/openapis/marblecore-api/admin.yml
@@ -435,7 +435,9 @@
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationSubnetsDto"
+              type: array
+              items:
+                type: string
       '400':
         $ref: 'components.yml#/responses/400'
       '422':

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -3923,7 +3923,7 @@ export function deleteOrganization(organizationId: string, opts?: Oazapfts.Reque
 export function updateOrganizationSubnets(organizationId: string, organizationSubnetsDto: OrganizationSubnetsDto, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
-        data: OrganizationSubnetsDto;
+        data: string[];
     } | {
         status: 400;
         data: string;


### PR DESCRIPTION
This PR does 2 things:
- It updates the field with the registered ranges on the backend (they can be register différently than the values sent, i.e: "192.168.1.24" will become "192.168.1.24/32" and ranges are normalized)
- Allow single IP V4/V6 to be added instead of only ranges.