### PR TITLE
fix flashing tab in user scoring

### DIFF
--- a/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
@@ -6,7 +6,7 @@ import { type UpdateScoringRulesetPayload, updateScoringRulesetPayloadSchema } f
 import { handleSubmit } from '@app-builder/utils/form';
 import { createSimpleContext } from '@marble/shared';
 import { useForm } from '@tanstack/react-form';
-import { Link, Outlet, useMatches, useNavigate, useRouter } from '@tanstack/react-router';
+import { Link, Outlet, useMatches, useNavigate, useParams, useRouter } from '@tanstack/react-router';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -26,7 +26,6 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
   const { t } = useTranslation(['user-scoring']);
   const [panelOpen, setPanelOpen] = useState(false);
   const { data, isPending } = useListScoringRulesetsQuery();
-  const dataModel = useDataModelQuery().data?.dataModel ?? [];
   const matches = useMatches();
   const showCreateButton = matches.some(
     (m) => (m.staticData as { showCreateRulesetButton?: boolean })?.showCreateRulesetButton,
@@ -55,21 +54,7 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
                   <Spinner className="size-4" />
                 </div>
               ) : (
-                rulesets.map((ruleset) => (
-                  <Link
-                    key={ruleset.id}
-                    to="/user-scoring/$recordType/$version"
-                    params={{
-                      recordType: ruleset.recordType,
-                      version: ruleset.status === 'draft' ? 'draft' : ruleset.version.toString(),
-                    }}
-                    className={tabClassName}
-                  >
-                    {t('user-scoring:section.tab_scores', {
-                      name: dataModel.find((table) => table.name === ruleset.recordType)?.alias || ruleset.recordType,
-                    })}
-                  </Link>
-                ))
+                rulesets.map((ruleset) => <RulesetTab key={ruleset.recordType} ruleset={ruleset} />)
               )}
             </Tabs>
             <Outlet />
@@ -82,6 +67,27 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
         </Page.Container>
       </Page.Main>
     </CreateRulesetPanelContext.Provider>
+  );
+}
+
+function RulesetTab({ ruleset }: { ruleset: { recordType: string; status: string; version: number; name: string } }) {
+  const params = useParams({ strict: false }) as { recordType?: string };
+  const isActive = params.recordType === ruleset.recordType;
+
+  return (
+    <Link
+      to="/user-scoring/$recordType/$version"
+      params={{
+        recordType: ruleset.recordType,
+        version: ruleset.status === 'draft' ? 'draft' : ruleset.version.toString(),
+      }}
+      className={tabClassName}
+      activeProps={{}}
+      inactiveProps={{}}
+      data-status={isActive ? 'active' : undefined}
+    >
+      {ruleset.name}
+    </Link>
   );
 }
 

--- a/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
@@ -71,7 +71,7 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
 }
 
 function RulesetTab({ ruleset }: { ruleset: { recordType: string; status: string; version: number; name: string } }) {
-  const params = useParams({ strict: false }) as { recordType?: string };
+  const params = useParams({ strict: false });
   const isActive = params.recordType === ruleset.recordType;
 
   return (

--- a/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
@@ -4,7 +4,7 @@ import { isNotFoundHttpError } from '@app-builder/models';
 import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
 import { type ScoringRulesetWithRules } from '@app-builder/models/scoring';
 import { hasAnyEntitlement } from '@app-builder/services/feature-access';
-import { createFileRoute, Navigate, redirect, useLoaderData } from '@tanstack/react-router';
+import { createFileRoute, redirect, useLoaderData } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 
 const scoringRulesetLoader = createServerFn()
@@ -42,10 +42,14 @@ export const Route = createFileRoute('/_app/_builder/user-scoring/$recordType/$v
 });
 
 function UserScoringRulesetRoute() {
-  const { ruleset, customLists, preparationStatus, hasValidLicense } = Route.useLoaderData();
-  const { settings } = useLoaderData({ from: '/_app/_builder/user-scoring' });
+  const loaderData = Route.useLoaderData();
+  const parentData = useLoaderData({ from: '/_app/_builder/user-scoring' });
 
-  if (!settings) return <Navigate to="/user-scoring/overview" replace />;
+  // During router.invalidate(), loader data can be temporarily undefined
+  if (!loaderData || !parentData?.settings) return null;
+
+  const { ruleset, customLists, preparationStatus, hasValidLicense } = loaderData;
+  const { settings } = parentData;
 
   return (
     <ScoringRulesetPage


### PR DESCRIPTION
## Content
  1. Tab selection blink - After committing/updating a ruleset, the tab's link version changed (e.g. draft → 1) before the URL updated, causing aria-current to drop and the active style to flash. Fixed by matching active state on recordType
  only via data-status, bypassing Link's full-path matching.
  2. Loader data crash - router.invalidate() temporarily made useLoaderData() return undefined, crashing the child route component. Added a guard to return null during the brief undefined window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed active state indication for ruleset tabs
  * Improved data handling during route transitions to prevent temporary display issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->