### PR TITLE
Pascal/mar 1784 score distribution graph popover are unreadable in dark mode

### DIFF
--- a/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
@@ -1,7 +1,7 @@
 import { BreadCrumbs } from '@app-builder/components/Breadcrumbs';
 import { Page } from '@app-builder/components/Page';
 import { DataModelObject } from '@app-builder/models';
-import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABELS, type ScoringSettings } from '@app-builder/models/scoring';
+import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS, type ScoringSettings } from '@app-builder/models/scoring';
 import { useRelatedCasesByObjectQuery } from '@app-builder/queries/cases/related-cases-by-object';
 import { useGetAnnotationsQuery } from '@app-builder/queries/data/get-annotations';
 import { useDataModelWithOptionsQuery } from '@app-builder/queries/data/get-data-model-with-options';
@@ -46,7 +46,7 @@ export const ClientDetailPage = ({
   scoringSettings,
   activeScore,
 }: ClientDetailPageProps) => {
-  const { t } = useTranslation(['common', 'client360']);
+  const { t } = useTranslation(['common', 'client360', 'user-scoring']);
   const dataModelQuery = useDataModelWithOptionsQuery();
   const annotationsQuery = useGetAnnotationsQuery(objectType, objectId, true);
   const [showExplorer, setShowExplorer] = useState(false);
@@ -67,9 +67,10 @@ export const ClientDetailPage = ({
   if (scoringSettings && activeScore) {
     scoreColor =
       SCORING_LEVELS_COLORS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ?? 'inherit';
-    scoreLabel =
-      SCORING_LEVELS_LABELS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ??
-      activeScore.risk_level.toString();
+    scoreLabel = t(
+      SCORING_LEVELS_LABEL_KEYS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ??
+        activeScore.risk_level.toString(),
+    );
   }
 
   const handleScoreClick = () => setShowScorePanel(true);

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABELS, type ScoringSettings } from '@app-builder/models/scoring';
+import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS, type ScoringSettings } from '@app-builder/models/scoring';
 import { useGetScoringRulesetQuery } from '@app-builder/queries/scoring/get-ruleset';
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { type ScoringScore } from 'marble-api';
@@ -91,14 +91,16 @@ export function ScoreDetailPanel({
   activeScore,
   scoringSettings,
 }: ScoreDetailPanelProps) {
-  const { t } = useTranslation(['client360']);
+  const { t } = useTranslation(['client360', 'user-scoring']);
   const formatDateTime = useFormatDateTime();
   const rulesetQuery = useGetScoringRulesetQuery(objectType);
   const thresholds = rulesetQuery.data?.ruleset.thresholds;
 
   const maxRiskLevel = scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6;
   const scoreColor = SCORING_LEVELS_COLORS[maxRiskLevel][activeScore.risk_level] ?? 'inherit';
-  const scoreLabel = SCORING_LEVELS_LABELS[maxRiskLevel][activeScore.risk_level] ?? activeScore.risk_level.toString();
+  const scoreLabel = t(
+    SCORING_LEVELS_LABEL_KEYS[maxRiskLevel][activeScore.risk_level] ?? activeScore.risk_level.toString(),
+  );
 
   return (
     <PanelRoot open={open} onOpenChange={onOpenChange}>

--- a/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
+++ b/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
@@ -3,7 +3,7 @@ import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/pub
 import {
   isMaxRiskLevelInRange,
   SCORING_LEVELS_COLORS,
-  SCORING_LEVELS_LABELS,
+  SCORING_LEVELS_LABEL_KEYS,
   type ScoringRulesetWithRules,
   type ScoringSettings,
   SECONDS_PER_UNIT,
@@ -274,7 +274,7 @@ function RiskLevelBadges({ maxRiskLevel, thresholds }: { maxRiskLevel: number; t
   }
 
   const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
-  const labels = SCORING_LEVELS_LABELS[maxRiskLevel];
+  const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
   return (
     <div className="flex flex-col gap-v2-sm">
@@ -286,7 +286,7 @@ function RiskLevelBadges({ maxRiskLevel, thresholds }: { maxRiskLevel: number; t
             <Fragment key={color}>
               <div className="flex items-center gap-v2-xs h-6 px-2 rounded-full border" style={{ borderColor: color }}>
                 <div className="size-3 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                <span className="text-xs text-grey-primary">{labels[i]}</span>
+                <span className="text-xs text-grey-primary">{t(labelKeys[i] ?? '')}</span>
               </div>
               {!isLast ? (
                 <span className="text-xs font-medium text-grey-placeholder">{`≤ ${thresholds[i]} <`}</span>

--- a/packages/app-builder/src/components/UserScoring/ScoringLevelThresholds.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringLevelThresholds.tsx
@@ -1,4 +1,4 @@
-import { isMaxRiskLevelInRange, SCORING_LEVELS_COLORS, SCORING_LEVELS_LABELS } from '@app-builder/models/scoring';
+import { isMaxRiskLevelInRange, SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS } from '@app-builder/models/scoring';
 import { useTranslation } from 'react-i18next';
 import { Input, NumberInput } from 'ui-design-system';
 
@@ -15,7 +15,7 @@ export function ScoringLevelThresholds({ maxRiskLevel, thresholds, onThresholdsC
   }
 
   const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
-  const labels = SCORING_LEVELS_LABELS[maxRiskLevel];
+  const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
   const handleChange = (index: number, value: number) => {
     const next = [...thresholds];
@@ -40,7 +40,7 @@ export function ScoringLevelThresholds({ maxRiskLevel, thresholds, onThresholdsC
               {/* Level name display */}
               <div className="flex items-center gap-v2-xs h-10 w-[195px] shrink-0 border border-grey-border rounded-sm px-2">
                 <div className="size-4 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                <span className="text-s font-medium flex-1 min-w-0 truncate">{labels[i]}</span>
+                <span className="text-s font-medium flex-1 min-w-0 truncate">{t(labelKeys[i] ?? '')}</span>
               </div>
 
               {isFirst ? (

--- a/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@app-builder/components/Spinner';
 import {
   SCORING_LEVELS_COLORS,
-  SCORING_LEVELS_LABELS,
+  SCORING_LEVELS_LABEL_KEYS,
   type ScoringRuleset,
   type ScoringSettings as ScoringSettingsModel,
 } from '@app-builder/models/scoring';
@@ -68,7 +68,7 @@ function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; se
   const distributionQuery = useGetScoreDistributionQuery(ruleset.recordType);
   const maxRiskLevel = settings.maxRiskLevel as 3 | 4 | 5 | 6;
   const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
-  const labels = SCORING_LEVELS_LABELS[maxRiskLevel];
+  const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
   return (
     <div className="bg-surface-card border border-grey-border rounded-v2-md p-v2-md flex flex-col gap-v2-md h-[400px]">
@@ -99,7 +99,7 @@ function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; se
             .filter((item) => item.count > 0)
             .map((item) => ({
               id: item.risk_level,
-              label: labels[item.risk_level] ?? item.risk_level.toString(),
+              label: t(labelKeys[item.risk_level] ?? item.risk_level.toString()),
               value: item.count,
               color: colors[item.risk_level] ?? '#ccc',
             }));

--- a/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
@@ -112,6 +112,12 @@ function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; se
                 padAngle={1}
                 colors={{ datum: 'data.color' }}
                 enableArcLabels={false}
+                tooltip={({ datum }) => (
+                  <div className="flex items-center gap-v2-xs bg-surface-card p-v2-xs rounded-lg border border-grey-border shadow-sm text-s text-grey-primary whitespace-nowrap">
+                    <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: datum.color }} />
+                    {datum.label}: {datum.value} ({Math.round((datum.value / total) * 100)}%)
+                  </div>
+                )}
                 arcLinkLabel={(datum) => `${Math.round((datum.value / total) * 100)}%`}
                 arcLinkLabelsColor={{ from: 'color' }}
                 arcLinkLabelsThickness={0}

--- a/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
@@ -105,50 +105,32 @@ function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; se
             }));
 
           return (
-            <div className="flex-1">
-              <ResponsivePie
-                data={pieData}
-                innerRadius={0.7}
-                padAngle={1}
-                colors={{ datum: 'data.color' }}
-                enableArcLabels={false}
-                tooltip={({ datum }) => (
-                  <div className="flex items-center gap-v2-xs bg-surface-card p-v2-xs rounded-lg border border-grey-border shadow-sm text-s text-grey-primary whitespace-nowrap">
-                    <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: datum.color }} />
-                    {datum.label}: {datum.value} ({Math.round((datum.value / total) * 100)}%)
+            <div className="flex flex-1 flex-col gap-v2-sm">
+              <div className="flex-1">
+                <ResponsivePie
+                  data={pieData}
+                  innerRadius={0.7}
+                  padAngle={1}
+                  colors={{ datum: 'data.color' }}
+                  enableArcLabels={false}
+                  tooltip={({ datum }) => (
+                    <div className="flex items-center gap-v2-xs bg-surface-card p-v2-xs rounded-lg border border-grey-border shadow-sm text-s text-grey-primary whitespace-nowrap">
+                      <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: datum.color }} />
+                      {datum.label}: {datum.value} ({Math.round((datum.value / total) * 100)}%)
+                    </div>
+                  )}
+                  enableArcLinkLabels={false}
+                  margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+                />
+              </div>
+              <div className="flex flex-wrap items-center justify-center gap-x-v2-md gap-y-v2-xs">
+                {pieData.map((item) => (
+                  <div key={item.id} className="flex items-center gap-v2-xs">
+                    <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
+                    <span className="text-xs font-medium text-grey-secondary">{item.label}</span>
                   </div>
-                )}
-                arcLinkLabel={(datum) => `${Math.round((datum.value / total) * 100)}%`}
-                arcLinkLabelsColor={{ from: 'color' }}
-                arcLinkLabelsThickness={0}
-                arcLinkLabelsDiagonalLength={12}
-                arcLinkLabelsStraightLength={12}
-                arcLinkLabelsTextColor="var(--color-grey-primary)"
-                legends={[
-                  {
-                    anchor: 'bottom',
-                    direction: 'row',
-                    justify: false,
-                    translateY: 56,
-                    itemsSpacing: 32,
-                    itemWidth: 40,
-                    itemHeight: 24,
-                    itemDirection: 'left-to-right',
-                    symbolSize: 12,
-                    symbolShape: 'circle',
-                  },
-                ]}
-                margin={{ top: 30, right: 40, bottom: 70, left: 40 }}
-                theme={{
-                  legends: {
-                    text: {
-                      fill: 'var(--color-grey-secondary)',
-                      fontSize: 12,
-                      fontWeight: 500,
-                    },
-                  },
-                }}
-              />
+                ))}
+              </div>
             </div>
           );
         })

--- a/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
@@ -5,6 +5,7 @@ import {
   type ScoringRuleset,
   type ScoringSettings as ScoringSettingsModel,
 } from '@app-builder/models/scoring';
+import { useDataModelQuery } from '@app-builder/queries/data/get-data-model';
 import { useGetScoreDistributionQuery } from '@app-builder/queries/scoring/get-score-distribution';
 import { useListScoringRulesetsQuery } from '@app-builder/queries/scoring/list-rulesets';
 import { ResponsivePie } from '@nivo/pie';
@@ -66,13 +67,15 @@ export function ScoringOverviewPage({ settings }: { settings: ScoringSettingsMod
 function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; settings: ScoringSettingsModel }) {
   const { t } = useTranslation(['user-scoring', 'common']);
   const distributionQuery = useGetScoreDistributionQuery(ruleset.recordType);
+  const dataModel = useDataModelQuery().data?.dataModel ?? [];
+  const entityName = dataModel.find((table) => table.name === ruleset.recordType)?.alias || ruleset.recordType;
   const maxRiskLevel = settings.maxRiskLevel as 3 | 4 | 5 | 6;
   const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
   const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
   return (
     <div className="bg-surface-card border border-grey-border rounded-v2-md p-v2-md flex flex-col gap-v2-md h-[400px]">
-      <p className="text-s font-medium">{t('user-scoring:overview.ruleset_card.title', { name: ruleset.name })}</p>
+      <p className="text-s font-medium">{t('user-scoring:overview.ruleset_card.title', { name: entityName })}</p>
       {match(distributionQuery)
         .with({ isPending: true }, () => (
           <div className="flex flex-1 items-center justify-center">

--- a/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
@@ -26,6 +26,7 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
   const { t } = useTranslation(['user-scoring']);
   const [panelOpen, setPanelOpen] = useState(false);
   const { data, isPending } = useListScoringRulesetsQuery();
+  const dataModel = useDataModelQuery().data?.dataModel ?? [];
   const matches = useMatches();
   const showCreateButton = matches.some(
     (m) => (m.staticData as { showCreateRulesetButton?: boolean })?.showCreateRulesetButton,
@@ -64,7 +65,9 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
                     }}
                     className={tabClassName}
                   >
-                    {ruleset.name}
+                    {t('user-scoring:section.tab_scores', {
+                      name: dataModel.find((table) => table.name === ruleset.recordType)?.alias || ruleset.recordType,
+                    })}
                   </Link>
                 ))
               )}

--- a/packages/app-builder/src/components/UserScoring/ScoringSettings.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSettings.tsx
@@ -4,7 +4,7 @@ import {
   MAX_RISK_LEVELS,
   type MaxRiskLevel,
   SCORING_LEVELS_COLORS,
-  SCORING_LEVELS_LABELS,
+  SCORING_LEVELS_LABEL_KEYS,
   type ScoringSettings as ScoringSettingsModel,
 } from '@app-builder/models/scoring';
 import { useUpdateScoringSettingsMutation } from '@app-builder/queries/scoring/update-settings';
@@ -84,19 +84,20 @@ function ScoringScaleCard({ maxLevel, selected, onSelect }: ScoringScaleCardProp
 }
 
 function ScoringLevels({ maxLevel, className }: { maxLevel: number; className?: string }) {
+  const { t } = useTranslation(['user-scoring']);
   if (!isMaxRiskLevelInRange(maxLevel)) {
     return null;
   }
 
   const scoringColors = SCORING_LEVELS_COLORS[maxLevel];
-  const scoringLabels = SCORING_LEVELS_LABELS[maxLevel];
+  const scoringLabelKeys = SCORING_LEVELS_LABEL_KEYS[maxLevel];
 
   return (
     <div className={cn(className)}>
       {scoringColors.map((color, i) => (
         <div key={color} className="flex gap-v2-sm items-center">
           <div className="size-4 rounded-full" style={{ backgroundColor: color }} />
-          <span>{scoringLabels[i]}</span>
+          <span>{t(scoringLabelKeys[i] ?? '')}</span>
         </div>
       ))}
     </div>

--- a/packages/app-builder/src/locales/ar/user-scoring.json
+++ b/packages/app-builder/src/locales/ar/user-scoring.json
@@ -59,6 +59,7 @@
   "section.create_panel.unit_placeholder": "وحدة",
   "section.create_panel.validate": "تحقق",
   "section.tab_overview": "نظرة عامة",
+  "section.tab_scores": "نقاط {{name}}",
 
   "section.title": "تكوين النقاط",
   "settings.define_scale": "حدد مقياس مخاطر، ثم اختر الكيان الذي تريد إنشاء مجموعة القواعد عليه.",

--- a/packages/app-builder/src/locales/ar/user-scoring.json
+++ b/packages/app-builder/src/locales/ar/user-scoring.json
@@ -1,4 +1,9 @@
 {
+  "level.high": "مرتفع",
+
+  "level.low": "منخفض",
+  "level.medium": "متوسط",
+  "level.very_high": "مرتفع جداً",
   "overview.configure_score": "تكوين النقاط",
 
   "overview.no_ruleset": "لا يوجد لديك أي مجموعة قواعد مكوّنة بعد. اختر كيانًا لإنشاء مجموعة قواعد للبدء.",

--- a/packages/app-builder/src/locales/en/user-scoring.json
+++ b/packages/app-builder/src/locales/en/user-scoring.json
@@ -59,6 +59,7 @@
   "section.create_panel.unit_placeholder": "unit",
   "section.create_panel.validate": "Validate",
   "section.tab_overview": "Overview",
+  "section.tab_scores": "Scores {{name}}",
 
   "section.title": "Customer Scoring",
   "settings.define_scale": "Define a risk scale, then choose the entity on which you want to create the ruleset.",

--- a/packages/app-builder/src/locales/en/user-scoring.json
+++ b/packages/app-builder/src/locales/en/user-scoring.json
@@ -1,4 +1,9 @@
 {
+  "level.high": "High",
+
+  "level.low": "Low",
+  "level.medium": "Medium",
+  "level.very_high": "Very high",
   "overview.configure_score": "Configure a score",
 
   "overview.no_ruleset": "You don't have any ruleset configured yet. Choose an entity on which to create a ruleset to start.",

--- a/packages/app-builder/src/locales/fr/user-scoring.json
+++ b/packages/app-builder/src/locales/fr/user-scoring.json
@@ -1,4 +1,9 @@
 {
+  "level.high": "Élevé",
+
+  "level.low": "Faible",
+  "level.medium": "Moyen",
+  "level.very_high": "Très élevé",
   "overview.configure_score": "Configurer un score",
 
   "overview.no_ruleset": "Vous n'avez pas encore de jeu de règles configuré. Choisissez une entité sur laquelle créer un jeu de règles pour commencer.",

--- a/packages/app-builder/src/locales/fr/user-scoring.json
+++ b/packages/app-builder/src/locales/fr/user-scoring.json
@@ -59,6 +59,7 @@
   "section.create_panel.unit_placeholder": "unité",
   "section.create_panel.validate": "Valider",
   "section.tab_overview": "Vue d'ensemble",
+  "section.tab_scores": "Scores {{name}}",
 
   "section.title": "Scoring client",
   "settings.define_scale": "Définissez une échelle de risque, puis choisissez l'entité sur laquelle créer le jeu de règles.",

--- a/packages/app-builder/src/models/scoring/display.ts
+++ b/packages/app-builder/src/models/scoring/display.ts
@@ -8,9 +8,13 @@ export const SCORING_LEVELS_COLORS: Record<MaxRiskLevel, string[]> = {
   6: ['#89D4AD', '#FFD57E', '#FDBD35', '#FF6600', '#DB5F4A', '#D2371D'],
 };
 
-export const SCORING_LEVELS_LABELS: Record<MaxRiskLevel, string[]> = {
-  3: ['Low', 'Medium', 'High'],
-  4: ['Low', 'Medium', 'High', 'Very high'],
+/**
+ * i18n keys for levels 3 and 4 (e.g. 'user-scoring:level.low').
+ * Levels 5 and 6 use plain number strings (not translated).
+ */
+export const SCORING_LEVELS_LABEL_KEYS: Record<MaxRiskLevel, string[]> = {
+  3: ['user-scoring:level.low', 'user-scoring:level.medium', 'user-scoring:level.high'],
+  4: ['user-scoring:level.low', 'user-scoring:level.medium', 'user-scoring:level.high', 'user-scoring:level.very_high'],
   5: ['1', '2', '3', '4', '5'],
   6: ['1', '2', '3', '4', '5', '6'],
 };


### PR DESCRIPTION
## Summary

  - Fix score distribution pie chart tooltip unreadable in dark mode (white on white) by adding a custom tooltip with theme-aware colors
  - Replace Nivo's SVG legend with a custom HTML legend that auto-sizes, supports RTL, and works in dark mode
  - Translate hardcoded scoring level labels ("Low", "Medium", "High", "Very high") into en/fr/ar
  - Use table alias instead of raw table name + fully translated surrounding text in tab labels and card titles

----

## Full illustration in arabic

### Before
<img width="1020" height="619" alt="Capture d’écran 2026-04-20 à 21 54 21" src="https://github.com/user-attachments/assets/af0cfae4-2328-4ca0-be85-91428592d3a3" />

### After
<img width="1027" height="648" alt="Capture d’écran 2026-04-20 à 21 53 59" src="https://github.com/user-attachments/assets/8ca76ba9-98d9-42f8-a8e0-9cf6b1cfe774" />
