### PR TITLE
Remove OpenAPI v0 button o/.

### DIFF
--- a/packages/app-builder/src/locales/ar/api.json
+++ b/packages/app-builder/src/locales/ar/api.json
@@ -1,4 +1,3 @@
 {
-  "download_openapi_spec": "تنزيل مواصفات OpenAPI v0 (مهمل)",
   "download_openapi_spec_v1": "تنزيل مواصفات OpenAPI v1"
 }

--- a/packages/app-builder/src/locales/en/api.json
+++ b/packages/app-builder/src/locales/en/api.json
@@ -1,4 +1,3 @@
 {
-  "download_openapi_spec": "Download OpenAPI specification v0 (Deprecated)",
   "download_openapi_spec_v1": "Download OpenAPI specification v1"
 }

--- a/packages/app-builder/src/locales/fr/api.json
+++ b/packages/app-builder/src/locales/fr/api.json
@@ -1,4 +1,3 @@
 {
-  "download_openapi_spec": "Télécharger la spécification OpenAPI v0 (Obsolète)",
   "download_openapi_spec_v1": "Télécharger la spécification OpenAPI v1"
 }

--- a/packages/app-builder/src/repositories/DataModelRepository.ts
+++ b/packages/app-builder/src/repositories/DataModelRepository.ts
@@ -39,7 +39,6 @@ import { GroupedAnnotations, type OpenApiSpec, UpdateTableBodyDto } from 'marble
 
 export interface DataModelRepository {
   getDataModel(): Promise<DataModel>;
-  getOpenApiSpec(): Promise<OpenApiSpec>;
   getOpenApiSpecOfVersion(version: string): Promise<OpenApiSpec>;
   createTable(body: CreateTableValue): Promise<{ id: string }>;
   patchDataModelTable(tableId: string, body: UpdateTableBodyDto): Promise<void>;
@@ -77,9 +76,6 @@ export function makeGetDataModelRepository() {
       const { data_model } = await marbleCoreApiClient.getDataModel();
 
       return adaptDataModel(data_model);
-    },
-    getOpenApiSpec: async () => {
-      return marbleCoreApiClient.getDataModelOpenApi();
     },
     getOpenApiSpecOfVersion: async (version: string) => {
       return marbleCoreApiClient.getDataModelOpenApiOfVersion(version);

--- a/packages/app-builder/src/routes/_app/_builder/settings/api-keys.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/settings/api-keys.tsx
@@ -37,9 +37,8 @@ const apiKeysLoader = createServerFn()
 
     if (!isReadApiKeyAvailable(user)) throw redirect({ to: '/' });
 
-    const [apiKeys, openapi, openapiV1] = await Promise.all([
+    const [apiKeys, openapiV1] = await Promise.all([
       apiKey.listApiKeys(),
-      dataModelRepository.getOpenApiSpec(),
       dataModelRepository.getOpenApiSpecOfVersion('v1'),
     ]);
 
@@ -62,7 +61,6 @@ const apiKeysLoader = createServerFn()
 
     return {
       apiKeys,
-      openapi,
       openapiV1,
       createdApiKey,
       isCreateApiKeyAvailable: isCreateApiKeyAvailable(user),
@@ -87,7 +85,6 @@ function ApiKeys() {
   const { t } = useTranslation(['common', 'settings', 'api']);
   const {
     apiKeys,
-    openapi,
     openapiV1,
     createdApiKey,
     isCreateApiKeyAvailable,
@@ -165,23 +162,6 @@ function ApiKeys() {
           >
             <Icon icon="download" className="me-2 size-5" />
             {t('api:download_openapi_spec_v1')}
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={() => {
-              try {
-                const blob = new Blob([JSON.stringify(openapi)], {
-                  type: 'application/json;charset=utf-8,',
-                });
-                const url = URL.createObjectURL(blob);
-                void downloadFile(url, 'openapi.json');
-              } catch (_error) {
-                toast.error(t('common:errors.unknown'));
-              }
-            }}
-          >
-            <Icon icon="download" className="me-2 size-5" />
-            {t('api:download_openapi_spec')}
           </Button>
         </div>
         {createdApiKey ? <CreatedAPIKey createdApiKey={createdApiKey} /> : null}


### PR DESCRIPTION
The venerable v0 is going to be deprecated, and all related API will be removed from the backend.

Keeping this in results in a Lose Your Marble when the backend returns 404.

I once again request that you plz mrg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed deprecated OpenAPI v0 download functionality across the application; only OpenAPI v1 specification is now available for download. Locale entries updated accordingly in all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->