### PR TITLE
force primary_ordering_field t o 'updated_at' if it is empty

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
@@ -424,8 +424,7 @@ export function validateValues(
   if (scope === 'table') {
     // enforce 'updated_at' to be the default sort order if there is no other
     const hasUpdatedAt = values.fields.some((f) => f.name === 'updated_at'); // should always be true
-    const mainTimestampFieldName = values.mainTimestampFieldName || (hasUpdatedAt ? 'updated_at' : '');
-    if (!mainTimestampFieldName && hasUpdatedAt) values.mainTimestampFieldName = 'updated_at';
+    if (!values.mainTimestampFieldName && hasUpdatedAt) values.mainTimestampFieldName = 'updated_at';
 
     const errors = getTablePropertyErrors(values);
     if (!values.mainTimestampFieldName) {

--- a/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
@@ -423,11 +423,10 @@ export function validateValues(
 ): ValidationResult {
   if (scope === 'table') {
     // enforce 'updated_at' to be the default sort order if there is no other
-    const mainTimestampFieldName =
-      values.mainTimestampFieldName || (values.fields.some((f) => f.name === 'updated_at') ? 'updated_at' : '');
-    if (!mainTimestampFieldName && values.fields.some((f) => f.name === 'updated_at')) {
-      values.mainTimestampFieldName = 'updated_at';
-    }
+    const hasUpdatedAt = values.fields.some((f) => f.name === 'updated_at'); // should always be true
+    const mainTimestampFieldName = values.mainTimestampFieldName || (hasUpdatedAt ? 'updated_at' : '');
+    if (!mainTimestampFieldName && hasUpdatedAt) values.mainTimestampFieldName = 'updated_at';
+
     const errors = getTablePropertyErrors(values);
     if (!values.mainTimestampFieldName) {
       errors.push({

--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
@@ -68,17 +68,6 @@ export function EditTableDrawer({
     wasOpenRef.current = open;
   }, [open, tableModel]);
 
-  const changeSet = useMemo(
-    () =>
-      computeChangeSet(
-        initialTableStateRef.current[tableModel.id]!,
-        tablesState[tableModel.id]!,
-        initialLinksStateRef.current,
-        linksState,
-      ),
-    [linksState, tablesState, tableModel.id],
-  );
-
   const isDirty = useMemo(
     () =>
       JSON.stringify(normalizeTablesStateForDirtyCheck(tablesState)) !==
@@ -237,6 +226,12 @@ export function EditTableDrawer({
       return;
     }
     setValidationErrors([]);
+    const changeSet = computeChangeSet(
+      initialTableStateRef.current[tableModel.id]!,
+      tablesState[tableModel.id]!,
+      initialLinksStateRef.current,
+      linksState,
+    );
     await onSave(
       values,
       changeSet,

--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
@@ -15,6 +15,7 @@ export function adaptUpdateTableValue(
   originalFields: TableField[],
   originalLinks: LinkValue[],
   tableNameById: Map<string, string>,
+  originalMainTimestampFieldName?: string | null,
 ): EditSemanticTablePayload {
   const tableChange = changeSet.find((change): change is TableChange => change.type === 'table');
   const changedProperties = tableChange?.changedProperties ?? [];
@@ -42,7 +43,8 @@ export function adaptUpdateTableValue(
     ...(changedProperties.includes('entityType')
       ? { semantic_type: tableState.entityType === 'unset' ? 'other' : tableState.entityType }
       : {}),
-    ...(changedProperties.includes('mainTimestampFieldName')
+    ...(changedProperties.includes('mainTimestampFieldName') ||
+    (!originalMainTimestampFieldName && !!tableState.mainTimestampFieldName)
       ? { primary_ordering_field: tableState.mainTimestampFieldName }
       : {}),
     fields: adaptFieldsOperations(
@@ -59,6 +61,7 @@ export function adaptUpdateTableValue(
     ),
     ...(fieldOrderChanged ? { metadata: { fieldOrder: currentFieldOrder } } : {}),
   };
+  console.log('adaptedTable', adaptedTable);
   return adaptedTable;
 }
 

--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
@@ -61,7 +61,6 @@ export function adaptUpdateTableValue(
     ),
     ...(fieldOrderChanged ? { metadata: { fieldOrder: currentFieldOrder } } : {}),
   };
-  console.log('adaptedTable', adaptedTable);
   return adaptedTable;
 }
 

--- a/packages/app-builder/src/components/Data/SemanticTables/Flow/TableDetails.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Flow/TableDetails.tsx
@@ -124,7 +124,14 @@ export function TableDetails({ data }: NodeProps<TableDetailsFlowNode>) {
           const tableNameById = new Map(dataModel.map((t) => [t.id, t.name]));
           await updateTableMutation
             .mutateAsync(
-              adaptUpdateTableValue(tableState, changeSet, initialTableState.fields, initialLinks, tableNameById),
+              adaptUpdateTableValue(
+                tableState,
+                changeSet,
+                initialTableState.fields,
+                initialLinks,
+                tableNameById,
+                data.tableModel.mainTimestampFieldName,
+              ),
             )
             .then(() => {
               toast.success(t('data:table_details.table_updated', { name: tableState.alias || tableState.name }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Change detection for table edits now runs at save-time instead of during render, reducing unnecessary work and improving responsiveness while editing.
  * Timestamp field validation and assignment logic streamlined for more consistent handling of main timestamps across table creation and edits.
  * Update flow preserves original timestamp selection more reliably when saving changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->