### PR TITLE
feat: set default inbox page size to 50 and make it customizable MAR-1245

### DIFF
--- a/packages/app-builder/src/components/PaginationButtons.tsx
+++ b/packages/app-builder/src/components/PaginationButtons.tsx
@@ -13,7 +13,7 @@ export const paginationSchema = z.object({
   offsetId: z.string().optional(),
   next: z.coerce.boolean().optional(),
   previous: z.coerce.boolean().optional(),
-  limit: z.number().optional(),
+  limit: z.coerce.number().optional(),
   order: z.enum(['ASC', 'DESC']).optional(),
   sorting: z.enum(['created_at']).optional(),
 });
@@ -28,6 +28,7 @@ type CursorPaginationsButtonsProps = PaginatedResponse<ItemWithId> & {
   hasPreviousPage: boolean;
   boundariesDisplay: 'ranks' | 'dates';
   pageNb: number;
+  itemsPerPage?: number;
 };
 
 function FormattedDatesRange({
@@ -143,13 +144,21 @@ function FormattedDatesRange({
   );
 }
 
-function RankNumberRange({ pageNb, nbInPage }: { pageNb: number; nbInPage: number }) {
+function RankNumberRange({
+  pageNumber,
+  currentPageItemCount,
+  itemsPerPage,
+}: {
+  pageNumber: number;
+  currentPageItemCount: number;
+  itemsPerPage: number;
+}) {
   const { t } = useTranslation(['common']);
 
-  const start = pageNb * defaultPaginationSize + 1;
-  const end = nbInPage > 0 ? pageNb * defaultPaginationSize + nbInPage : 0;
+  const start = pageNumber * itemsPerPage + 1;
+  const end = currentPageItemCount > 0 ? pageNumber * itemsPerPage + currentPageItemCount : 0;
 
-  if (pageNb === 0 && nbInPage === 0) {
+  if (pageNumber === 0 && currentPageItemCount === 0) {
     return null;
   }
 
@@ -170,6 +179,7 @@ export function CursorPaginationButtons({
   onPaginationChange,
   boundariesDisplay,
   pageNb,
+  itemsPerPage = defaultPaginationSize,
 }: CursorPaginationsButtonsProps) {
   const language = useFormatLanguage();
 
@@ -198,7 +208,11 @@ export function CursorPaginationButtons({
   return (
     <div className="flex items-center justify-end gap-2">
       {boundariesDisplay === 'ranks' ? (
-        <RankNumberRange pageNb={pageNb} nbInPage={items.length} />
+        <RankNumberRange
+          pageNumber={pageNb}
+          currentPageItemCount={items.length}
+          itemsPerPage={itemsPerPage}
+        />
       ) : (
         <FormattedDatesRange {...{ startTs, endTs, language }} />
       )}

--- a/packages/app-builder/src/hooks/useCursorPaginatedFetcher.ts
+++ b/packages/app-builder/src/hooks/useCursorPaginatedFetcher.ts
@@ -10,6 +10,7 @@ import { useCursorPagination } from './useCursorPagination';
 type BaseUseCursorPaginatedFetcherOptions<D> = {
   resourceId: string | shortUUID.UUID;
   initialData: D;
+  itemsPerPage?: number;
   getQueryParams?: (cursor: string | null) => Record<string, unknown>;
   validateData?: (data: D) => boolean;
 };
@@ -24,6 +25,7 @@ type UseCursorPaginatedFetcherOptions<T, D> = BaseUseCursorPaginatedFetcherOptio
 export const useCursorPaginatedFetcher = <T, D = T>({
   resourceId,
   initialData,
+  itemsPerPage,
   getQueryParams,
   validateData,
   ...opts

--- a/packages/app-builder/src/locales/ar/cases.json
+++ b/packages/app-builder/src/locales/ar/cases.json
@@ -203,6 +203,7 @@
   "kyc_enrichment.loading": "تحميل التعزيز KYC... (يمكن أن يستغرق ذلك دقيقة واحدة)",
   "kyc_enrichment.loading.toaster.error": "فشل تحميل التعزيز KYC",
   "kyc_enrichment.title": "KYC Enrichment",
+  "list.results_per_page": "حالات لكل صفحة",
   "next_unassigned_case": "انتقل إلى القضية غير المعينة التالية",
   "pick_file_cta": "اختر ملفًا",
   "required_actions.decide_final_status": "تقرر الوضع النهائي",

--- a/packages/app-builder/src/locales/ar/common.json
+++ b/packages/app-builder/src/locales/ar/common.json
@@ -55,7 +55,7 @@
   "help_center.to_switch_tabs": "للتبديل بين التبويبات",
   "hide": "يخفي",
   "items_displayed_dates": "من <emph> {{start}} </emph> إلى <emph> {{end}} </emph>",
-  "items_displayed_ranks": "من <emph> {{start}} </emph> إلى <remphown> {{end}} </emph>",
+  "items_displayed_ranks": "من <emph> {{start}} </emph> إلى <emph> {{end}} </emph>",
   "items_displayed_same_date": "على <emph> {{date}} </emph> من <emph> {{start}} </emph> إلى <emph> {{end}} </emph>",
   "items_displayed_same_datetime": "على <emph> {{Date}} </emph> في <emph> {{time}} </emph>",
   "live": "يعيش",

--- a/packages/app-builder/src/locales/en/cases.json
+++ b/packages/app-builder/src/locales/en/cases.json
@@ -203,6 +203,7 @@
   "kyc_enrichment.loading": "Loading KYC enrichment...(can take up to a minute)",
   "kyc_enrichment.loading.toaster.error": "Failed to load KYC enrichment data",
   "kyc_enrichment.title": "KYC Enrichment",
+  "list.results_per_page": "Cases per page",
   "next_unassigned_case": "Go to the next unassigned case",
   "pick_file_cta": "Pick a file",
   "required_actions.decide_final_status": "Decide final status",

--- a/packages/app-builder/src/locales/fr/cases.json
+++ b/packages/app-builder/src/locales/fr/cases.json
@@ -203,6 +203,7 @@
   "kyc_enrichment.loading": "Chargement de l'enrichissement KYC... (peut prendre jusqu'à une minute)",
   "kyc_enrichment.loading.toaster.error": "Échec du chargement de l'enrichissement KYC",
   "kyc_enrichment.title": "Enrichissement KYC",
+  "list.results_per_page": "Investigations par page",
   "next_unassigned_case": "Aller à la prochaine investigation non-affectée",
   "pick_file_cta": "Choisissez un fichier",
   "required_actions.decide_final_status": "Choisir le statut final",

--- a/packages/app-builder/src/repositories/CaseRepository.ts
+++ b/packages/app-builder/src/repositories/CaseRepository.ts
@@ -24,13 +24,14 @@ import {
 } from '@app-builder/models/kyc-case-enrichment';
 import {
   adaptPagination,
-  defaultPaginationSize,
   type FiltersWithPagination,
   type PaginatedResponse,
 } from '@app-builder/models/pagination';
 import { add } from 'date-fns/add';
 import { map } from 'remeda';
 import { Temporal } from 'temporal-polyfill';
+
+export const DEFAULT_CASE_PAGINATION_SIZE = 50;
 
 export type CaseFilters = {
   snoozed?: boolean;
@@ -140,7 +141,7 @@ export function makeGetCaseRepository() {
         inboxId: inboxIds,
         status: statuses,
         includeSnoozed: rest.snoozed,
-        limit: defaultPaginationSize,
+        limit: DEFAULT_CASE_PAGINATION_SIZE,
         ...rest,
       });
 


### PR DESCRIPTION
- Make default inbox pagination limit 50
- Add button to customize limit for 25, 50 and 100 items per page
<img width="1493" height="109" alt="image" src="https://github.com/user-attachments/assets/704fb6ab-1e2d-4e94-a430-e5849ac402f2" />
