### PR TITLE
fix: case manager page screenings key

### DIFF
--- a/packages/app-builder/src/components/Cases/RequiredActions.tsx
+++ b/packages/app-builder/src/components/Cases/RequiredActions.tsx
@@ -21,15 +21,15 @@ export const RequiredActions = ({
   caseId,
 }: {
   caseId: string;
-  decision: Pick<DetailedCaseDecision, 'id' | 'outcome' | 'reviewStatus' | 'sanctionChecks'>;
+  decision: Pick<DetailedCaseDecision, 'id' | 'outcome' | 'reviewStatus' | 'screenings'>;
 }) => {
   const { t } = useTranslation(casesI18n);
   const reviewDecisionModalStore = useDialogStore();
 
-  const hasPendingScreening = decision.sanctionChecks.some((s) => s.status === 'in_review');
+  const hasPendingScreening = decision.screenings.some((s) => s.status === 'in_review');
   const isPendingDecision =
     decision.reviewStatus === 'pending' && decision.outcome === 'block_and_review';
-  const isThereSanctionChecks = decision.sanctionChecks.length > 0;
+  const isThereSanctionChecks = decision.screenings.length > 0;
 
   return isPendingDecision || isThereSanctionChecks ? (
     <div className="bg-grey-98 group-hover:bg-grey-95 flex flex-col gap-2.5 rounded-sm p-4 transition-colors">
@@ -43,10 +43,10 @@ export const RequiredActions = ({
             </span>
           </div>
           <div className="flex flex-col">
-            {decision.sanctionChecks.map((s, i) => {
+            {decision.screenings.map((s, i) => {
               return (
                 <div key={s.id} className="flex items-center pl-6 text-xs font-medium">
-                  <Divider isLast={i === decision.sanctionChecks.length - 1} />
+                  <Divider isLast={i === decision.screenings.length - 1} />
                   <span
                     className={cn('inline-flex items-center gap-2 text-xs font-medium', {
                       'text-red-43': s.status === 'error',
@@ -96,7 +96,7 @@ export const RequiredActions = ({
           <ReviewDecisionModal
             decisionId={decision.id}
             store={reviewDecisionModalStore}
-            sanctionCheck={decision.sanctionChecks[0]}
+            sanctionCheck={decision.screenings[0]}
           />
         </div>
       ) : null}

--- a/packages/app-builder/src/models/cases.ts
+++ b/packages/app-builder/src/models/cases.ts
@@ -650,7 +650,7 @@ export type DetailedCaseDecision = {
   };
   score: number;
   rules: RuleExecution[];
-  sanctionChecks: {
+  screenings: {
     id: string;
     status: SanctionCheckStatus;
     partial: boolean;
@@ -679,6 +679,6 @@ export function adaptDetailedCaseDecision(dto: DetailedCaseDecisionDto): Detaile
     },
     score: dto.score,
     rules: dto.rules.map((r) => adaptRuleExecutionDto(r, false)),
-    sanctionChecks: dto.screenings ?? [],
+    screenings: dto.screenings ?? [],
   };
 }

--- a/packages/app-builder/src/models/cases.ts
+++ b/packages/app-builder/src/models/cases.ts
@@ -679,6 +679,6 @@ export function adaptDetailedCaseDecision(dto: DetailedCaseDecisionDto): Detaile
     },
     score: dto.score,
     rules: dto.rules.map((r) => adaptRuleExecutionDto(r, false)),
-    sanctionChecks: dto.sanction_checks ?? [],
+    sanctionChecks: dto.screenings ?? [],
   };
 }

--- a/packages/marble-api/openapis/marblecore-api/cases.yml
+++ b/packages/marble-api/openapis/marblecore-api/cases.yml
@@ -1009,7 +1009,7 @@ components:
               type: array
               items:
                 $ref: 'decisions.yml#/components/schemas/RuleExecutionDto'
-            sanction_checks:
+            screenings:
               type: array
               items:
                 type: object

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -368,7 +368,7 @@ export type RuleExecutionDto = {
 };
 export type DetailedCaseDecisionDto = CaseDecisionDto & {
     rules: RuleExecutionDto[];
-    sanction_checks?: {
+    screenings?: {
         id: string;
         status: "in_review" | "confirmed_hit";
         name: string;


### PR DESCRIPTION
Fix: in this PR https://github.com/checkmarble/marble-backend/pull/1202
the "list decisions by case" endpoint now returns screenings (partial) in the decisions object, but it was not using the correct key.

More complete renaming of any remaining "sanctionCheck"s to be done in a later PR.