### PR TITLE
fix screening case view topics not wrap if too long

### DIFF
--- a/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ScreeningCaseDetailPage.tsx
+++ b/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ScreeningCaseDetailPage.tsx
@@ -147,7 +147,7 @@ const IndirectScreeningRequestDetail = ({ screening }: { screening: ContinuousSc
             {t('continuousScreening:review.entity_details.view_all')}
           </Button>
         </div>
-        <div className="flex items-center gap-v2-sm">
+        <div className="flex flex-wrap items-center gap-v2-sm">
           {screening.opensanctionEntityPayload.properties['topics']?.map((topic) => {
             return <TopicTag key={topic} topic={topic} className="text-small" />;
           })}


### PR DESCRIPTION
This pull request makes a small UI improvement to the `ScreeningCaseDetailPage` component by ensuring that the list of topic tags wraps to a new line if there are too many to fit in a single row.

* Updated the container for topic tags in `ScreeningCaseDetailPage.tsx` to use `flex-wrap`, improving the display of tags when there are many topics.

BEFORE: 
<img width="511" height="972" alt="Capture d’écran 2026-04-21 à 15 49 18" src="https://github.com/user-attachments/assets/5711e977-44d5-4344-bc6c-bdba21d3fa14" />

AFTER:
<img width="541" height="849" alt="Capture d’écran 2026-04-21 à 15 49 30" src="https://github.com/user-attachments/assets/9605c5d5-8629-43e3-8d7b-f5f9a12b8d35" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Topic tags now wrap onto multiple lines for improved visibility when multiple tags are displayed together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->