### PR TITLE
fix: fix z-index side panel create case

### DIFF
--- a/packages/app-builder/src/components/Cases/CaseRightPanel.tsx
+++ b/packages/app-builder/src/components/Cases/CaseRightPanel.tsx
@@ -75,7 +75,7 @@ function CaseRightPanelRoot({ children, ...props }: Omit<RightPanelRootProps, 'o
 const CaseRightPanelContent = () => {
   const { t } = useTranslation(casesI18n);
   return (
-    <RightPanel.Content className="flex max-w-md flex-col gap-4">
+    <RightPanel.Content className="flex max-w-md flex-col gap-4 z-10">
       <RightPanel.Title>
         <span className="w-full first-letter:capitalize">{t('cases:case.new_case')}</span>
         <RightPanel.Close />


### PR DESCRIPTION
- New sticky pagination was going on top of the side panel, fixed the z-index for it to always be on top