### PR TITLE
fix filters in audit logs page

### DIFF
--- a/packages/app-builder/src/routes/_app/_builder/settings/audit-logs.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/settings/audit-logs.tsx
@@ -3,9 +3,7 @@ import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
 import { isAdmin } from '@app-builder/models';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
-import { getRequest } from '@tanstack/react-start/server';
-import QueryString from 'qs';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const DEFAULT_LIMIT = 25;
 
@@ -14,31 +12,33 @@ const pageQueryStringSchema = z.object({
   limit: z.coerce.number().optional().default(DEFAULT_LIMIT),
 });
 
+const activityFollowUpLoaderSchema = z.object({
+  query: pageQueryStringSchema,
+});
+
 const activityFollowUpLoader = createServerFn()
   .middleware([authMiddleware])
-  .handler(async function activityFollowUpLoader({ context }) {
-    const request = getRequest();
+  .inputValidator(activityFollowUpLoaderSchema)
+  .handler(async function activityFollowUpLoader({ context, data: { query } }) {
     const { user, apiKey } = context.authInfo;
 
     if (!isAdmin(user)) {
       throw redirect({ to: '/' });
     }
 
-    const url = new URL(request.url);
-    const searchParams = new URLSearchParams(url.search);
-    const parsedSearchParams = pageQueryStringSchema.parse(Object.fromEntries(searchParams));
-
     const apiKeys = await apiKey.listApiKeys();
 
     return {
-      query: parsedSearchParams.q,
-      limit: parsedSearchParams.limit,
+      query: query.q,
+      limit: query.limit,
       apiKeys,
     };
   });
 
 export const Route = createFileRoute('/_app/_builder/settings/audit-logs')({
-  loader: () => activityFollowUpLoader(),
+  validateSearch: pageQueryStringSchema,
+  loaderDeps: ({ search }) => search,
+  loader: ({ deps }) => activityFollowUpLoader({ data: { query: deps } }),
   component: ActivityFollowUp,
 });
 
@@ -47,14 +47,14 @@ function ActivityFollowUp() {
   const { query, limit, apiKeys } = Route.useLoaderData();
 
   const updatePage = (newQuery: string, newLimit: number) => {
-    const qs = QueryString.stringify(
-      {
+    navigate({
+      to: '.',
+      search: {
         q: newQuery !== '' ? newQuery : undefined,
         limit: newLimit !== DEFAULT_LIMIT ? newLimit : undefined,
       },
-      { addQueryPrefix: true, skipNulls: true },
-    );
-    navigate({ to: `/settings/audit-logs${qs}`, replace: true });
+      replace: true,
+    });
   };
 
   return <ActivityFollowUpPage query={query} limit={limit} updatePage={updatePage} apiKeys={apiKeys} />;


### PR DESCRIPTION
## Root cause
After migrating from Remix to TanStack Start, the audit-logs route was still using the Remix-era pattern of parsing search params from getRequest().url. TanStack Router requires explicit validateSearch on the route definition for search params to flow through.

### Changes in audit-logs.tsx:

  1. Added validateSearch: pageQueryStringSchema — tells TanStack Router to parse and validate search params from the URL
  2. Added loaderDeps: ({ search }) => search — makes the loader re-run when search params change
  3. Loader now receives search params via data input (with inputValidator) instead of manually parsing getRequest().url
  4. navigate uses search option instead of string-concatenating query params with qs — this is the TanStack Router way
  5. Switched from zod to zod/v4 to match the rest of the codebase
  6. Removed unused getRequest, QueryString imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated audit logs search parameter validation and pagination navigation handling for improved internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->