### PR TITLE
dark mode for flow, default semantic type on old tables and field creation

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'ui-design-system';
 import { Icon } from 'ui-icons';
+import { inferSemanticTypeFromName } from '../../DataVisualisation/dataFieldsUtils';
 import { type FieldValidationError, type ValidationError, validateValues } from '../CreateTable/createTable-types';
 import { DrawerContext } from '../Shared/DrawerContext';
 import { EntityTypeMenu } from '../Shared/EntityTypeMenu';
@@ -391,6 +392,10 @@ function EditableAlias({ alias, onChange }: EditableAliasProps) {
 
 function adaptFieldToTableField(field: DataModelField): TableField {
   const isSystemField = field.name === 'object_id' || field.name === 'updated_at';
+  const { semanticType: fallbackSemanticType, semanticSubType: fallbackSemanticSubType } = inferSemanticTypeFromName(
+    field.name,
+    field.dataType,
+  );
   return {
     id: field.id,
     name: field.name,
@@ -408,8 +413,8 @@ function adaptFieldToTableField(field: DataModelField): TableField {
         ? 'unique_id'
         : field.name === 'updated_at'
           ? 'last_update'
-          : (field.semanticType ?? ('text' as const)),
-    semanticSubType: field.name === 'object_id' ? 'opaque_id' : field.semanticSubType,
+          : (field.semanticType ?? fallbackSemanticType),
+    semanticSubType: field.name === 'object_id' ? 'opaque_id' : (field.semanticSubType ?? fallbackSemanticSubType),
     currencyExponent: field.currencyExponent,
     decimalPrecision: field.decimalPrecision,
     currencyFieldId: field.currencyFieldId,

--- a/packages/app-builder/src/components/Data/SemanticTables/Flow/TableFlow.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Flow/TableFlow.tsx
@@ -1,5 +1,6 @@
 import { AutoLayoutControlButton } from '@app-builder/components/ReactFlow';
 import { SchemaMenuMenuItem, SchemaMenuMenuPopover, SchemaMenuRoot } from '@app-builder/components/Schema/SchemaMenu';
+import { useTheme } from '@app-builder/contexts/ThemeContext';
 import { type DataModel } from '@app-builder/models/data-model';
 import Dagre from '@dagrejs/dagre';
 import {
@@ -233,6 +234,7 @@ function DataModelFlowImpl({ dataModel, children }: TableFlowProps) {
       fitView();
     });
   }, [edges, fitView, nodes]);
+  const theme = useTheme();
 
   return (
     <ReactFlow<Node<DataModelNodeData>, Edge<DataModelEdgeData>>
@@ -246,6 +248,7 @@ function DataModelFlowImpl({ dataModel, children }: TableFlowProps) {
       onEdgesChange={onEdgesChange}
       defaultEdgeOptions={defaultDataModelEdgeOptions}
       connectionLineStyle={defaultDataModelEdgeOptions.style}
+      colorMode={theme.theme}
     >
       <Controls position="bottom-left" className="z-10">
         <CustomControls />

--- a/packages/app-builder/src/components/Data/SemanticTables/Shared/FieldDetailPanel.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Shared/FieldDetailPanel.tsx
@@ -42,6 +42,7 @@ export function FieldDetailPanel({
     FieldsEditorContext.useValue();
   const dataModel = useDataModel();
   const { isEditDataModelInfoAvailable, isDeleteDataModelFieldAvailable } = useDataModelFeatureAccess();
+  const [hasBeenChangedManually, setHasBeenChangedManually] = useState(false);
 
   const { t } = useTranslation(['data', 'common']);
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
@@ -56,6 +57,7 @@ export function FieldDetailPanel({
     } else {
       aliasInputRef.current?.focus();
     }
+    setHasBeenChangedManually(false);
   }, [fieldId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const isNameDuplicate = useMemo(() => {
@@ -145,6 +147,7 @@ export function FieldDetailPanel({
   }
 
   function inferTypeFromName(field: TableField) {
+    if (hasBeenChangedManually) return;
     if (!field.isNew) return;
     const { semanticType, semanticSubType } = inferSemanticTypeFromName(field.name, field.dataType, field.isEnum);
     update({
@@ -268,6 +271,7 @@ export function FieldDetailPanel({
                   const subOpts = getSemanticSubOptions(field.dataType as DataTypeKey, newSemanticType);
                   const isCurrentSubTypeValid = subOpts?.some((opt) => opt.value === field.semanticSubType) ?? false;
                   const firstSubType = subOpts?.[0]?.value as SemanticSubTypeField | undefined;
+                  setHasBeenChangedManually(true);
                   update({
                     semanticType: newSemanticType,
                     semanticSubType: isCurrentSubTypeValid ? field.semanticSubType : firstSubType,
@@ -286,7 +290,10 @@ export function FieldDetailPanel({
               <SelectV2
                 value={field.semanticSubType}
                 placeholder=""
-                onChange={(value) => update({ semanticSubType: value as SemanticSubTypeField })}
+                onChange={(value) => {
+                  setHasBeenChangedManually(true);
+                  update({ semanticSubType: value as SemanticSubTypeField });
+                }}
                 options={semanticSubOptions}
                 disabled={isLocked}
               />


### PR DESCRIPTION
MAR-1737: Default selected type for Float should be Number
MAR-1772: [Subjective] Dark mode colors are not great
MAR-1771: Semantic type should not be guessed if it was manually set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data flow visualization now respects the app's current theme settings.

* **Bug Fixes**
  * Improved semantic type inference to better detect field types from names and data types.
  * Manual semantic type selections are now preserved and no longer overwritten by automatic inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->