### PR TITLE
fix: remove circular imports for server functions and queries

### DIFF
--- a/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ReviewScreeningMatch.tsx
+++ b/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ReviewScreeningMatch.tsx
@@ -2,11 +2,9 @@ import { Callout } from '@app-builder/components';
 import { StatusRadioGroup } from '@app-builder/components/Screenings/StatusRadioGroup';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { ContinuousScreeningMatch } from '@app-builder/models/continuous-screening';
-import {
-  reviewMatchPayloadSchema,
-  useReviewContinuousScreeningMatchMutation,
-} from '@app-builder/queries/continuous-screening/review-match';
+import { useReviewContinuousScreeningMatchMutation } from '@app-builder/queries/continuous-screening/review-match';
 import { ReviewScreeningMatchPayload } from '@app-builder/queries/screening/review-screening-match';
+import { reviewMatchPayloadSchema } from '@app-builder/schemas/continuous-screenings';
 import { handleSubmit, submitOnCtrlEnter } from '@app-builder/utils/form';
 import { useForm, useStore } from '@tanstack/react-form';
 import { ReactNode, useState } from 'react';

--- a/packages/app-builder/src/components/ClientDetail/AddConfigurationModal.tsx
+++ b/packages/app-builder/src/components/ClientDetail/AddConfigurationModal.tsx
@@ -1,9 +1,7 @@
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { DataModel } from '@app-builder/models';
-import {
-  addConfigurationPayloadSchema,
-  useAddConfigurationMutation,
-} from '@app-builder/queries/client360/add-configuration';
+import { useAddConfigurationMutation } from '@app-builder/queries/client360/add-configuration';
+import { addConfigurationPayloadSchema } from '@app-builder/schemas/client360';
 import { handleSubmit } from '@app-builder/utils/form';
 import { useForm, useStore } from '@tanstack/react-form';
 import { Client360Table } from 'marble-api';

--- a/packages/app-builder/src/components/ClientDetail/SearchPage.tsx
+++ b/packages/app-builder/src/components/ClientDetail/SearchPage.tsx
@@ -1,5 +1,5 @@
-import { Client360SearchPayload } from '@app-builder/queries/client360/search';
 import { useDataModelQuery } from '@app-builder/queries/data/get-data-model';
+import { Client360SearchPayload } from '@app-builder/schemas/client360';
 import { Client360Table } from 'marble-api';
 import { Fragment, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/packages/app-builder/src/components/ClientDetail/SearchResults.tsx
+++ b/packages/app-builder/src/components/ClientDetail/SearchResults.tsx
@@ -1,5 +1,6 @@
-import { Client360SearchPayload, useSearchClient360Query } from '@app-builder/queries/client360/search';
+import { useSearchClient360Query } from '@app-builder/queries/client360/search';
 import { useGetAnnotationsQuery } from '@app-builder/queries/data/get-annotations';
+import { Client360SearchPayload } from '@app-builder/schemas/client360';
 import { useOrganizationObjectTags } from '@app-builder/services/organization/organization-object-tags';
 import { Link } from '@tanstack/react-router';
 import { Client360Table } from 'marble-api';

--- a/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
@@ -2,11 +2,8 @@ import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorCon
 import { type DurationUnit, SECONDS_PER_UNIT, secondsToDisplay } from '@app-builder/models/scoring';
 import { useDataModelQuery } from '@app-builder/queries/data/get-data-model';
 import { useListScoringRulesetsQuery } from '@app-builder/queries/scoring/list-rulesets';
-import {
-  type UpdateScoringRulesetPayload,
-  updateScoringRulesetPayloadSchema,
-  useUpdateScoringRulesetMutation,
-} from '@app-builder/queries/scoring/update-ruleset';
+import { useUpdateScoringRulesetMutation } from '@app-builder/queries/scoring/update-ruleset';
+import { type UpdateScoringRulesetPayload, updateScoringRulesetPayloadSchema } from '@app-builder/schemas/user-scoring';
 import { handleSubmit } from '@app-builder/utils/form';
 import { createSimpleContext } from '@marble/shared';
 import { useForm } from '@tanstack/react-form';

--- a/packages/app-builder/src/constants/client360.ts
+++ b/packages/app-builder/src/constants/client360.ts
@@ -1,0 +1,1 @@
+export const semanticTypes = ['person', 'company'] as const;

--- a/packages/app-builder/src/queries/client360/add-configuration.ts
+++ b/packages/app-builder/src/queries/client360/add-configuration.ts
@@ -1,18 +1,7 @@
+import { AddConfigurationPayload } from '@app-builder/schemas/client360';
 import { addClient360ConfigurationFn } from '@app-builder/server-fns/client-360';
 import { useMutation } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
-import { z } from 'zod/v4';
-
-const semanticTypes = ['person', 'company'] as const;
-
-export const addConfigurationPayloadSchema = z.object({
-  tableId: z.uuid(),
-  semanticType: z.enum(semanticTypes),
-  captionField: z.string().min(1),
-  alias: z.string().optional(),
-});
-
-export type AddConfigurationPayload = z.infer<typeof addConfigurationPayloadSchema>;
 
 export const useAddConfigurationMutation = () => {
   const addConfiguration = useServerFn(addClient360ConfigurationFn);

--- a/packages/app-builder/src/queries/client360/search.ts
+++ b/packages/app-builder/src/queries/client360/search.ts
@@ -1,16 +1,9 @@
 import { DataModelObjectValue } from '@app-builder/models';
 import { PaginatedResponse } from '@app-builder/models/pagination';
+import { Client360SearchPayload } from '@app-builder/schemas/client360';
 import { searchClient360Fn } from '@app-builder/server-fns/client-360';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
-import { z } from 'zod/v4';
-
-export const client360SearchPayloadSchema = z.object({
-  table: z.string(),
-  terms: z.string(),
-});
-
-export type Client360SearchPayload = z.infer<typeof client360SearchPayloadSchema>;
 
 export const useSearchClient360Query = (payload: Client360SearchPayload) => {
   const searchClient360 = useServerFn(searchClient360Fn);

--- a/packages/app-builder/src/queries/continuous-screening/review-match.ts
+++ b/packages/app-builder/src/queries/continuous-screening/review-match.ts
@@ -1,15 +1,7 @@
+import { ReviewMatchPayload } from '@app-builder/schemas/continuous-screenings';
 import { reviewContinuousScreeningMatchFn } from '@app-builder/server-fns/continuous-screening';
 import { useMutation } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
-import { z } from 'zod/v4';
-
-export const reviewMatchPayloadSchema = z.object({
-  matchId: z.string(),
-  status: z.union([z.literal('confirmed_hit'), z.literal('no_hit')]),
-  comment: z.string().optional(),
-});
-
-export type ReviewMatchPayload = z.infer<typeof reviewMatchPayloadSchema>;
 
 export const useReviewContinuousScreeningMatchMutation = () => {
   const reviewContinuousScreeningMatch = useServerFn(reviewContinuousScreeningMatchFn);

--- a/packages/app-builder/src/queries/scoring/update-ruleset.ts
+++ b/packages/app-builder/src/queries/scoring/update-ruleset.ts
@@ -1,34 +1,7 @@
+import { type UpdateScoringRulesetPayload } from '@app-builder/schemas/user-scoring';
 import { updateScoringRulesetFn } from '@app-builder/server-fns/scoring';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
-import { z } from 'zod/v4';
-
-export const updateScoringRulesetPayloadSchema = z.object({
-  id: z.string().optional(),
-  recordType: z.string(),
-  name: z.string(),
-  description: z.string().optional(),
-  thresholds: z.array(z.number()).superRefine((arr, ctx) => {
-    arr.forEach((val, i) => {
-      if (i > 0 && val <= arr[i - 1]!) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [i] });
-      }
-    });
-  }),
-  cooldownSeconds: z.number().optional(),
-  scoringIntervalSeconds: z.number().optional(),
-  rules: z.array(
-    z.object({
-      stableId: z.string().optional(),
-      name: z.string(),
-      description: z.string().optional(),
-      riskType: z.string(),
-      ast: z.any(),
-    }),
-  ),
-});
-
-export type UpdateScoringRulesetPayload = z.infer<typeof updateScoringRulesetPayloadSchema>;
 
 export const useUpdateScoringRulesetMutation = () => {
   const updateScoringRuleset = useServerFn(updateScoringRulesetFn);

--- a/packages/app-builder/src/queries/scoring/update-settings.ts
+++ b/packages/app-builder/src/queries/scoring/update-settings.ts
@@ -1,13 +1,7 @@
+import { type UpdateScoringSettingsPayload } from '@app-builder/schemas/user-scoring';
 import { updateScoringSettingsFn } from '@app-builder/server-fns/scoring';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
-import { z } from 'zod/v4';
-
-export const updateScoringSettingsPayloadSchema = z.object({
-  maxRiskLevel: z.number(),
-});
-
-export type UpdateScoringSettingsPayload = z.infer<typeof updateScoringSettingsPayloadSchema>;
 
 export const useUpdateScoringSettingsMutation = () => {
   const updateScoringSettings = useServerFn(updateScoringSettingsFn);

--- a/packages/app-builder/src/schemas/client360.ts
+++ b/packages/app-builder/src/schemas/client360.ts
@@ -1,0 +1,16 @@
+import { semanticTypes } from '@app-builder/constants/client360';
+import { z } from 'zod/v4';
+
+export const client360SearchPayloadSchema = z.object({
+  table: z.string(),
+  terms: z.string(),
+});
+export type Client360SearchPayload = z.infer<typeof client360SearchPayloadSchema>;
+
+export const addConfigurationPayloadSchema = z.object({
+  tableId: z.uuid(),
+  semanticType: z.enum(semanticTypes),
+  captionField: z.string().min(1),
+  alias: z.string().optional(),
+});
+export type AddConfigurationPayload = z.infer<typeof addConfigurationPayloadSchema>;

--- a/packages/app-builder/src/schemas/continuous-screenings.ts
+++ b/packages/app-builder/src/schemas/continuous-screenings.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod/v4';
+
+export const reviewMatchPayloadSchema = z.object({
+  matchId: z.string(),
+  status: z.union([z.literal('confirmed_hit'), z.literal('no_hit')]),
+  comment: z.string().optional(),
+});
+export type ReviewMatchPayload = z.infer<typeof reviewMatchPayloadSchema>;

--- a/packages/app-builder/src/schemas/user-scoring.ts
+++ b/packages/app-builder/src/schemas/user-scoring.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+
+export const updateScoringRulesetPayloadSchema = z.object({
+  id: z.string().optional(),
+  recordType: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  thresholds: z.array(z.number()).superRefine((arr, ctx) => {
+    arr.forEach((val, i) => {
+      if (i > 0 && val <= arr[i - 1]!) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [i] });
+      }
+    });
+  }),
+  cooldownSeconds: z.number().optional(),
+  scoringIntervalSeconds: z.number().optional(),
+  rules: z.array(
+    z.object({
+      stableId: z.string().optional(),
+      name: z.string(),
+      description: z.string().optional(),
+      riskType: z.string(),
+      ast: z.any(),
+    }),
+  ),
+});
+export type UpdateScoringRulesetPayload = z.infer<typeof updateScoringRulesetPayloadSchema>;
+
+export const updateScoringSettingsPayloadSchema = z.object({
+  maxRiskLevel: z.number(),
+});
+export type UpdateScoringSettingsPayload = z.infer<typeof updateScoringSettingsPayloadSchema>;

--- a/packages/app-builder/src/server-fns/client-360.ts
+++ b/packages/app-builder/src/server-fns/client-360.ts
@@ -1,6 +1,5 @@
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
-import { addConfigurationPayloadSchema } from '@app-builder/queries/client360/add-configuration';
-import { client360SearchPayloadSchema } from '@app-builder/queries/client360/search';
+import { addConfigurationPayloadSchema, client360SearchPayloadSchema } from '@app-builder/schemas/client360';
 import { setToast } from '@app-builder/services/toast.server';
 import { createServerFn } from '@tanstack/react-start';
 

--- a/packages/app-builder/src/server-fns/continuous-screening.ts
+++ b/packages/app-builder/src/server-fns/continuous-screening.ts
@@ -1,6 +1,6 @@
 import { createContinuousScreeningConfigSchema } from '@app-builder/components/ContinuousScreening/context/CreationStepper';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
-import { reviewMatchPayloadSchema } from '@app-builder/queries/continuous-screening/review-match';
+import { reviewMatchPayloadSchema } from '@app-builder/schemas/continuous-screenings';
 import { isContinuousScreeningAvailable } from '@app-builder/services/feature-access';
 import { setToast } from '@app-builder/services/toast.server';
 import { redirect } from '@tanstack/react-router';

--- a/packages/app-builder/src/server-fns/scoring.ts
+++ b/packages/app-builder/src/server-fns/scoring.ts
@@ -1,6 +1,8 @@
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
-import { updateScoringRulesetPayloadSchema } from '@app-builder/queries/scoring/update-ruleset';
-import { updateScoringSettingsPayloadSchema } from '@app-builder/queries/scoring/update-settings';
+import {
+  updateScoringRulesetPayloadSchema,
+  updateScoringSettingsPayloadSchema,
+} from '@app-builder/schemas/user-scoring';
 import { setToast } from '@app-builder/services/toast.server';
 import { redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';


### PR DESCRIPTION
Circular imports are BAD.

Queries were defining zod schema and importing server functions. But server functions were also importing the queries to retrieve the schemas (for input validation).

So I extracted the schemas outside the queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal schema definitions for improved code maintainability and centralized type management across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->