### PR TITLE
show "snooze rules" button only if there are rules to snooze + displa…

### DIFF
--- a/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
+++ b/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
@@ -142,8 +142,11 @@ export function DecisionPanel({ setDrawerContentMode, decision, dataModel }: Dec
         .with({ isError: true }, () => (
           <div className="text-grey-secondary p-4 text-center text-xs">{t('common:global_error')}</div>
         ))
-        .otherwise(() =>
-          filteredRuleExecutions.length === 0 ? null : (
+        .otherwise(() => {
+          const allRules = detailDecisionQuery.data?.decision.rules ?? [];
+          if (allRules.length === 0) return null;
+
+          return (
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-between">
                 <span className="text-m text-grey-primary font-medium">{t('cases:decisions.rules')}</span>
@@ -154,27 +157,29 @@ export function DecisionPanel({ setDrawerContentMode, decision, dataModel }: Dec
                   <Switch id="showHitOnly" checked={showHitOnly} onCheckedChange={setShowHitOnly} />
                 </div>
               </div>
-              <RulesExecutionsContainer className="h-fit">
-                {filteredRuleExecutions.map((ruleExecution) => (
-                  <RuleExecutionCollapsible key={ruleExecution.ruleId}>
-                    <RuleExecutionTitle ruleExecution={ruleExecution} />
-                    <RuleExecutionContent>
-                      <RuleExecutionDescription description={ruleExecution.description} />
-                      {scenarioIterationRules.data ? (
-                        <RuleExecutionDetail
-                          scenarioId={detailDecisionQuery.data?.decision.scenario.id ?? ''}
-                          ruleExecution={ruleExecution}
-                          rules={scenarioIterationRules.data.rules}
-                          isIterationArchived={scenarioIterationRules.data.archived}
-                        />
-                      ) : null}
-                    </RuleExecutionContent>
-                  </RuleExecutionCollapsible>
-                ))}
-              </RulesExecutionsContainer>
+              {filteredRuleExecutions.length > 0 ? (
+                <RulesExecutionsContainer className="h-fit">
+                  {filteredRuleExecutions.map((ruleExecution) => (
+                    <RuleExecutionCollapsible key={ruleExecution.ruleId}>
+                      <RuleExecutionTitle ruleExecution={ruleExecution} />
+                      <RuleExecutionContent>
+                        <RuleExecutionDescription description={ruleExecution.description} />
+                        {scenarioIterationRules.data ? (
+                          <RuleExecutionDetail
+                            scenarioId={detailDecisionQuery.data?.decision.scenario.id ?? ''}
+                            ruleExecution={ruleExecution}
+                            rules={scenarioIterationRules.data.rules}
+                            isIterationArchived={scenarioIterationRules.data.archived}
+                          />
+                        ) : null}
+                      </RuleExecutionContent>
+                    </RuleExecutionCollapsible>
+                  ))}
+                </RulesExecutionsContainer>
+              ) : null}
             </div>
-          ),
-        )}
+          );
+        })}
 
       {/* Trigger Object */}
       {detailDecisionQuery.data ? (

--- a/packages/app-builder/src/components/Cases/CaseDetails.tsx
+++ b/packages/app-builder/src/components/Cases/CaseDetails.tsx
@@ -7,6 +7,7 @@ import { type CurrentUser, DataModelWithTableOptions, isAdmin } from '@app-build
 import { CaseDetail, CaseReview, DetailedCaseDecision, SuspiciousActivityReport } from '@app-builder/models/cases';
 import { useAddReviewToCaseCommentsMutation } from '@app-builder/queries/add-review-to-case-comments';
 import { useCaseReviewFeedbackMutation } from '@app-builder/queries/case-review-feedback';
+import { useCaseDecisionsQuery } from '@app-builder/queries/cases/list-decisions';
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { useGetCopyToClipboard } from '@app-builder/utils/use-get-copy-to-clipboard';
 import { useRef, useState } from 'react';
@@ -55,6 +56,11 @@ export const CaseDetails = ({
   });
   const reviewReactionMutation = useCaseReviewFeedbackMutation(caseDetail.id, caseReview?.id);
   const addReviewToCaseCommentsMutation = useAddReviewToCaseCommentsMutation(caseDetail.id, caseReview?.id);
+
+  const caseDecisionsQuery = useCaseDecisionsQuery(caseDetail.id);
+  const hasRuleHits = caseDecisionsQuery.data?.pages.some((page) =>
+    page.decisions.some((d) => d.rules.some((r) => r.outcome === 'hit')),
+  );
 
   const [selectedTab, setSelectedTab] = useState<'caseDetails' | 'review'>('caseDetails');
   const revalidate = useLoaderRevalidator();
@@ -224,10 +230,12 @@ export const CaseDetails = ({
             <div className="flex flex-col justify-start gap-1.5">
               <div className="text-h2 text-grey-primary flex items-center justify-between px-1 font-medium">
                 <span>{t('cases:alerts')}</span>
-                <Button variant="secondary" onClick={() => setDrawerContentMode('snooze')}>
-                  <Icon icon="snooze" className="size-3.5" />
-                  {t('cases:decisions.snooze_rules')}
-                </Button>
+                {hasRuleHits ? (
+                  <Button variant="secondary" onClick={() => setDrawerContentMode('snooze')}>
+                    <Icon icon="snooze" className="size-3.5" />
+                    {t('cases:decisions.snooze_rules')}
+                  </Button>
+                ) : null}
               </div>
               <CaseAlerts
                 selectDecision={selectDecision}


### PR DESCRIPTION
## Summary
- Hide "Snooze Rules" button on cases with no rule hits (only shown when loaded decisions contain at least one rule with `outcome === 'hit'`)
- Fix rules section in decision panel being entirely hidden (including the "show hits only" toggle) when no rules matched — now the toggle stays visible so users can switch to viewing all rules…y fix for alerts detail panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "snooze rules" button now conditionally displays only when rule hits are detected, improving interface clarity.
  * Improved rules section rendering to properly maintain section structure while filtering execution results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->