### PR TITLE
Pascal/mar 1776 in cases created last 10 days by inbox the legends were all

### DIFF
--- a/packages/app-builder/src/components/Cases/Overview/Graph/CaseByDateGraph.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Graph/CaseByDateGraph.tsx
@@ -7,6 +7,7 @@ import { Fragment, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button } from 'ui-design-system';
+import { BAR_BORDER_RADIUS, BAR_BORDER_WIDTH, buildBarGradient, nivoTheme } from '../../Analytics/chart-theme';
 import { CaseStatusBadge } from '../../CaseStatus';
 import { getYAxisTicksValues, graphCaseStatuses, graphStatusesColors } from '../constants';
 
@@ -74,22 +75,37 @@ export const CaseByDateGraph = () => {
                       },
                     }}
                     margin={{ top: 5, right: 5, bottom: 54, left: 50 }}
+                    borderRadius={BAR_BORDER_RADIUS}
+                    borderWidth={BAR_BORDER_WIDTH}
+                    borderColor={{ from: 'color' }}
                     defs={[
+                      ...graphCaseStatuses.map((status) =>
+                        buildBarGradient(graphStatusesColors[status], `grad-${status}`),
+                      ),
                       {
                         id: 'unhoverOpacity',
                         type: 'linearGradient',
                         colors: [
-                          { offset: 0, color: 'inherit', opacity: 0.75 },
-                          { offset: 100, color: 'inherit', opacity: 0.75 },
+                          { offset: 0, color: 'inherit', opacity: 0.5 },
+                          { offset: 100, color: 'inherit', opacity: 0.5 },
                         ],
                       },
                     ]}
                     fill={[
-                      {
-                        match: (n) => hovering !== null && n.data.indexValue !== hovering,
-                        id: 'unhoverOpacity',
-                      },
+                      ...graphCaseStatuses.map((status) => ({
+                        match: { id: status },
+                        id: `grad-${status}`,
+                      })),
+                      ...(hovering !== null
+                        ? [
+                            {
+                              match: (n: { data: { indexValue: string | number } }) => n.data.indexValue !== hovering,
+                              id: 'unhoverOpacity',
+                            },
+                          ]
+                        : []),
                     ]}
+                    colorBy="id"
                     colors={({ id }) => graphStatusesColors[id as keyof typeof graphStatusesColors]}
                     padding={0.3}
                     layout="vertical"
@@ -103,6 +119,8 @@ export const CaseByDateGraph = () => {
                         itemWidth: 100,
                         itemHeight: 25,
                         translateY: 54,
+                        symbolShape: 'circle',
+                        symbolSize: 10,
                         data: graphCaseStatuses.map((status) => ({
                           id: status,
                           label: t(`cases:case.status.${status}`),
@@ -123,12 +141,7 @@ export const CaseByDateGraph = () => {
                         </div>
                       </div>
                     )}
-                    theme={{
-                      text: { fill: 'var(--color-grey-secondary)' },
-                      axis: { ticks: { text: { fill: 'var(--color-grey-secondary)' } } },
-                      legends: { text: { fill: 'var(--color-grey-secondary)' } },
-                      grid: { line: { stroke: 'var(--color-grey-border)', strokeWidth: 1, strokeDasharray: '4 4' } },
-                    }}
+                    theme={nivoTheme}
                   />
                 </div>
               </>

--- a/packages/app-builder/src/components/Cases/Overview/Graph/CaseByDateGraph.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Graph/CaseByDateGraph.tsx
@@ -90,14 +90,11 @@ export const CaseByDateGraph = () => {
                         id: 'unhoverOpacity',
                       },
                     ]}
-                    colors={Object.values(graphStatusesColors)}
+                    colors={({ id }) => graphStatusesColors[id as keyof typeof graphStatusesColors]}
                     padding={0.3}
                     layout="vertical"
                     onMouseEnter={(d) => setHovering(d.indexValue as string)}
                     onMouseLeave={() => setHovering(null)}
-                    legendLabel={(datum) =>
-                      t(`cases:case.status.${datum.id as 'snoozed' | 'pending' | 'investigating' | 'closed'}`)
-                    }
                     legends={[
                       {
                         dataFrom: 'keys',
@@ -106,6 +103,11 @@ export const CaseByDateGraph = () => {
                         itemWidth: 100,
                         itemHeight: 25,
                         translateY: 54,
+                        data: graphCaseStatuses.map((status) => ({
+                          id: status,
+                          label: t(`cases:case.status.${status}`),
+                          color: graphStatusesColors[status],
+                        })),
                       },
                     ]}
                     tooltip={({ data }) => (

--- a/packages/app-builder/src/components/Cases/Overview/Graph/CaseByInboxGraph.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Graph/CaseByInboxGraph.tsx
@@ -83,14 +83,11 @@ export const CaseByInboxGraph = () => {
                       },
                     ]}
                     colorBy="id"
-                    colors={Object.values(graphStatusesColors)}
+                    colors={({ id }) => graphStatusesColors[id as keyof typeof graphStatusesColors]}
                     padding={0.3}
                     layout="vertical"
                     onMouseEnter={(d) => setHovering(d.indexValue as string)}
                     onMouseLeave={() => setHovering(null)}
-                    legendLabel={(datum) =>
-                      t(`cases:case.status.${datum.id as 'snoozed' | 'pending' | 'investigating' | 'closed'}`)
-                    }
                     legends={[
                       {
                         dataFrom: 'keys',
@@ -99,6 +96,11 @@ export const CaseByInboxGraph = () => {
                         itemWidth: 100,
                         itemHeight: 25,
                         translateY: 100,
+                        data: graphCaseStatuses.map((status) => ({
+                          id: status,
+                          label: t(`cases:case.status.${status}`),
+                          color: graphStatusesColors[status],
+                        })),
                       },
                     ]}
                     tooltip={({ id, value, data }) => (

--- a/packages/app-builder/src/components/Cases/Overview/Graph/CaseByInboxGraph.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Graph/CaseByInboxGraph.tsx
@@ -7,6 +7,7 @@ import { Fragment, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button } from 'ui-design-system';
+import { BAR_BORDER_RADIUS, BAR_BORDER_WIDTH, buildBarGradient, nivoTheme } from '../../Analytics/chart-theme';
 import { CaseStatusBadge } from '../../CaseStatus';
 import { getYAxisTicksValues, graphCaseStatuses, graphStatusesColors } from '../constants';
 
@@ -66,7 +67,13 @@ export const CaseByInboxGraph = () => {
                       truncateTickAt: 10,
                     }}
                     margin={{ top: 5, right: 5, bottom: 100, left: 50 }}
+                    borderRadius={BAR_BORDER_RADIUS}
+                    borderWidth={BAR_BORDER_WIDTH}
+                    borderColor={{ from: 'color' }}
                     defs={[
+                      ...graphCaseStatuses.map((status) =>
+                        buildBarGradient(graphStatusesColors[status], `grad-${status}`),
+                      ),
                       {
                         id: 'unhoverOpacity',
                         type: 'linearGradient',
@@ -77,10 +84,18 @@ export const CaseByInboxGraph = () => {
                       },
                     ]}
                     fill={[
-                      {
-                        match: (n) => hovering !== null && n.data.indexValue !== hovering,
-                        id: 'unhoverOpacity',
-                      },
+                      ...graphCaseStatuses.map((status) => ({
+                        match: { id: status },
+                        id: `grad-${status}`,
+                      })),
+                      ...(hovering !== null
+                        ? [
+                            {
+                              match: (n: { data: { indexValue: string | number } }) => n.data.indexValue !== hovering,
+                              id: 'unhoverOpacity',
+                            },
+                          ]
+                        : []),
                     ]}
                     colorBy="id"
                     colors={({ id }) => graphStatusesColors[id as keyof typeof graphStatusesColors]}
@@ -96,6 +111,8 @@ export const CaseByInboxGraph = () => {
                         itemWidth: 100,
                         itemHeight: 25,
                         translateY: 100,
+                        symbolShape: 'circle',
+                        symbolSize: 10,
                         data: graphCaseStatuses.map((status) => ({
                           id: status,
                           label: t(`cases:case.status.${status}`),
@@ -116,12 +133,7 @@ export const CaseByInboxGraph = () => {
                         </div>
                       </div>
                     )}
-                    theme={{
-                      text: { fill: 'var(--color-grey-secondary)' },
-                      axis: { ticks: { text: { fill: 'var(--color-grey-secondary)' } } },
-                      legends: { text: { fill: 'var(--color-grey-secondary)' } },
-                      grid: { line: { stroke: 'var(--color-grey-border)', strokeWidth: 1, strokeDasharray: '4 4' } },
-                    }}
+                    theme={nivoTheme}
                   />
                 </div>
               </>


### PR DESCRIPTION
## Changes
  - Fix legend showing black boxes when no data by providing explicit legend data with hardcoded colors
  - Add gradient fill (buildBarGradient), borderRadius, and borderWidth to match analytics chart style
  - Use shared nivoTheme from chart-theme.ts instead of inline theme
  - Use circle symbols in legends (symbolShape: 'circle') for consistency with analytics charts
  - Add colorBy="id" to both charts for correct color-to-key mapping

I also found that the new graph bars, while looking good in light more, are a bit violent in dark mode. Asked Maud for an opinion.