### PR TITLE
fix: screening rule query params schema

### DIFF
--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
@@ -48,7 +48,7 @@ import { Button, cn, Switch, Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { z } from 'zod/v4';
 
-const searchParamsSchema = z.object({ isNew: z.stringbool().optional() });
+const searchParamsSchema = z.object({ isNew: z.boolean().optional() });
 const screeningLoaderDataSchema = z.object({
   scenarioId: z.string().transform((shortId) => fromSUUIDtoUUID(shortId)),
   screeningId: z.string().transform((shortId) => fromSUUIDtoUUID(shortId)),

--- a/packages/app-builder/src/server-fns/scenarios.ts
+++ b/packages/app-builder/src/server-fns/scenarios.ts
@@ -589,7 +589,7 @@ export const createScreeningRuleFn = createServerFn({ method: 'POST' })
         iterationId: fromUUIDtoSUUID(data.iterationId),
         screeningId: fromUUIDtoSUUID(config.id as string),
       },
-      search: { isNew: 'true' },
+      search: { isNew: true },
     });
   });
 


### PR DESCRIPTION
Tanstack already send the `isNew` query param as a boolean which made the schema expect for a string when a boolean was given.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL parameter validation for scenario screening features to properly handle boolean query parameters, ensuring reliable navigation through screening iterations and consistent behavior when accessing configurations via direct URLs or shared links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->