### PR TITLE
fix: persist boolean display preference on table field create/update

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
@@ -238,6 +238,7 @@ export function adaptTableField(field: TableField): CreateTableValue['fields'][n
       currencyFieldId: field.currencyFieldId,
       foreignkeyTable: field.foreignkeyTable,
       hidden: field.hidden,
+      booleanDisplay: field.booleanDisplay,
     },
   };
 }

--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
@@ -225,6 +225,7 @@ const metadataKeys = [
   'currencyFieldId',
   'foreignkeyTable',
   'hidden',
+  'booleanDisplay',
 ] as const satisfies (keyof TableField)[];
 
 function adaptTableFieldUpdate(current: TableField, original: TableField, rawModelField?: DataModelField) {
@@ -259,6 +260,7 @@ function adaptTableFieldUpdate(current: TableField, original: TableField, rawMod
           currencyFieldId: current.currencyFieldId,
           foreignkeyTable: current.foreignkeyTable,
           hidden: current.hidden,
+          booleanDisplay: current.booleanDisplay,
         }
       : undefined,
   });


### PR DESCRIPTION
resolved: https://linear.app/marble-eu/issue/MAR-1802/the-boolean-display-setting-is-not-saved


## Summary
- The switch vs Yes/No preference (`booleanDisplay`) on a table field was set in the form state but never forwarded in the metadata payload to the backend, so the user selection was lost after save.
- Added `booleanDisplay` to the create adapter's metadata (`createTable-types.ts`).
- Added `booleanDisplay` to the edit adapter's metadata and to `metadataKeys` (so toggling just this setting is correctly detected as a change) in `updateTable-adapter.ts`.

## Test plan
- [ ] Create a new table with a Bool field, toggle representation to Yes/No, save, reload — selection persists.
- [ ] Edit an existing Bool field: switching only the representation (no other field changes) triggers a save and persists after reload.
- [ ] Non-boolean field settings (currency, decimal precision, foreign key, hidden) still save as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table creation now preserves configurable boolean display settings for fields, so boolean columns render according to your chosen display option.
  * Table editing now tracks and applies changes to boolean display metadata, ensuring updates to boolean column presentation are saved and reflected in semantic tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->