### PR TITLE
Fix typo breaking "prepare" button

### DIFF
--- a/packages/app-builder/src/components/Scenario/Iteration/Actions/PrepareScenarioVersion.tsx
+++ b/packages/app-builder/src/components/Scenario/Iteration/Actions/PrepareScenarioVersion.tsx
@@ -42,7 +42,7 @@ export function PrepareScenarioVersion({
       </Tooltip.Default>
     );
   }
-  if (!isPreparationServiceOccupied) {
+  if (isPreparationServiceOccupied) {
     return (
       <Tooltip.Default
         className="text-xs"


### PR DESCRIPTION
TL:DR: when I did https://github.com/checkmarble/marble-frontend/pull/1096, I changed the condition to `!isPreparationServiceOccupied` at some point to check that the tooltip displays right when the service is occupied (which is harder to replicate locally), but then forgot to remove it...