### PR TITLE
fix toaster in settings page

### DIFF
--- a/packages/app-builder/src/components/Lists/CreateListModal.tsx
+++ b/packages/app-builder/src/components/Lists/CreateListModal.tsx
@@ -1,11 +1,11 @@
 import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/FormErrorOrDescription';
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
-import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useCreateListMutation } from '@app-builder/queries/lists/create-list';
 import { CreateListPayload, createListPayloadSchema } from '@app-builder/schemas/lists';
 import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Select } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -14,7 +14,6 @@ import { Nudge } from '../Nudge';
 export function CreateListModal({ isIpGpsAvailable }: { isIpGpsAvailable: boolean }) {
   const { t } = useTranslation(['lists', 'navigation', 'common']);
   const createListMutation = useCreateListMutation();
-  const revalidate = useLoaderRevalidator();
 
   const form = useForm({
     defaultValues: {
@@ -24,9 +23,18 @@ export function CreateListModal({ isIpGpsAvailable }: { isIpGpsAvailable: boolea
     } as CreateListPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createListMutation.mutateAsync(value).then(() => {
-          revalidate();
-        });
+        createListMutation
+          .mutateAsync(value)
+          .then((res) => {
+            // On success the server redirects — this only runs if it returned an error object
+            if (res && 'error' in res) {
+              toast.error(t('common:errors.list.duplicate_list_name'));
+              return;
+            }
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Screenings/EnrichMatchButton.tsx
+++ b/packages/app-builder/src/components/Screenings/EnrichMatchButton.tsx
@@ -2,6 +2,7 @@ import { screeningsI18n } from '@app-builder/components/Screenings/screenings-i1
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useEnrichMatchMutation } from '@app-builder/queries/screening/enrich-match';
 import { useCallbackRef } from '@app-builder/utils/hooks';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -12,9 +13,19 @@ export function EnrichMatchButton({ matchId }: { matchId: string }) {
   const revalidate = useLoaderRevalidator();
 
   const handleButtonClick = useCallbackRef(() => {
-    enrichMatchMutation.mutateAsync(matchId).then(() => {
-      revalidate();
-    });
+    enrichMatchMutation
+      .mutateAsync(matchId)
+      .then((res) => {
+        if (res && 'error' in res) {
+          toast.error(t('screenings:error.match_already_enriched'));
+          return;
+        }
+        toast.success(t('screenings:success.match_enriched'));
+        revalidate();
+      })
+      .catch(() => {
+        toast.error(t('common:errors.unknown'));
+      });
   });
 
   return (

--- a/packages/app-builder/src/components/Settings/ApiKey/CreateApiKey.tsx
+++ b/packages/app-builder/src/components/Settings/ApiKey/CreateApiKey.tsx
@@ -3,6 +3,7 @@ import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { apiKeyRoleOptions } from '@app-builder/models/api-keys';
+
 import {
   CreateApiKeyPayload,
   createApiKeyPayloadSchema,
@@ -12,6 +13,7 @@ import { tKeyForApiKeyRole } from '@app-builder/services/i18n/translation-keys/a
 import { getFieldErrors, handleSubmit } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Select } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -43,12 +45,15 @@ const CreateApiKeyContent = ({ onSuccess }: { onSuccess: () => void }) => {
   const form = useForm({
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createApiKeyMutation.mutateAsync(value).then((res) => {
-          if (!res) {
+        createApiKeyMutation
+          .mutateAsync(value)
+          .then(() => {
             onSuccess();
-          }
-          revalidate();
-        });
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     defaultValues: { description: '', role: 'API_CLIENT' } as CreateApiKeyPayload,

--- a/packages/app-builder/src/components/Settings/Inboxes/CreateInbox.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/CreateInbox.tsx
@@ -12,6 +12,7 @@ import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, HiddenInputs, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -58,11 +59,17 @@ export function CreateInboxContent({
     },
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createInboxMutation.mutateAsync(value).then((res) => {
-          setOpen(false);
-          queryClient.invalidateQueries({ queryKey: ['inboxes'] });
-          revalidate();
-        });
+        createInboxMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+            setOpen(false);
+            queryClient.invalidateQueries({ queryKey: ['inboxes'] });
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
   });

--- a/packages/app-builder/src/components/Settings/Inboxes/CreateInboxUser.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/CreateInboxUser.tsx
@@ -17,6 +17,7 @@ import { Namespace } from 'i18next';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import { matchSorter } from 'match-sorter';
 import { useDeferredValue, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, MenuCommand, Modal, Switch } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -101,12 +102,15 @@ export function CreateInboxUserContent({
       autoAssignable: false,
     } as CreateInboxUserPayload,
     onSubmit: async ({ value }) => {
-      createInboxUserMutation.mutateAsync(value).then((res) => {
-        if (!res) {
+      createInboxUserMutation
+        .mutateAsync(value)
+        .then(() => {
           onSuccess();
-        }
-        revalidate();
-      });
+          revalidate();
+        })
+        .catch(() => {
+          toast.error(t('common:errors.unknown'));
+        });
     },
     validators: {
       onSubmit: createInboxUserPayloadSchema,

--- a/packages/app-builder/src/components/Settings/Inboxes/CreateInboxUser.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/CreateInboxUser.tsx
@@ -101,7 +101,7 @@ export function CreateInboxUserContent({
       role: 'admin',
       autoAssignable: false,
     } as CreateInboxUserPayload,
-    onSubmit: async ({ value }) => {
+    onSubmit: ({ value }) => {
       createInboxUserMutation
         .mutateAsync(value)
         .then(() => {

--- a/packages/app-builder/src/components/Settings/Inboxes/UpdateInbox.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/UpdateInbox.tsx
@@ -13,6 +13,7 @@ import {
 import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, MenuCommand, Modal, Switch } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -83,12 +84,15 @@ export function UpdateInboxContent({
     } as UpdateInboxPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateInboxMutation.mutateAsync(value).then((res) => {
-          if (!res) {
+        updateInboxMutation
+          .mutateAsync(value)
+          .then(() => {
             onSuccess();
-          }
-          revalidate();
-        });
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Inboxes/UpdateInboxUser.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/UpdateInboxUser.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 import { Namespace } from 'i18next';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Select } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -71,12 +72,15 @@ export function UpdateInboxUserContent({
     defaultValues: currentInboxUser as UpdateInboxUserPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateInboxUserMutation.mutateAsync(value).then((res) => {
-          if (!res) {
+        updateInboxUserMutation
+          .mutateAsync(value)
+          .then(() => {
             onSuccess();
-          }
-          revalidate();
-        });
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/IpWhitelisting/IpWhitelistingSettingsPage.tsx
+++ b/packages/app-builder/src/components/Settings/IpWhitelisting/IpWhitelistingSettingsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@app-builder/queries/settings/organization/update-allowed-networks';
 import { handleSubmit } from '@app-builder/utils/form';
 import { useForm, useStore } from '@tanstack/react-form';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Button, Input } from 'ui-design-system';
@@ -30,13 +31,23 @@ export const IpWhitelistingSettingsPage = ({
       allowedNetworks,
     },
     onSubmit: ({ value }) => {
-      updateAllowedNetworksMutation.mutateAsync(value).then((res) => {
-        if (res?.subnets) {
-          // Manually update the form value as the backend registers normalized values of cidr/ips
-          form.setFieldValue('allowedNetworks', res.subnets);
-        }
-        revalidate();
-      });
+      updateAllowedNetworksMutation
+        .mutateAsync(value)
+        .then((res) => {
+          if (res && 'error' in res) {
+            toast.error(t('settings:ip_whitelisting.errors.ip_not_in_range'));
+            return;
+          }
+          if (res?.subnets) {
+            // Manually update the form value as the backend registers normalized values of cidr/ips
+            form.setFieldValue('allowedNetworks', res.subnets);
+          }
+          toast.success(t('common:success.save'));
+          revalidate();
+        })
+        .catch(() => {
+          toast.error(t('common:errors.unknown'));
+        });
     },
     validators: {
       onSubmit: updateAllowedNetworksPayloadSchema,

--- a/packages/app-builder/src/components/Settings/Organization/UpdateOrganization.tsx
+++ b/packages/app-builder/src/components/Settings/Organization/UpdateOrganization.tsx
@@ -10,6 +10,7 @@ import {
 import { getFieldErrors, handleSubmit } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -85,11 +86,16 @@ export function UpdateOrganizationSettingsContents({
     },
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateOrganizationMutation.mutateAsync(value).then((res) => {
-          closeModal();
-
-          revalidate();
-        });
+        updateOrganizationMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+            closeModal();
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Scenario/CreateFilter.tsx
+++ b/packages/app-builder/src/components/Settings/Scenario/CreateFilter.tsx
@@ -8,6 +8,7 @@ import {
 import { handleSubmit } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, MenuCommand, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -65,6 +66,9 @@ export function CreateFilter({
             setOpen(false);
             revalidate();
             form.reset();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
           });
       }
     },

--- a/packages/app-builder/src/components/Settings/Tags/CreateTag.tsx
+++ b/packages/app-builder/src/components/Settings/Tags/CreateTag.tsx
@@ -12,6 +12,7 @@ import {
 import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, MenuCommand, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -48,11 +49,16 @@ const CreateTagContent = ({ onSuccess }: { onSuccess: () => void }) => {
     defaultValues: { name: '', color: tagColors[0], target: 'case' } as CreateTagPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createTagMutation.mutateAsync(value).then((res) => {
-          onSuccess();
-
-          revalidate();
-        });
+        createTagMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+            onSuccess();
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Tags/UpdateTag.tsx
+++ b/packages/app-builder/src/components/Settings/Tags/UpdateTag.tsx
@@ -12,6 +12,7 @@ import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { type Tag } from 'marble-api';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -45,11 +46,16 @@ const UpdateTagContent = ({ tag, onSuccess }: { tag: Tag; onSuccess: () => void 
     defaultValues: tag as UpdateTagPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateTagMutation.mutateAsync(value).then((res) => {
-          onSuccess();
-
-          revalidate();
-        });
+        updateTagMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+            onSuccess();
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Users/CreateUser.tsx
+++ b/packages/app-builder/src/components/Settings/Users/CreateUser.tsx
@@ -17,6 +17,7 @@ import clsx from 'clsx';
 import { Namespace } from 'i18next';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Select } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -80,11 +81,19 @@ function CreateUserContent({
     } as CreateUserPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createUserMutation.mutateAsync(value).then((res) => {
-          onSuccess();
-
-          revalidate();
-        });
+        createUserMutation
+          .mutateAsync(value)
+          .then((res) => {
+            if (res && 'error' in res) {
+              toast.error(t('common:errors.list.duplicate_email'));
+              return;
+            }
+            onSuccess();
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Users/UpdateUser.tsx
+++ b/packages/app-builder/src/components/Settings/Users/UpdateUser.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
 import { Namespace } from 'i18next';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import { useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Select } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -63,11 +64,16 @@ function UpdateUserContent({
     defaultValues: user as UpdateUserPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateUserMutation.mutateAsync(value).then((res) => {
-          onSuccess();
-
-          revalidate();
-        });
+        updateUserMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+            onSuccess();
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Webhooks/CreateWebhook.tsx
+++ b/packages/app-builder/src/components/Settings/Webhooks/CreateWebhook.tsx
@@ -17,6 +17,7 @@ import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import * as React from 'react';
+import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, Modal } from 'ui-design-system';
@@ -58,12 +59,15 @@ function CreateWebhookContent({
     } as CreateWebhookPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createWebhookMutation.mutateAsync(value).then((res) => {
-          if (!res) {
+        createWebhookMutation
+          .mutateAsync(value)
+          .then(() => {
             onSuccess();
-          }
-          revalidate();
-        });
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Webhooks/CreateWebhookSecret.tsx
+++ b/packages/app-builder/src/components/Settings/Webhooks/CreateWebhookSecret.tsx
@@ -11,6 +11,7 @@ import {
 import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { type ReactElement, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal } from 'ui-design-system';
 
@@ -39,11 +40,15 @@ function CreateWebhookSecretContent({ webhookId, onSuccess }: { webhookId: strin
     } as CreateWebhookSecretPayload,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        createMutation.mutateAsync(value).then((res) => {
-          onSuccess();
-
-          revalidate();
-        });
+        createMutation
+          .mutateAsync(value)
+          .then(() => {
+            onSuccess();
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/components/Settings/Webhooks/RevokeWebhookSecret.tsx
+++ b/packages/app-builder/src/components/Settings/Webhooks/RevokeWebhookSecret.tsx
@@ -2,6 +2,7 @@ import { LoadingIcon } from '@app-builder/components/Spinner';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useRevokeWebhookSecretMutation } from '@app-builder/queries/settings/webhooks/revoke-webhook-secret';
 import { type ReactElement, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal } from 'ui-design-system';
 
@@ -40,11 +41,15 @@ function RevokeWebhookSecretContent({
   const revalidate = useLoaderRevalidator();
 
   const handleRevoke = () => {
-    revokeMutation.mutateAsync({ webhookId, secretId }).then((res) => {
-      onSuccess();
-
-      revalidate();
-    });
+    revokeMutation
+      .mutateAsync({ webhookId, secretId })
+      .then(() => {
+        onSuccess();
+        revalidate();
+      })
+      .catch(() => {
+        toast.error(t('common:errors.unknown'));
+      });
   };
 
   return (

--- a/packages/app-builder/src/components/Settings/Webhooks/UpdateWebhook.tsx
+++ b/packages/app-builder/src/components/Settings/Webhooks/UpdateWebhook.tsx
@@ -17,6 +17,7 @@ import { getFieldErrors } from '@app-builder/utils/form';
 import { useForm } from '@tanstack/react-form';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import * as React from 'react';
+import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, Modal } from 'ui-design-system';
@@ -59,11 +60,15 @@ function UpdateWebhookContent({
     defaultValues: defaultValue,
     onSubmit: ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateWebhookMutation.mutateAsync(value).then((res) => {
-          setOpen(false);
-
-          revalidate();
-        });
+        updateWebhookMutation
+          .mutateAsync(value)
+          .then(() => {
+            setOpen(false);
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
     validators: {

--- a/packages/app-builder/src/queries/screening/enrich-match.ts
+++ b/packages/app-builder/src/queries/screening/enrich-match.ts
@@ -8,7 +8,7 @@ export const useEnrichMatchMutation = () => {
   return useMutation({
     mutationKey: ['screening', 'enrich-match'],
     mutationFn: async (matchId: string) => {
-      await enrichMatch({ data: { matchId } });
+      return enrichMatch({ data: { matchId } });
     },
   });
 };

--- a/packages/app-builder/src/routes/_app/_builder/settings/analytics/filters.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/settings/analytics/filters.tsx
@@ -12,6 +12,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, Table, useTable } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -281,6 +282,9 @@ function Filters() {
                         setIsConfirmOpen(false);
                         setItemToDelete(null);
                         revalidate();
+                      })
+                      .catch(() => {
+                        toast.error(t('common:errors.unknown'));
                       });
                   }}
                 >

--- a/packages/app-builder/src/routes/_app/_builder/settings/data-display.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/settings/data-display.tsx
@@ -21,6 +21,7 @@ import { useMutation } from '@tanstack/react-query';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { createServerFn, useServerFn } from '@tanstack/react-start';
 import { cva } from 'class-variance-authority';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Button, Collapsible, Switch } from 'ui-design-system';
@@ -106,7 +107,14 @@ function DataDisplaySettings() {
     },
     onSubmit: async ({ value, formApi }) => {
       if (formApi.state.isValid) {
-        updateMutation.mutate(value);
+        updateMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
       }
     },
   });

--- a/packages/app-builder/src/routes/_app/_builder/settings/scenarios.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/settings/scenarios.tsx
@@ -3,6 +3,7 @@ import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/Fo
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { FormSelectTimezone } from '@app-builder/components/Settings/FormSelectTimezone';
+import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
 import { isAdmin } from '@app-builder/models';
 import {
@@ -16,6 +17,7 @@ import { useForm } from '@tanstack/react-form';
 import { useMutation } from '@tanstack/react-query';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { createServerFn, useServerFn } from '@tanstack/react-start';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'ui-design-system';
 
@@ -44,6 +46,7 @@ function Scenarios() {
   const { t } = useTranslation(['settings', 'common']);
   const { organization, user, entitlements } = Route.useLoaderData();
   const updateOrganizationScenarios = useServerFn(updateOrganizationScenariosFn);
+  const revalidate = useLoaderRevalidator();
 
   const updateMutation = useMutation({
     mutationFn: (value: UpdateOrganizationScenariosPayload) => updateOrganizationScenarios({ data: value }),
@@ -51,7 +54,17 @@ function Scenarios() {
 
   const form = useForm({
     onSubmit: ({ value, formApi }) => {
-      if (formApi.state.isValid) updateMutation.mutate(value);
+      if (formApi.state.isValid) {
+        updateMutation
+          .mutateAsync(value)
+          .then(() => {
+            toast.success(t('common:success.save'));
+            revalidate();
+          })
+          .catch(() => {
+            toast.error(t('common:errors.unknown'));
+          });
+      }
     },
     validators: {
       onChange: updateOrganizationScenariosPayloadSchema as unknown as any,

--- a/packages/app-builder/src/server-fns/lists.ts
+++ b/packages/app-builder/src/server-fns/lists.ts
@@ -7,7 +7,6 @@ import {
   deleteValuePayloadSchema,
   editListPayloadSchema,
 } from '@app-builder/schemas/lists';
-import { setToast } from '@app-builder/services/toast.server';
 import { getServerEnv } from '@app-builder/utils/environment';
 import { getCustomListDataUploadEndpoint } from '@app-builder/utils/files';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
@@ -26,12 +25,9 @@ export const createListFn = createServerFn({ method: 'POST' })
       if (error instanceof Response && error.status >= 300 && error.status < 400) {
         throw error;
       }
-      await setToast({
-        type: 'error',
-        messageKey: isStatusConflictHttpError(error)
-          ? 'common:errors.list.duplicate_list_name'
-          : 'common:errors.unknown',
-      });
+      if (isStatusConflictHttpError(error)) {
+        return { error: 'duplicate_list_name' as const };
+      }
       throw new Error('Failed to create list');
     }
   });

--- a/packages/app-builder/src/server-fns/screenings.ts
+++ b/packages/app-builder/src/server-fns/screenings.ts
@@ -132,12 +132,9 @@ export const enrichMatchFn = createServerFn({ method: 'POST' })
   .handler(async ({ context, data }) => {
     try {
       await context.authInfo.screening.enrichMatch({ matchId: data.matchId });
-      await setToast({ type: 'success', message: 'screenings:success.match_enriched' });
     } catch (error) {
       if (isStatusConflictHttpError(error)) {
-        await setToast({ type: 'error', message: 'screenings:error.match_already_enriched' });
-      } else {
-        await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
+        return { error: 'already_enriched' as const };
       }
       throw new Error('Failed to enrich match');
     }

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -327,14 +327,8 @@ export const updateOrganizationFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(updateOrganizationPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      const { organizationId, autoAssignQueueLimit } = data;
-      await context.authInfo.organization.updateOrganization({ organizationId, changes: { autoAssignQueueLimit } });
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to update organization');
-    }
+    const { organizationId, autoAssignQueueLimit } = data;
+    await context.authInfo.organization.updateOrganization({ organizationId, changes: { autoAssignQueueLimit } });
   });
 
 export const updateOrganizationScenariosFn = createServerFn({ method: 'POST' })

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -458,10 +458,9 @@ export const createUserFn = createServerFn({ method: 'POST' })
         organization_id: data.organizationId,
       });
     } catch (error) {
-      await setToast({
-        type: 'error',
-        messageKey: isStatusConflictHttpError(error) ? 'common:errors.list.duplicate_email' : 'common:errors.unknown',
-      });
+      if (isStatusConflictHttpError(error)) {
+        return { error: 'duplicate_email' as const };
+      }
       throw new Error('Failed to create user');
     }
   });
@@ -481,18 +480,13 @@ export const updateUserFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(updateUserPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.apiClient.updateUser(data.userId, {
-        first_name: data.firstName,
-        last_name: data.lastName,
-        email: data.email,
-        role: data.role,
-        organization_id: data.organizationId,
-      });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to update user');
-    }
+    await context.authInfo.apiClient.updateUser(data.userId, {
+      first_name: data.firstName,
+      last_name: data.lastName,
+      email: data.email,
+      role: data.role,
+      organization_id: data.organizationId,
+    });
   });
 
 // ---- Webhooks ----

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -206,11 +206,8 @@ export const createInboxFn = createServerFn({ method: 'POST' })
       if (data.redirectRoute) {
         throw redirect({ to: data.redirectRoute, params: { inboxId: fromUUIDtoSUUID(createdInbox.id) } });
       }
-
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to create inbox');
     }
   });
@@ -240,7 +237,6 @@ export const updateInboxFn = createServerFn({ method: 'POST' })
       throw redirect({ to: data.redirectRoute, params: { inboxId: fromUUIDtoSUUID(updatedInbox.id) } });
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to update inbox');
     }
   });
@@ -257,7 +253,6 @@ export const createInboxUserFn = createServerFn({ method: 'POST' })
       });
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to create inbox user');
     }
   });
@@ -297,7 +292,6 @@ export const updateInboxUserFn = createServerFn({ method: 'POST' })
       });
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to update inbox user');
     }
   });

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -62,7 +62,6 @@ export const createApiKeyFn = createServerFn({ method: 'POST' })
       throw redirect({ to: '/settings/api-keys' });
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to create API key');
     }
   });
@@ -423,13 +422,7 @@ export const createTagFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(createTagPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.apiClient.createTag(data);
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to create tag');
-    }
+    await context.authInfo.apiClient.createTag(data);
   });
 
 export const deleteTagFn = createServerFn({ method: 'POST' })
@@ -447,13 +440,7 @@ export const updateTagFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(updateTagPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.apiClient.updateTag(data.id, data);
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to update tag');
-    }
+    await context.authInfo.apiClient.updateTag(data.id, data);
   });
 
 // ---- Users ----

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -44,7 +44,7 @@ import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { Dict } from '@swan-io/boxed';
 import { redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
-import { getRequest } from '@tanstack/react-start/server';
+
 import { pick } from 'radash';
 import * as R from 'remeda';
 import { Temporal } from 'temporal-polyfill';
@@ -309,18 +309,15 @@ export const updateAllowedNetworksFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(updateAllowedNetworksPayloadSchema.and(z.object({ organizationId: z.string() })))
   .handler(async ({ context, data }) => {
-    const t = await context.services.i18nextService.getFixedT(getRequest(), ['settings']);
-
     try {
       const subnets = await context.authInfo.organization.updateAllowedNetworks(
         data.organizationId,
         data.allowedNetworks,
       );
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
       return { subnets };
     } catch (error) {
       if (isHttpError(error) && error.status === UNPROCESSABLE_ENTITY) {
-        await setToast({ type: 'error', message: t('settings:ip_whitelisting.errors.ip_not_in_range') });
+        return { error: 'ip_not_in_range' as const };
       }
       throw new Error('Failed to update allowed networks');
     }
@@ -344,20 +341,14 @@ export const updateOrganizationScenariosFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(updateOrganizationScenariosPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.organization.updateOrganization({
-        organizationId: data.organizationId,
-        changes: {
-          defaultScenarioTimezone: data.defaultScenarioTimezone,
-          sanctionThreshold: data.sanctionThreshold,
-          sanctionLimit: data.sanctionLimit,
-        },
-      });
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to update organization scenarios');
-    }
+    await context.authInfo.organization.updateOrganization({
+      organizationId: data.organizationId,
+      changes: {
+        defaultScenarioTimezone: data.defaultScenarioTimezone,
+        sanctionThreshold: data.sanctionThreshold,
+        sanctionLimit: data.sanctionLimit,
+      },
+    });
   });
 
 export const updateDataDisplayFn = createServerFn({ method: 'POST' })

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -37,7 +37,7 @@ import {
   updateWebhookPayloadSchema,
 } from '@app-builder/schemas/settings';
 import { useAuthSession } from '@app-builder/services/auth/auth-session.server';
-import { setToast } from '@app-builder/services/toast.server';
+
 import { UNPROCESSABLE_ENTITY } from '@app-builder/utils/http/http-status-codes';
 import { protectArray } from '@app-builder/utils/schema/helpers/array';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
@@ -149,7 +149,6 @@ export const deleteExportedFieldFn = createServerFn({ method: 'POST' })
 
       throw new Error('Invalid payload');
     } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to delete exported field');
     }
   });
@@ -189,7 +188,6 @@ export const updateExportedFieldFn = createServerFn({ method: 'POST' })
 
       throw new Error('Invalid payload');
     } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to update exported field');
     }
   });
@@ -350,20 +348,14 @@ export const updateDataDisplayFn = createServerFn({ method: 'POST' })
     ),
   )
   .handler(async ({ context, data }) => {
-    try {
-      await Promise.all(
-        Dict.entries(data).map(([tableId, body]) =>
-          context.authInfo.dataModelRepository.setDataModelTableOptions(tableId, {
-            ...body,
-            displayedFields: body.displayedFields ?? [],
-          }),
-        ),
-      );
-      await setToast({ type: 'success', messageKey: 'common:success.save' });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to update data display');
-    }
+    await Promise.all(
+      Dict.entries(data).map(([tableId, body]) =>
+        context.authInfo.dataModelRepository.setDataModelTableOptions(tableId, {
+          ...body,
+          displayedFields: body.displayedFields ?? [],
+        }),
+      ),
+    );
   });
 
 // ---- Personal Settings ----
@@ -494,7 +486,6 @@ export const createWebhookFn = createServerFn({ method: 'POST' })
       throw redirect({ to: '/settings/webhooks/$webhookId', params: { webhookId: webhook.id } });
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
       throw new Error('Failed to create webhook');
     }
   });
@@ -503,15 +494,10 @@ export const createWebhookSecretFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(createWebhookSecretPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.webhookRepository.createWebhookSecret({
-        webhookId: data.webhookId,
-        createSecretBody: { expireExistingInDays: data.expireExistingInDays },
-      });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to create webhook secret');
-    }
+    await context.authInfo.webhookRepository.createWebhookSecret({
+      webhookId: data.webhookId,
+      createSecretBody: { expireExistingInDays: data.expireExistingInDays },
+    });
   });
 
 export const deleteWebhookFn = createServerFn({ method: 'POST' })
@@ -531,28 +517,18 @@ export const revokeWebhookSecretFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(revokeWebhookSecretPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.webhookRepository.revokeWebhookSecret({
-        webhookId: data.webhookId,
-        secretId: data.secretId,
-      });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to revoke webhook secret');
-    }
+    await context.authInfo.webhookRepository.revokeWebhookSecret({
+      webhookId: data.webhookId,
+      secretId: data.secretId,
+    });
   });
 
 export const updateWebhookFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(updateWebhookPayloadSchema)
   .handler(async ({ context, data }) => {
-    try {
-      await context.authInfo.webhookRepository.updateWebhook({
-        webhookId: data.id,
-        webhookUpdateBody: data,
-      });
-    } catch {
-      await setToast({ type: 'error', messageKey: 'common:errors.unknown' });
-      throw new Error('Failed to update webhook');
-    }
+    await context.authInfo.webhookRepository.updateWebhook({
+      webhookId: data.id,
+      webhookUpdateBody: data,
+    });
   });


### PR DESCRIPTION
## Summary

After the Remix → TanStack Start migration, server-side setToast() + revalidate() no longer reliably displays toasts. On error paths, the server function throws after setting the toast, so revalidate() is never called and the toast sits in the session cookie until the next page load.

  This PR fully migrates server-fns/settings.ts to client-side toasts using react-hot-toast (already used elsewhere in the codebase), plus createListFn and enrichMatchFn as cross-domain exemplars. The setToast import has been completely removed from settings.ts.

  Migration pattern: remove setToast from server functions, show toasts directly on the client in .then()/.catch(). For conditional errors (e.g. 409 conflict), the server function returns { error: 'key' } instead of throwing.

  Remaining server-fn files (cases.ts, scenarios.ts, data.ts, screenings.ts, continuous-screening.ts, scoring.ts, client-360.ts, user.ts) still use setToast and will be migrated in follow-up PRs. Migration plan in dev/active/migrate-toast/.

  Test plan

  - Settings > Audit logs: verify filters apply correctly when selecting user/API key/date range
  - Settings > Organization: save auto-assign queue limit → toast appears immediately on success and error
  - Settings > IP whitelisting: save valid IPs → success toast; save invalid IP → specific error toast
  - Settings > Scenario settings: save → success toast; trigger error → error toast
  - Settings > Tags: create/update → success toast; error → error toast
  - Settings > Users: create duplicate email → specific error toast; update → success toast
  - Settings > Inboxes: create/update → success toast on success, error toast on failure
  - Settings > Webhooks: create/update/revoke secret → error toast on failure
  - Settings > Data display: save field ordering → success toast
  - Settings > Analytics filters: create/delete filter → error toast on failure
  - Detection > Lists: create list with duplicate name → error toast
  - Screenings: enrich match → success toast; already enriched → specific error toast

This was (if I'm correct) 19 actions out of 76 that have this pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added success notifications when operations complete (creating/updating lists, users, inboxes, tags, webhooks, API keys, and other settings).

* **Bug Fixes**
  * Improved error handling across form submissions with user-facing error messages for failed operations.
  * Enhanced feedback for duplicate entries and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->