### PR TITLE
fix rule creation

### DIFF
--- a/packages/app-builder/src/components/UserScoring/RulesTable.tsx
+++ b/packages/app-builder/src/components/UserScoring/RulesTable.tsx
@@ -1,9 +1,10 @@
 import { NewAstNode } from '@app-builder/models';
 import { NewAggregatorAstNode } from '@app-builder/models/astNode/aggregation';
-import { isSwitchAstNode, NewSwitchAstNode } from '@app-builder/models/astNode/control-flow';
+import { NewSwitchAstNode } from '@app-builder/models/astNode/control-flow';
 import { type CustomList } from '@app-builder/models/custom-list';
 import { type DataModel } from '@app-builder/models/data-model';
 import {
+  buildAstNodeFromModel,
   RULE_TYPES,
   type RuleModelType,
   type ScoringRule,
@@ -90,10 +91,28 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
   const mutation = useUpdateScoringRulesetMutation();
 
   const handleConfirm = (ruleType: RuleModelType) => {
-    const fieldNode = match(ruleType)
-      .with('user_attribute', () => NewAstNode())
-      .with('aggregate', () => NewAggregatorAstNode('SUM'))
-      .with('screening_tags', 'entity_tags', 'past_alerts', () => undefined)
+    const ast = match(ruleType)
+      .with('user_attribute', () => NewSwitchAstNode(ruleType, NewAstNode()))
+      .with('aggregate', () => NewSwitchAstNode(ruleType, NewAggregatorAstNode('SUM')))
+      .with('screening_tags', 'entity_tags', () =>
+        buildAstNodeFromModel(
+          {
+            type: ruleType as 'screening_tags' | 'entity_tags',
+            conditions: {
+              type: 'tags',
+              branches: [{ value: [], impact: { modifier: 0 } }],
+              default: { modifier: 0 },
+            },
+          },
+          { entityType },
+        ),
+      )
+      .with('past_alerts', () =>
+        buildAstNodeFromModel({
+          type: 'past_alerts',
+          conditions: { type: 'bool', ifTrue: { modifier: 0 }, ifFalse: { modifier: 0 } },
+        }),
+      )
       .exhaustive();
 
     setPanelRule({
@@ -101,7 +120,7 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
       name: '',
       description: '',
       riskType: 'customer_features',
-      ast: NewSwitchAstNode(ruleType, fieldNode),
+      ast,
     });
     setOpen(false);
   };
@@ -301,7 +320,6 @@ function RuleRow({
   onRuleDelete,
 }: RuleRowProps) {
   const { t } = useTranslation(['user-scoring']);
-  const switchNode = rule.ast && isSwitchAstNode(rule.ast) ? rule.ast : null;
   const [isEditing, setIsEditing] = useState(false);
 
   return (
@@ -311,48 +329,44 @@ function RuleRow({
       </div>
       <div className="flex flex-1 flex-col gap-v2-sm px-v2-md py-v2-sm">
         <span className="text-grey-primary text-s font-medium">{rule.name}</span>
-        {switchNode ? (
-          <SwitchNode
-            node={switchNode}
-            mode="view"
+        <SwitchNode
+          node={rule.ast}
+          mode="view"
+          dataModel={dataModel}
+          entityType={entityType}
+          maxRiskLevel={maxRiskLevel}
+          customLists={customLists}
+        />
+      </div>
+      <div className="flex shrink-0 items-center justify-end px-v2-md py-v2-sm">
+        <button
+          type="button"
+          className="border-purple-primary text-purple-primary flex size-6 items-center justify-center rounded-lg border shadow-sm"
+          aria-label="Edit rule"
+          onClick={() => setIsEditing(true)}
+        >
+          <Icon icon="edit" className="size-4" />
+        </button>
+        <PanelRoot open={isEditing} onOpenChange={setIsEditing}>
+          <ScoringRuleEditPanel
+            rule={rule}
             dataModel={dataModel}
             entityType={entityType}
             maxRiskLevel={maxRiskLevel}
             customLists={customLists}
+            hasValidLicense={hasValidLicense}
+            onChange={onRuleChange}
+            onDelete={
+              onRuleDelete
+                ? () => {
+                    onRuleDelete();
+                    setIsEditing(false);
+                  }
+                : undefined
+            }
           />
-        ) : null}
+        </PanelRoot>
       </div>
-      {switchNode ? (
-        <div className="flex shrink-0 items-center justify-end px-v2-md py-v2-sm">
-          <button
-            type="button"
-            className="border-purple-primary text-purple-primary flex size-6 items-center justify-center rounded-lg border shadow-sm"
-            aria-label="Edit rule"
-            onClick={() => setIsEditing(true)}
-          >
-            <Icon icon="edit" className="size-4" />
-          </button>
-          <PanelRoot open={isEditing} onOpenChange={setIsEditing}>
-            <ScoringRuleEditPanel
-              rule={rule}
-              dataModel={dataModel}
-              entityType={entityType}
-              maxRiskLevel={maxRiskLevel}
-              customLists={customLists}
-              hasValidLicense={hasValidLicense}
-              onChange={onRuleChange}
-              onDelete={
-                onRuleDelete
-                  ? () => {
-                      onRuleDelete();
-                      setIsEditing(false);
-                    }
-                  : undefined
-              }
-            />
-          </PanelRoot>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/packages/app-builder/src/components/UserScoring/ScoringRuleEditPanel.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringRuleEditPanel.tsx
@@ -1,14 +1,13 @@
 import { AstBuilder } from '@app-builder/components/AstBuilder';
 import { type DataModel } from '@app-builder/models';
-import { isSwitchAstNode } from '@app-builder/models/astNode/control-flow';
 import { type CustomList } from '@app-builder/models/custom-list';
 import {
-  buildSwitchAstNodeFromModel,
+  buildAstNodeFromModel,
   type DraftRuleModel,
   isCompleteRule,
   RISK_TYPES,
   type ScoringRule,
-  transformSwitchAstNodeToModel,
+  transformAstNodeToModel,
 } from '@app-builder/models/scoring';
 import {
   type BuilderOptionsResource,
@@ -73,7 +72,7 @@ export function ScoringRuleEditPanel({
   const [name, setName] = useState(rule.name);
   const [riskType, setRiskType] = useState(rule.riskType);
   const [currentModel, setCurrentModel] = useState<DraftRuleModel | null>(() =>
-    isSwitchAstNode(rule.ast) ? transformSwitchAstNodeToModel(rule.ast, entityType, dataModel) : null,
+    transformAstNodeToModel(rule.ast, entityType, dataModel),
   );
 
   const RISK_TYPE_OPTIONS: SelectOption<string>[] = RISK_TYPES.map((v) => ({
@@ -85,7 +84,12 @@ export function ScoringRuleEditPanel({
 
   const handleValidate = async () => {
     if (isValid && currentModel && isCompleteRule(currentModel) && onChange) {
-      const result = await onChange({ ...rule, name, riskType, ast: buildSwitchAstNodeFromModel(currentModel) });
+      const result = await onChange({
+        ...rule,
+        name,
+        riskType,
+        ast: buildAstNodeFromModel(currentModel, { entityType }),
+      });
       if (result) {
         sharp.actions.close();
       }
@@ -142,17 +146,15 @@ export function ScoringRuleEditPanel({
         </div>
         <PanelContent>
           <div className="flex flex-col gap-v2-md p-v2-md border border-grey-border rounded-v2-md">
-            {isSwitchAstNode(rule.ast) ? (
-              <SwitchNode
-                mode="edit"
-                node={rule.ast}
-                dataModel={dataModel}
-                entityType={entityType}
-                maxRiskLevel={maxRiskLevel}
-                customLists={customLists}
-                onModelChange={(model) => setCurrentModel(model)}
-              />
-            ) : null}
+            <SwitchNode
+              mode="edit"
+              node={rule.ast}
+              dataModel={dataModel}
+              entityType={entityType}
+              maxRiskLevel={maxRiskLevel}
+              customLists={customLists}
+              onModelChange={(model) => setCurrentModel(model)}
+            />
           </div>
         </PanelContent>
         <PanelFooter>

--- a/packages/app-builder/src/components/UserScoring/SwitchNode/SwitchNode.tsx
+++ b/packages/app-builder/src/components/UserScoring/SwitchNode/SwitchNode.tsx
@@ -1,4 +1,4 @@
-import { type SwitchAstNode } from '@app-builder/models/astNode/control-flow';
+import { type AstNode } from '@app-builder/models';
 import { type CustomList } from '@app-builder/models/custom-list';
 import { type DataModel } from '@app-builder/models/data-model';
 import { type RuleModel } from '@app-builder/models/scoring';
@@ -6,7 +6,7 @@ import { SwitchNodeEdit } from './SwitchNodeEdit';
 import { SwitchNodeView } from './SwitchNodeView';
 
 interface SwitchNodeProps {
-  node: SwitchAstNode;
+  node: AstNode;
   mode: 'edit' | 'view';
   dataModel: DataModel;
   entityType: string;

--- a/packages/app-builder/src/components/UserScoring/SwitchNode/SwitchNodeEdit.tsx
+++ b/packages/app-builder/src/components/UserScoring/SwitchNode/SwitchNodeEdit.tsx
@@ -1,7 +1,7 @@
-import { type SwitchAstNode } from '@app-builder/models/astNode/control-flow';
+import { type AstNode } from '@app-builder/models';
 import { type CustomList } from '@app-builder/models/custom-list';
 import { type DataModel } from '@app-builder/models/data-model';
-import { type RuleModel, transformSwitchAstNodeToModel } from '@app-builder/models/scoring';
+import { type RuleModel, transformAstNodeToModel } from '@app-builder/models/scoring';
 import { match } from 'ts-pattern';
 import { AggregateRuleEdit } from './AggregateRuleEdit';
 import { PastAlertsRuleEdit } from './PastAlertsRuleEdit';
@@ -9,7 +9,7 @@ import { TagsRuleEdit } from './TagsRuleEdit';
 import { UserAttributeRuleEdit } from './UserAttributeRuleEdit';
 
 interface SwitchNodeEditProps {
-  node: SwitchAstNode;
+  node: AstNode;
   maxRiskLevel: number;
   dataModel: DataModel;
   entityType: string;
@@ -25,7 +25,7 @@ export function SwitchNodeEdit({
   customLists,
   onModelChange,
 }: SwitchNodeEditProps) {
-  const model = transformSwitchAstNodeToModel(node, entityType, dataModel);
+  const model = transformAstNodeToModel(node, entityType, dataModel);
   if (!model) return null;
 
   return (

--- a/packages/app-builder/src/components/UserScoring/SwitchNode/SwitchNodeView.tsx
+++ b/packages/app-builder/src/components/UserScoring/SwitchNode/SwitchNodeView.tsx
@@ -1,7 +1,8 @@
-import { type SwitchAstNode } from '@app-builder/models/astNode/control-flow';
+import { type AstNode } from '@app-builder/models';
+import { isSwitchAstNode } from '@app-builder/models/astNode/control-flow';
 import { type CustomList } from '@app-builder/models/custom-list';
 import { type DataModel } from '@app-builder/models/data-model';
-import { getOperationType, isCompleteRule, transformSwitchAstNodeToModel } from '@app-builder/models/scoring';
+import { getOperationType, isCompleteRule, transformAstNodeToModel } from '@app-builder/models/scoring';
 import { SCREENING_CATEGORY_I18N_KEY_MAP, topicsToCategories } from '@app-builder/models/screening';
 import { getAstNodeDisplayName } from '@app-builder/services/ast-node/getAstNodeDisplayName';
 import { useOrganizationObjectTags } from '@app-builder/services/organization/organization-object-tags';
@@ -16,7 +17,7 @@ import { FieldPill } from './shared';
 import { TagsSwitchDescription } from './TagsSwitchDescription';
 
 interface SwitchNodeViewProps {
-  node: SwitchAstNode;
+  node: AstNode;
   dataModel: DataModel;
   entityType: string;
   maxRiskLevel: number;
@@ -30,8 +31,9 @@ export function SwitchNodeView({ node, dataModel, entityType, maxRiskLevel, cust
     i18n: { language },
   } = useTranslation(['user-scoring', 'scenarios']);
   const { getTagById } = useOrganizationObjectTags();
-  const fieldType = getOperationType(entityType, dataModel, node);
-  const model = transformSwitchAstNodeToModel(node, entityType, dataModel);
+  const fieldType = isSwitchAstNode(node) ? getOperationType(entityType, dataModel, node) : null;
+  const model = transformAstNodeToModel(node, entityType, dataModel);
+  const hasChildren = isSwitchAstNode(node) ? node.children.length > 0 : true;
 
   return (
     <div className="flex flex-col gap-v2-sm pl-10 text-xs text-grey-secondary">
@@ -74,7 +76,7 @@ export function SwitchNodeView({ node, dataModel, entityType, maxRiskLevel, cust
           : null}
       </div>
 
-      {node.children.length === 0 ? (
+      {!hasChildren ? (
         <p className="italic text-grey-placeholder">{t('user-scoring:switch.no_condition')}</p>
       ) : model && isCompleteRule(model) ? (
         match(model)

--- a/packages/app-builder/src/models/scoring/ast-transform.ts
+++ b/packages/app-builder/src/models/scoring/ast-transform.ts
@@ -2,11 +2,11 @@ import { match } from 'ts-pattern';
 import { v7 as uuidv7 } from 'uuid';
 import { type AstNode, type DataModel } from '..';
 import { type AggregationAstNode, isAggregation } from '../astNode/aggregation';
-import { NewUndefinedAstNode } from '../astNode/ast-node';
 import { isMainAstBinaryNode } from '../astNode/builder-ast-node';
 import { isConstant, NewConstantAstNode } from '../astNode/constant';
 import {
   isScoreComputationAstNode,
+  isSwitchAstNode,
   type ScoreComputationAstNode,
   type SwitchAstNode,
   scoreComputationAstNodeName,
@@ -16,8 +16,10 @@ import { isCustomListAccess, NewCustomListAstNode } from '../astNode/custom-list
 import { isPayload, type PayloadAstNode } from '../astNode/data-accessor';
 import {
   isMonitoringListCheckAstNode,
+  isRecordHasTagsAstNode,
   monitoringListCheckAstNodeName,
   NewTagCheckAstNode,
+  recordHasTagsAstNodeName,
 } from '../astNode/monitoring-list-check';
 import { isRecordHasPastAlertAstNode, NewRecordHasPastAlertsAstNode } from '../astNode/risk';
 import {
@@ -33,7 +35,18 @@ import {
 } from './conditions';
 import { type DraftRuleModel, type RuleModel } from './rule-model';
 
-export function transformSwitchAstNodeToModel(
+export type BuildContext = { entityType?: string };
+
+export function transformAstNodeToModel(
+  node: AstNode,
+  entityType?: string,
+  dataModel?: DataModel,
+): DraftRuleModel | null {
+  if (!isSwitchAstNode(node)) return null;
+  return transformSwitchAstNodeToModel(node, entityType, dataModel);
+}
+
+function transformSwitchAstNodeToModel(
   node: SwitchAstNode,
   entityType?: string,
   dataModel?: DataModel,
@@ -64,7 +77,7 @@ export function transformSwitchAstNodeToModel(
     if (scoreComputationNodes.length === 0) {
       return {
         type,
-        conditions: { type: 'tags', branches: [], default: { modifier: 0 } },
+        conditions: { type: 'tags', branches: [{ value: [], impact: { modifier: 0 } }], default: { modifier: 0 } },
       };
     }
     const conditions = parseTagsBranches(scoreComputationNodes);
@@ -99,29 +112,32 @@ export function transformSwitchAstNodeToModel(
   return null;
 }
 
-export function buildSwitchAstNodeFromModel(model: RuleModel): SwitchAstNode {
-  if (model.type === 'screening_tags' || model.type === 'entity_tags') {
-    return {
-      id: uuidv7(),
-      name: switchAstNodeName,
-      constant: undefined,
-      namedChildren: {
-        field: NewUndefinedAstNode(),
-        type: NewConstantAstNode({ constant: model.type }),
-      },
-      children: buildTagsSwitchChildren(model.conditions),
-    };
-  }
+export function buildAstNodeFromModel(model: RuleModel, ctx: BuildContext = {}): AstNode {
   if (model.type === 'past_alerts') {
     return {
       id: uuidv7(),
       name: switchAstNodeName,
       constant: undefined,
       namedChildren: {
-        field: NewUndefinedAstNode(),
+        field: NewConstantAstNode({ constant: null }),
         type: NewConstantAstNode({ constant: model.type }),
       },
       children: buildPastAlertsSwitchChildren(model.conditions),
+    };
+  }
+  if (model.type === 'screening_tags' || model.type === 'entity_tags') {
+    if (!ctx.entityType) {
+      throw new Error(`buildAstNodeFromModel: entityType is required to build a "${model.type}" rule`);
+    }
+    return {
+      id: uuidv7(),
+      name: switchAstNodeName,
+      constant: undefined,
+      namedChildren: {
+        field: NewConstantAstNode({ constant: null }),
+        type: NewConstantAstNode({ constant: model.type }),
+      },
+      children: buildTagsSwitchChildren(model.type, model.conditions, ctx.entityType),
     };
   }
   const children = buildConditionChildren(model.field, model.conditions);
@@ -135,16 +151,6 @@ export function buildSwitchAstNodeFromModel(model: RuleModel): SwitchAstNode {
     },
     children,
   };
-}
-
-function buildTagsSwitchChildren(conditions: TagsSwitch): AstNode[] {
-  const branchNodes = conditions.branches.map((branch) => {
-    const branchCondition = NewTagCheckAstNode(monitoringListCheckAstNodeName, {
-      topicFilters: branch.value,
-    });
-    return buildScoreComputationAstNode(branchCondition, branch.impact);
-  });
-  return [...branchNodes, buildScoreComputationAstNode(NewConstantAstNode({ constant: true }), conditions.default)];
 }
 
 function buildPastAlertsSwitchChildren(conditions: BoolSwitch): AstNode[] {
@@ -173,6 +179,22 @@ function parsePastAlertsBranches(nodes: ScoreComputationAstNode[]): BoolSwitch |
   return { type: 'bool', ifTrue, ifFalse };
 }
 
+function buildTagsSwitchChildren(
+  type: 'screening_tags' | 'entity_tags',
+  conditions: TagsSwitch,
+  entityType: string,
+): AstNode[] {
+  const branchNodes = conditions.branches.map((branch) => {
+    const config = { targetTableName: entityType, topicFilters: branch.value };
+    const branchCondition =
+      type === 'screening_tags'
+        ? NewTagCheckAstNode(monitoringListCheckAstNodeName, config)
+        : NewTagCheckAstNode(recordHasTagsAstNodeName, config);
+    return buildScoreComputationAstNode(branchCondition, branch.impact);
+  });
+  return [...branchNodes, buildScoreComputationAstNode(NewConstantAstNode({ constant: true }), conditions.default)];
+}
+
 function parseTagsBranches(nodes: ScoreComputationAstNode[]): TagsSwitch | null {
   const lastNode = nodes[nodes.length - 1]!;
   const lastCondition = lastNode.children[0];
@@ -187,7 +209,7 @@ function parseTagsBranches(nodes: ScoreComputationAstNode[]): TagsSwitch | null 
 
     const conditionNode = branchNode.children[0];
     let tagValues: string[] = [];
-    if (conditionNode && isMonitoringListCheckAstNode(conditionNode)) {
+    if (conditionNode && (isMonitoringListCheckAstNode(conditionNode) || isRecordHasTagsAstNode(conditionNode))) {
       tagValues = conditionNode.namedChildren.config.constant.topicFilters;
     }
     return { value: tagValues, impact: branchImpact };


### PR DESCRIPTION
cf:
- https://linear.app/marble-eu/issue/MAR-1747/error-when-creating-a-new-past-alerts-rule
- https://linear.app/marble-eu/issue/MAR-1748/error-when-creating-a-new-screening-rule
- https://linear.app/marble-eu/issue/MAR-1749/error-when-creating-a-tag-rule

## Problem
Saving a rule of type past_alerts, screening_tags, or entity_tags failed with:

```
BadParameterError: ast node does not return a [score_computation_result]
```

## Root cause

The frontend was sending Switch.namedChildren.field = { name: "Undefined" }. Undefined is a real backend function that throws at eval time — it does not behave like a no-op. The backend's Switch evaluator expects field to be a null-valued constant when there is no field (if field != nil guard).

screening_tags rules also had a secondary bug: for every branch, the AST builder hardcoded MonitoringListCheck, even for entity_tags rules which must use RecordHasTags. The tag-check config was also missing targetTableName.

## Fix
- Switch field is now a null-valued constant node instead of Undefined. This applies to all three rule types. Serialises to { constant: null, children: [], named_children: {} }, which satisfies the backend's nil-field guard.

- entity_tags rules now build RecordHasTags nodes (not MonitoringListCheck). screening_tags still builds MonitoringListCheck. Both pass the rule's entityType as targetTableName in the config — previously sent as empty string, which would have failed backend validation.

- Default branches for new tag rules: when a user creates a new screening_tags / entity_tags rule, the UI now starts with one configurable branch + the else branch (was: only the else branch, giving the user nothing to configure).

## Refactor (small)
- transformSwitchAstNodeToModel → transformAstNodeToModel and buildSwitchAstNodeFromModel → buildAstNodeFromModel. The buildAst* function now takes a { entityType } context so tag-rule builders can set targetTableName.

- RulesTable.handleConfirm now builds the initial AST for tag and past-alerts rules via buildAstNodeFromModel, so every rule type starts from a structurally valid shape.

- Removed the defensive isSwitchAstNode(rule.ast) filter that was hiding rules with non-standard roots — all rule ASTs are Switch-rooted now; the check is redundant.

## Reviewer notes
Only past_alerts / screening_tags / entity_tags rule creation paths were changed on the wire. user_attribute / aggregate rules are structurally identical to before — their field is a real accessor so they never hit the bad Undefined path.
No backend change is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Scoring rule editing and viewing now behave consistently: rule conditions render and update reliably across all rule types.
  * Tag-based and past-alert conditions are handled more robustly, preventing missing/hidden conditions in the UI.
  * Simplified internal transformations reduce conditional gaps, improving stability when editing or saving rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->