### PR TITLE
fix: customer hub configuration

### DIFF
--- a/packages/app-builder/src/components/ClientDetail/AddConfigurationModal.tsx
+++ b/packages/app-builder/src/components/ClientDetail/AddConfigurationModal.tsx
@@ -70,11 +70,12 @@ export const AddConfigurationModal = ({
   );
   const tableFields = selectedTable ? selectedTable.fields.filter((field) => field.dataType === 'String') : [];
 
-  // Pre-fill alias and semanticType from the selected table
+  // Pre-fill alias, semanticType, and captionField from the selected table
   const selectedTableId = selectedTable?.id;
   useEffect(() => {
     if (selectedTable) {
       form.setFieldValue('alias', selectedTable.alias || '');
+      form.setFieldValue('captionField', selectedTable.captionField || '');
       if (selectedTable.semanticType === 'person' && selectedTable.subEntity === 'moral') {
         form.setFieldValue('semanticType', 'company');
       } else if (selectedTable.semanticType === 'person' && selectedTable.subEntity === 'natural') {

--- a/packages/app-builder/src/components/ClientDetail/AddConfigurationModal.tsx
+++ b/packages/app-builder/src/components/ClientDetail/AddConfigurationModal.tsx
@@ -5,7 +5,7 @@ import { addConfigurationPayloadSchema } from '@app-builder/schemas/client360';
 import { handleSubmit } from '@app-builder/utils/form';
 import { useForm, useStore } from '@tanstack/react-form';
 import { Client360Table } from 'marble-api';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Input, Modal, SelectV2 } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -48,11 +48,40 @@ export const AddConfigurationModal = ({
     },
   });
 
-  const availableTables = dataModel.filter((table) => tables.every((t) => t.id !== table.id));
+  const availableTables = dataModel.filter((table) => {
+    // Exclude tables already configured in Client360
+    if (tables.some((t) => t.id === table.id)) return false;
+
+    // Exclude tables with fixed semantic types (transaction, event, account, partner)
+    if (table.semanticType === 'transaction' || table.semanticType === 'event' || table.semanticType === 'account')
+      return false;
+    if (table.semanticType === 'person' && table.subEntity === 'generic') return false; // partner
+
+    // Exclude already fully configured tables (has person/company semantic type + caption field)
+    const hasPersonOrCompany =
+      table.semanticType === 'person' && (table.subEntity === 'natural' || table.subEntity === 'moral');
+    if (hasPersonOrCompany && table.captionField) return false;
+
+    return true;
+  });
+
   const selectedTable = useStore(form.store, (state) =>
     state.values.tableId ? dataModel.find((table) => table.id === state.values.tableId) : null,
   );
   const tableFields = selectedTable ? selectedTable.fields.filter((field) => field.dataType === 'String') : [];
+
+  // Pre-fill alias and semanticType from the selected table
+  const selectedTableId = selectedTable?.id;
+  useEffect(() => {
+    if (selectedTable) {
+      form.setFieldValue('alias', selectedTable.alias || '');
+      if (selectedTable.semanticType === 'person' && selectedTable.subEntity === 'moral') {
+        form.setFieldValue('semanticType', 'company');
+      } else if (selectedTable.semanticType === 'person' && selectedTable.subEntity === 'natural') {
+        form.setFieldValue('semanticType', 'person');
+      }
+    }
+  }, [selectedTableId]);
 
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>

--- a/packages/app-builder/src/server-fns/client-360.ts
+++ b/packages/app-builder/src/server-fns/client-360.ts
@@ -8,8 +8,24 @@ export const addClient360ConfigurationFn = createServerFn({ method: 'POST' })
   .inputValidator(addConfigurationPayloadSchema)
   .handler(async ({ context, data }) => {
     try {
-      const { tableId, ...body } = data;
-      await context.authInfo.dataModelRepository.patchDataModelTable(tableId, body);
+      const { tableId, semanticType, captionField, alias } = data;
+      const { dataModelRepository } = context.authInfo;
+
+      // Fetch data model to find the caption field id
+      const dataModel = await dataModelRepository.getDataModel();
+      const table = dataModel.find((t) => t.id === tableId);
+      const field = table?.fields.find((f) => f.name === captionField);
+
+      await dataModelRepository.patchDataModelTable(tableId, {
+        semantic_type: semanticType,
+        caption_field: captionField,
+        alias,
+        // Set the caption field's semantic_type to 'name' only if it has none
+        // Treat both undefined and "" as "no semantic type"
+        fields:
+          field && !field.semanticType ? [{ op: 'MOD', data: { id: field.id, semantic_type: 'name' } }] : undefined,
+      });
+
       await setToast({ type: 'success', messageKey: 'common:success.save' });
     } catch {
       await setToast({ type: 'error', messageKey: 'common:errors.unknown' });


### PR DESCRIPTION
This pull request enhances the logic for adding new configurations in the Client360 feature, focusing on improving table selection and ensuring data consistency. The main changes include stricter filtering of available tables, auto-prefilling the alias field, and updating the server-side payload structure.

**Improvements to table selection and configuration logic:**

* The `availableTables` logic in `AddConfigurationModal.tsx` now excludes tables that are already configured, have fixed semantic types (transaction, event, account, partner), or are already fully configured with the required fields and alias. This prevents users from selecting inappropriate or redundant tables.
* The modal now pre-fills the alias field with the selected table's existing alias (if present), improving user experience and reducing manual input.

**Technical and code consistency updates:**

* The server function `addClient360ConfigurationFn` now explicitly maps the payload fields to the expected backend property names (`semantic_type`, `caption_field`, and `alias`), ensuring data is stored correctly and consistently.
* The `useEffect` hook is added to `AddConfigurationModal.tsx` to handle side effects when the selected table changes, supporting the alias pre-fill feature. [[1]](diffhunk://#diff-1c8e62d0c0b1948cbfa7af6c187c61aa13a4c097a1c51b2256ff467ce05ece88L8-R8) [[2]](diffhunk://#diff-1c8e62d0c0b1948cbfa7af6c187c61aa13a4c097a1c51b2256ff467ce05ece88L51-R84)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alias now auto-populates when a table is selected in the configuration modal for faster setup.
  * Table picker excludes fully configured or fixed-semantic tables (reducing clutter and conflicts) and treats certain person/company variants appropriately.
  * Form pre-fills semantic type based on the selected table.
  * Configuration updates more reliably apply caption and alias changes and set a caption field’s semantic type when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->