### PR TITLE
Pascal/workflows UI glitch

### DIFF
--- a/packages/app-builder/src/components/Workflows/ActionSelector.tsx
+++ b/packages/app-builder/src/components/Workflows/ActionSelector.tsx
@@ -224,13 +224,13 @@ export function ActionSelector({ action, onChange }: ActionSelectorProps) {
                 key={option.value}
                 value={option.value}
                 onSelect={() => handleActionSelect(option.value)}
-                className="flex flex-col items-start gap-1 p-3 hover:bg-grey-05 rounded-md cursor-pointer"
+                className="h-auto flex-col items-start gap-1 p-3"
               >
                 <div className="flex items-center gap-2">
                   <Icon icon={option.icon as any} className="size-4 text-grey-secondary" />
                   <span className="font-medium text-grey-primary">{option.label}</span>
                 </div>
-                <span className="text-sm text-grey-secondary">{option.description}</span>
+                <span className="text-s text-grey-secondary">{option.description}</span>
               </MenuCommand.Item>
             ))}
           </MenuCommand.List>

--- a/packages/app-builder/src/components/Workflows/CaseNameEditor.tsx
+++ b/packages/app-builder/src/components/Workflows/CaseNameEditor.tsx
@@ -1,5 +1,5 @@
 import { AstBuilder } from '@app-builder/components/AstBuilder';
-import { type AstNode, stripIdFromNode } from '@app-builder/models';
+import { type AstNode } from '@app-builder/models';
 import {
   isStringTemplateAstNode,
   NewStringTemplateAstNode,
@@ -8,11 +8,8 @@ import {
   type StringTemplateAstNode,
 } from '@app-builder/models/astNode/strings';
 import { useCurrentScenario } from '@app-builder/routes/_builder+/detection+/scenarios+/$scenarioId+/_layout';
-import { Fragment, type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, type ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import * as R from 'remeda';
-import { Button } from 'ui-design-system';
-import { Icon } from 'ui-icons';
 import { useDefaultCaseName } from './CaseNameEditor.hook';
 
 export type CaseNameEditorProps = {
@@ -26,24 +23,8 @@ export const CaseNameEditor = ({ label, value, onChange }: CaseNameEditorProps) 
   const currentScenario = useCurrentScenario();
   const [isEditing, setIsEditing] = useState(false);
   const { defaultCaseNameNode } = useDefaultCaseName(currentScenario.triggerObjectType);
-  // const { validate, validation } = useAstValidationFetcher(currentScenario.id);
-  const initialValueRef = useRef(value);
-  // const handleValidation = useMemo(() => {
-  //   return R.debounce((astNode: AstNode) => validate(astNode, 'string'), {
-  //     waitMs: 300,
-  //   }).call;
-  // }, [validate]);
 
   const caseNameContent = value ? getAstNodeDisplayElement(value) : '';
-  const isDefaultCaseName = useMemo(() => {
-    if (!value) return true;
-
-    const strippedValue = stripIdFromNode(value);
-    const strippedInitial = stripIdFromNode(initialValueRef.current ?? defaultCaseNameNode);
-    const isEqual = R.isDeepEqual(strippedValue, strippedInitial);
-
-    return isEqual;
-  }, [value, initialValueRef, defaultCaseNameNode]);
 
   const handleAstNodeChange = (newAstNode: AstNode) => {
     if (isStringTemplateAstNode(newAstNode)) {
@@ -68,15 +49,6 @@ export const CaseNameEditor = ({ label, value, onChange }: CaseNameEditorProps) 
         >
           {caseNameContent}
         </button>
-        {!isDefaultCaseName ? (
-          <Button
-            variant="secondary"
-            onClick={() => onChange(initialValueRef.current ?? defaultCaseNameNode)}
-            className="self-stretch"
-          >
-            <Icon icon="restart-alt" className="size-5" />
-          </Button>
-        ) : null}
         {isEditing ? (
           <AstBuilder.Provider scenarioId={currentScenario.id} mode="edit">
             <AstBuilder.EditModal

--- a/packages/app-builder/src/components/Workflows/CaseNameEditor.tsx
+++ b/packages/app-builder/src/components/Workflows/CaseNameEditor.tsx
@@ -50,7 +50,7 @@ export const CaseNameEditor = ({ label, value, onChange }: CaseNameEditorProps) 
           {caseNameContent}
         </button>
         {isEditing ? (
-          <AstBuilder.Provider scenarioId={currentScenario.id} mode="edit">
+          <AstBuilder.Provider scenarioId={currentScenario.id} mode="edit" renderLoading={() => null}>
             <AstBuilder.EditModal
               node={value ?? NewStringTemplateAstNode()}
               onSave={handleAstNodeChange}

--- a/packages/app-builder/src/components/Workflows/ConditionSelector.tsx
+++ b/packages/app-builder/src/components/Workflows/ConditionSelector.tsx
@@ -179,12 +179,10 @@ export function ConditionSelector({
                   key={option.value}
                   value={option.value}
                   onSelect={() => handleConditionSelect(option.value)}
-                  className="flex flex-col items-start gap-1 p-3 hover:bg-grey-05 rounded-md cursor-pointer"
+                  className="h-auto flex-col items-start gap-1 p-3"
                 >
-                  <div className="flex items-center">
-                    <span className="font-medium text-grey-primary">{option.label}</span>
-                  </div>
-                  <span className="text-sm text-grey-secondary">{option.description}</span>
+                  <span className="font-medium text-grey-primary">{option.label}</span>
+                  <span className="text-s text-grey-secondary">{option.description}</span>
                 </MenuCommand.Item>
               ))}
             </MenuCommand.List>

--- a/packages/app-builder/src/components/Workflows/Rule.tsx
+++ b/packages/app-builder/src/components/Workflows/Rule.tsx
@@ -68,11 +68,11 @@ export function WorkflowRule({ rule, provided, snapshot }: RuleProps) {
         } ${isRuleModified ? 'drop-shadow-2xl' : ''}`}
       >
         {/* Conditions and Actions Boxes */}
-        <div className="flex items-center w-full">
-          <div className="flex-none items-stretch relative w-[800px] bg-surface-card">
+        <div className="flex items-stretch w-full">
+          <div className="flex flex-col relative min-w-0 w-[min(800px,60vw)]">
             {/* Unified bordered wrapper for title + content */}
             <div
-              className={`rounded-lg overflow-hidden border-2 transition-all duration-200 ${
+              className={`flex-1 rounded-lg overflow-hidden border-2 bg-surface-card transition-all duration-200 ${
                 snapshot.isDragging
                   ? 'border-purple-hover shadow-xl'
                   : isRuleModified
@@ -193,28 +193,26 @@ export function WorkflowRule({ rule, provided, snapshot }: RuleProps) {
             </div>
           </div>
 
-          {/* "Then" arrow */}
-          <div className="flex items-center justify-center">
+          {/* "Then" arrow + Actions Box — grouped so the arrow aligns to the action box center */}
+          <div className="flex items-center self-start">
             <div className="w-28 h-0.5 bg-grey-disabled relative">
               <div className="absolute -right-0 top-1/2 -translate-y-1/2 w-0 h-0 border-t-4 border-b-4 border-l-8 border-transparent border-l-grey-disabled"></div>
               <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-grey-border px-3 py-1 rounded-sm z-10">
                 <span className="text-sm font-bold text-white uppercase tracking-wide">{t('common:then')}</span>
               </div>
             </div>
-          </div>
-
-          {/* Actions Box */}
-          <div
-            className={`flex-none rounded-lg border-2 border-grey-border bg-surface-card p-4 transition-all duration-200 w-auto max-w-full bg-surface-card ${
-              snapshot.isDragging
-                ? 'border-purple-hover shadow-xl'
-                : isRuleModified
-                  ? 'border-purple-hover shadow-xl ring-2 ring-blue-200'
-                  : 'border-grey-20'
-            }`}
-          >
-            <div className="bg-grey-05 rounded-md">
-              <ActionSelector action={displayRule.actions?.[0]} onChange={(action) => updateAction(action)} />
+            <div
+              className={`flex-none rounded-lg border-2 border-grey-border bg-surface-card p-4 transition-all duration-200 w-auto max-w-full ${
+                snapshot.isDragging
+                  ? 'border-purple-hover shadow-xl'
+                  : isRuleModified
+                    ? 'border-purple-hover shadow-xl ring-2 ring-blue-200'
+                    : 'border-grey-20'
+              }`}
+            >
+              <div className="bg-grey-05 rounded-md">
+                <ActionSelector action={displayRule.actions?.[0]} onChange={(action) => updateAction(action)} />
+              </div>
             </div>
           </div>
         </div>

--- a/packages/app-builder/src/components/Workflows/WorkflowList.tsx
+++ b/packages/app-builder/src/components/Workflows/WorkflowList.tsx
@@ -49,9 +49,9 @@ export function WorkflowList() {
       <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <Droppable droppableId="workflow-rules" direction="vertical">
           {(provided) => (
-            <div className="gap-8 py-8 max-w-7xl ml-8" {...provided.droppableProps} ref={provided.innerRef}>
+            <div className="flex flex-col py-8 max-w-7xl ml-8" {...provided.droppableProps} ref={provided.innerRef}>
               {!isLoading && rules.length === 0 ? (
-                <div className="w-[800px] text-center text-grey-60 italic py-8">
+                <div className="w-[min(800px,60vw)] text-center text-grey-60 italic py-8">
                   {t('workflows:empty_state.no_rule_yet')}
                 </div>
               ) : null}
@@ -74,12 +74,12 @@ export function WorkflowList() {
                         {index < rules.length - 1 && (
                           <div
                             className={cn(
-                              'items-center w-[800px] justify-center transition-all duration-300',
+                              'flex items-center w-[min(800px,60vw)] justify-center transition-all duration-300',
                               isDragging ? 'opacity-0' : 'opacity-100',
                               isCurrentRuleEditing ? 'opacity-40 pointer-events-none blur-xs' : '',
                             )}
                           >
-                            <div className="w-[800px] flex justify-center items-center relative">
+                            <div className="w-full flex justify-center items-center relative">
                               <div className="w-0.5 h-16 bg-grey-disabled relative">
                                 <div className="absolute -bottom-0 left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-8 border-transparent border-t-grey-disabled"></div>
                                 <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-grey-border px-3 py-1 rounded-sm z-10">
@@ -103,7 +103,7 @@ export function WorkflowList() {
       </DragDropContext>
 
       <div
-        className={`flex flex-col items-center w-[800px] ml-8 pb-8 transition-all duration-300 ${
+        className={`flex flex-col items-center w-[min(800px,60vw)] ml-8 pb-8 transition-all duration-300 ${
           hasModifiedRules ? 'opacity-40 pointer-events-none blur-xs' : ''
         }`}
       >


### PR DESCRIPTION
## Contents
- fix some css issues on workflows page
- remove the "restore to default" button for case name template, that was not really useful.

## After
<img width="600" height="308" alt="Capture d’écran 2026-04-07 à 17 18 02" src="https://github.com/user-attachments/assets/0e6143c5-a6f6-4f6d-ac1c-0f303fb666ad" />
<img width="600" height="318" alt="Capture d’écran 2026-04-07 à 17 17 57" src="https://github.com/user-attachments/assets/e6a5ffb8-39c5-414a-82a2-a63470051079" />
<img width="600" height="514" alt="Capture d’écran 2026-04-07 à 17 17 53" src="https://github.com/user-attachments/assets/24286b8b-ef14-464a-a9b7-a26d5ea8588f" />


## Before
<img width="600" height="368" alt="Capture d’écran 2026-04-07 à 17 19 27" src="https://github.com/user-attachments/assets/f3a0dda5-33fa-41e2-8703-388b02f2fdbe" />
<img width="600" height="250" alt="Capture d’écran 2026-04-07 à 17 19 23" src="https://github.com/user-attachments/assets/2ea4589b-76cf-44e9-a7f1-903058d5f4a9" />
<img width="600" height="343" alt="Capture d’écran 2026-04-07 à 17 19 19" src="https://github.com/user-attachments/assets/2105ddf1-abad-4dbf-9fed-c144ad286757" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Enhanced responsive layout for workflow editor components across different screen sizes.
  * Refined dropdown option styling for clearer visual presentation.
  * Improved spacing and alignment in workflow rule action layouts.

* **Refactor**
  * Removed unused case name reset functionality to streamline the editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->