### PR TITLE
reintegrate object name & tags actions into the header bar, but remov…

### DIFF
--- a/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
@@ -1,4 +1,4 @@
-import { BreadCrumbs } from '@app-builder/components/Breadcrumbs';
+import { BackButton } from '@app-builder/components/Breadcrumbs';
 import { Page } from '@app-builder/components/Page';
 import { DataModelObject } from '@app-builder/models';
 import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS, type ScoringSettings } from '@app-builder/models/scoring';
@@ -78,18 +78,18 @@ export const ClientDetailPage = ({
   return (
     <DataModelExplorerProvider>
       <Page.Main>
-        <Page.Header>
-          <BreadCrumbs back="/client-detail" />
+        <Page.Header className="border-b-0 bg-transparent gap-4">
+          <BackButton back="/client-detail" />
+          <TitleBar
+            objectType={objectType}
+            objectId={objectId}
+            objectDetails={objectDetails}
+            annotationsQuery={annotationsQuery}
+            metadata={metadata}
+          />
         </Page.Header>
         <Page.Container ref={containerRef}>
           <Page.ContentV2 className="gap-v2-lg">
-            <TitleBar
-              objectType={objectType}
-              objectId={objectId}
-              objectDetails={objectDetails}
-              annotationsQuery={annotationsQuery}
-              metadata={metadata}
-            />
             {/* Client details */}
             <div className="flex gap-v2-md">
               {/* Score card */}

--- a/packages/app-builder/src/components/ClientDetail/TitleBar.tsx
+++ b/packages/app-builder/src/components/ClientDetail/TitleBar.tsx
@@ -28,13 +28,12 @@ export const TitleBar = ({ objectType, objectId, objectDetails, annotationsQuery
   const entityName = metadata.alias || metadata.name;
 
   return (
-    <div className="flex gap-v2-md items-center">
-      <div className="flex gap-v2-xs items-center">
-        <h1 className="text-h1 font-semibold capitalize">{objectDetails.data[metadata.caption_field] as string}</h1>
+    <div className="flex gap-v2-md items-center min-w-0">
+      <div className="flex gap-v2-xs items-center shrink-0">
+        <h1 className="text-l font-bold capitalize">{objectDetails.data[metadata.caption_field] as string}</h1>
         <Tag color="grey">{entityName}</Tag>
       </div>
-      <div className="w-px self-stretch bg-grey-border" />
-      <div className="flex gap-v2-xs items-center">
+      <div className="flex gap-v2-xs items-center font-normal">
         {match(annotationsQuery)
           .with({ isPending: true }, () => <Spinner className="size-4" />)
           .with({ isError: true }, () => (
@@ -55,16 +54,18 @@ export const TitleBar = ({ objectType, objectId, objectDetails, annotationsQuery
                     <ClientTagsList tagsIds={tagsAnnotations.map((annotation) => annotation.payload.tag_id)} />
                   </div>
                 ) : (
-                  <Trans
-                    t={t}
-                    i18nKey="client360:entity_tags.no_tag_present"
-                    components={{
-                      Entity: <Tag color="grey" />,
-                    }}
-                    values={{
-                      objectType: entityName,
-                    }}
-                  />
+                  <span className="font-normal text-s text-grey-secondary">
+                    <Trans
+                      t={t}
+                      i18nKey="client360:entity_tags.no_tag_present"
+                      components={{
+                        Entity: <Tag color="grey" />,
+                      }}
+                      values={{
+                        objectType: entityName,
+                      }}
+                    />
+                  </span>
                 )}
                 <MenuCommand.Menu persistOnSelect open={editTagsOpen} onOpenChange={setEditTagsOpen}>
                   <MenuCommand.Trigger>
@@ -90,7 +91,7 @@ export const TitleBar = ({ objectType, objectId, objectDetails, annotationsQuery
           .exhaustive()}
       </div>
       <div className="w-px self-stretch bg-grey-border" />
-      <div className="flex gap-v2-xs items-center">
+      <div className="flex gap-v2-xs items-center font-normal">
         {match(annotationsQuery)
           .with({ isPending: true }, () => <Spinner className="size-4" />)
           .with({ isError: true }, () => (
@@ -115,16 +116,18 @@ export const TitleBar = ({ objectType, objectId, objectDetails, annotationsQuery
                     ))}
                   </div>
                 ) : (
-                  <Trans
-                    t={t}
-                    i18nKey="client360:entity_tags.no_screening_tag_present"
-                    components={{
-                      Entity: <Tag color="grey" />,
-                    }}
-                    values={{
-                      objectType: entityName,
-                    }}
-                  />
+                  <span className="font-normal text-s text-grey-secondary">
+                    <Trans
+                      t={t}
+                      i18nKey="client360:entity_tags.no_screening_tag_present"
+                      components={{
+                        Entity: <Tag color="grey" />,
+                      }}
+                      values={{
+                        objectType: entityName,
+                      }}
+                    />
+                  </span>
                 )}
                 <MenuCommand.Menu
                   persistOnSelect


### PR DESCRIPTION
…e visual separation, in customer hub
As per [designs](https://www.figma.com/design/a9n93l5twcEpmthKw6cBz5/Marble---Wireframes?node-id=4017-37656&t=aJ3dITYUXgtiEWyl-4) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced breadcrumb navigation with a back button on client detail pages
  * Moved title bar into the page header and adjusted header layout classes

* **Style**
  * Adjusted title bar layout and typography (sizes and weights)
  * Standardized tag and annotation styling and spacing
  * Wrapped fallback texts with consistent styling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->