### PR TITLE
show clear message when related object is not ingested

### DIFF
--- a/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
@@ -568,6 +568,7 @@ function DataDerivedData({ metaData }: { metaData?: Record<string, unknown> }) {
 }
 
 function LinkToValue({ value, linkedTo }: { value?: string; linkedTo?: string }) {
+  const { t } = useTranslation(['data']);
   const [isOpen, setIsOpen] = useState(false);
   const options = useOptions();
   const objectDetailQuery = useObjectDetailsQuery(linkedTo, value, isOpen);
@@ -598,7 +599,9 @@ function LinkToValue({ value, linkedTo }: { value?: string; linkedTo?: string })
               />
             ))
             .otherwise(() => (
-              <EmptyValue />
+              <span className="text-grey-secondary text-s">
+                {t('data:viewer.related_object_not_ingested', { tableName: linkedTo, objectId: value })}
+              </span>
             ))}
         </div>
       )}

--- a/packages/app-builder/src/locales/ar/data.json
+++ b/packages/app-builder/src/locales/ar/data.json
@@ -321,6 +321,7 @@
   "viewer.no_object_found": "لم يتم العثور على كائن بالمعرف \"{{objectId}}\" في {{tableName}}",
   "viewer.object_id": "معرف الكائن",
   "viewer.object_type": "نوع الكائن",
+  "viewer.related_object_not_ingested": "الكائن المرتبط {{tableName}} بالمعرف \"{{objectId}}\" لم يتم استيعابه بعد.",
   "viewer.view_ingested_data": "عرض البيانات المستوردة",
   "vpn": "نعم",
   "yes": "نعم"

--- a/packages/app-builder/src/locales/en/data.json
+++ b/packages/app-builder/src/locales/en/data.json
@@ -321,6 +321,7 @@
   "viewer.no_object_found": "No object found for id \"{{objectId}}\" in {{tableName}}",
   "viewer.object_id": "Object ID",
   "viewer.object_type": "Object type",
+  "viewer.related_object_not_ingested": "The linked {{tableName}} with id \"{{objectId}}\" has not been ingested yet.",
   "viewer.view_ingested_data": "View ingested data",
   "vpn": "Yes",
   "yes": "Yes"

--- a/packages/app-builder/src/locales/fr/data.json
+++ b/packages/app-builder/src/locales/fr/data.json
@@ -321,6 +321,7 @@
   "viewer.no_object_found": "Aucun objet trouvé avec l'ID \"{{objectId}}\" dans {{tableName}}",
   "viewer.object_id": "ID de l'objet",
   "viewer.object_type": "Type d'objet",
+  "viewer.related_object_not_ingested": "Le {{tableName}} lié avec l'ID \"{{objectId}}\" n'a pas encore été ingéré.",
   "viewer.view_ingested_data": "Voir les données ingérées",
   "vpn": "Oui",
   "yes": "Oui"


### PR DESCRIPTION
Replace the "-" fallback in LinkToValue with an explicit "linked object has not been ingested" message, so viewers of ingested data (customer hub, pivots panel, etc.) immediately understand why the related object panel is empty.


resolved: https://linear.app/marble-eu/issue/MAR-1774/data-viewer-better-error-message-when-related-object-is-not-ingested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced messaging when viewing related objects that haven't been ingested, now displays table name and object ID for better clarity.

* **Localization**
  * Added translated error messages for undigested related objects across Arabic, English, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->