### PR TITLE
fix old tables edition

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
@@ -232,6 +232,7 @@ export function EditTableDrawer({
       tablesState[tableModel.id]!,
       initialLinksStateRef.current,
       linksState,
+      tableModel.fields,
     );
     await onSave(
       values,
@@ -480,6 +481,7 @@ function computeChangeSet(
   currentTableState: SemanticTableFormValues,
   initialLinksState: Record<string, LinkValue>,
   currentLinksState: Record<string, LinkValue>,
+  originalModelFields?: DataModelField[],
 ): ChangeRecord[] {
   const changes: ChangeRecord[] = [];
 
@@ -499,6 +501,7 @@ function computeChangeSet(
   // Field changes
   const initialFieldMap = new Map(initialTableState.fields.map((f) => [f.id, f]));
   const currentFieldMap = new Map(currentTableState.fields.map((f) => [f.id, f]));
+  const originalFieldMap = originalModelFields ? new Map(originalModelFields.map((f) => [f.id, f])) : undefined;
 
   for (const field of currentTableState.fields) {
     if (field.isNew) {
@@ -507,6 +510,18 @@ function computeChangeSet(
       const initialField = initialFieldMap.get(field.id);
       if (initialField && JSON.stringify(initialField) !== JSON.stringify(field)) {
         changes.push({ type: 'field', operation: 'MOD', objectId: field.id });
+      } else if (initialField && originalFieldMap) {
+        // Detect inferred semantic types: the form applies inference from field names,
+        // but both initial and current form state have the same inferred values.
+        // Compare against the original backend data to detect these as real changes.
+        const originalField = originalFieldMap.get(field.id);
+        if (originalField) {
+          const hasInferredSemanticType = !originalField.semanticType && field.semanticType;
+          const hasInferredSemanticSubType = !originalField.semanticSubType && field.semanticSubType;
+          if (hasInferredSemanticType || hasInferredSemanticSubType) {
+            changes.push({ type: 'field', operation: 'MOD', objectId: field.id });
+          }
+        }
       }
     }
   }
@@ -529,6 +544,5 @@ function computeChangeSet(
       changes.push({ type: 'link', operation: 'DEL', objectId: linkId });
     }
   }
-
   return changes;
 }

--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
@@ -1,3 +1,4 @@
+import { type DataModelField } from '@app-builder/models';
 import { EditSemanticFieldPayload, EditSemanticLinkPayload, EditSemanticTablePayload } from '@app-builder/schemas/data';
 import { ifChanged, omitUndefined } from '@app-builder/utils/omit-undefined';
 import { adaptLink, adaptSemanticField, adaptTableField } from '../CreateTable/createTable-types';
@@ -16,6 +17,7 @@ export function adaptUpdateTableValue(
   originalLinks: LinkValue[],
   tableNameById: Map<string, string>,
   originalMainTimestampFieldName?: string | null,
+  rawModelFields?: DataModelField[],
 ): EditSemanticTablePayload {
   const tableChange = changeSet.find((change): change is TableChange => change.type === 'table');
   const changedProperties = tableChange?.changedProperties ?? [];
@@ -54,6 +56,7 @@ export function adaptUpdateTableValue(
       newLinkValues,
       deletedLinkValues,
       tableNameById,
+      rawModelFields,
     ),
     links: adaptLinksOperations(
       changeSet.filter((change) => change.type === 'link'),
@@ -100,8 +103,10 @@ function adaptFieldsOperations(
   newLinkValues: LinkValue[] = [],
   deletedLinkValues: LinkValue[] = [],
   tableNameById: Map<string, string> = new Map(),
+  rawModelFields?: DataModelField[],
 ): EditSemanticFieldPayload[] | undefined {
   const originalFieldsById = new Map(originalFields.map((f) => [f.id, f]));
+  const rawFieldsById = rawModelFields ? new Map(rawModelFields.map((f) => [f.id, f])) : undefined;
   const fieldOps: EditSemanticTablePayload['fields'] = [];
   const processedFieldNames = new Set<string>();
 
@@ -129,7 +134,14 @@ function adaptFieldsOperations(
               foreignkeyTable: undefined,
             }
           : fieldValues;
-      fieldOps.push(adaptFieldOperation(change, effectiveField, originalFieldsById.get(effectiveField.id)));
+      fieldOps.push(
+        adaptFieldOperation(
+          change,
+          effectiveField,
+          originalFieldsById.get(effectiveField.id),
+          rawFieldsById?.get(effectiveField.id),
+        ),
+      );
       processedFieldNames.add(fieldValues.name);
     }
   }
@@ -177,12 +189,13 @@ function adaptFieldOperation(
   change: FieldChange,
   fieldValues: TableField,
   originalField?: TableField,
+  rawModelField?: DataModelField,
 ): EditSemanticFieldPayload {
   if (change.operation === 'MOD')
     return {
       op: 'MOD',
       data: originalField
-        ? adaptTableFieldUpdate(fieldValues, originalField)
+        ? adaptTableFieldUpdate(fieldValues, originalField, rawModelField)
         : { id: fieldValues.id, ...adaptTableField(fieldValues) },
     };
   if (change.operation === 'DEL')
@@ -206,12 +219,17 @@ const metadataKeys = [
   'hidden',
 ] as const satisfies (keyof TableField)[];
 
-function adaptTableFieldUpdate(current: TableField, original: TableField) {
-  const semanticTypeChanged =
-    current.semanticType !== original.semanticType || current.semanticSubType !== original.semanticSubType;
-  const metadataChanged = metadataKeys.some((k) => current[k] !== original[k]);
+function adaptTableFieldUpdate(current: TableField, original: TableField, rawModelField?: DataModelField) {
+  // When a raw model field is available, compare against the actual backend values
+  // to detect inferred semantic types as real changes
 
-  return omitUndefined({
+  const originalSemanticType = rawModelField ? rawModelField.semanticType : original.semanticType;
+  const originalSemanticSubType = rawModelField ? rawModelField.semanticSubType : original.semanticSubType;
+  const semanticTypeChanged =
+    current.semanticType !== originalSemanticType || current.semanticSubType !== originalSemanticSubType;
+  const metadataChanged = semanticTypeChanged || metadataKeys.some((k) => current[k] !== original[k]);
+
+  const field = omitUndefined({
     id: current.id,
     description: ifChanged(current.description, original.description),
     alias: ifChanged(current.alias || current.name, original.alias),
@@ -236,4 +254,5 @@ function adaptTableFieldUpdate(current: TableField, original: TableField) {
         }
       : undefined,
   });
+  return field;
 }

--- a/packages/app-builder/src/components/Data/SemanticTables/Flow/TableDetails.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Flow/TableDetails.tsx
@@ -143,6 +143,7 @@ export function TableDetails({ data }: NodeProps<TableDetailsFlowNode>) {
                 initialLinks,
                 tableNameById,
                 data.tableModel.mainTimestampFieldName,
+                data.tableModel.fields,
               ),
             )
             .then(() => {


### PR DESCRIPTION
MAR-1783: Cannot update a Person table for "no name" field

detect changes in fields after automatic semantic type inference from name and send the changes accordingly to the table update end point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and application of semantic type metadata changes when updating table fields. The system now properly recognizes semantic type modifications even when other field properties remain unchanged, ensuring changes are correctly persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->