### PR TITLE
fix: keep general settings when creating new user scoring draft

### DIFF
--- a/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
@@ -66,10 +66,12 @@ export const ClientDetailPage = ({
 
   if (scoringSettings && activeScore) {
     scoreColor =
-      SCORING_LEVELS_COLORS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ?? 'inherit';
+      SCORING_LEVELS_COLORS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][Math.max(activeScore.risk_level - 1, 0)] ??
+      'inherit';
     scoreLabel = t(
-      SCORING_LEVELS_LABEL_KEYS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ??
-        activeScore.risk_level.toString(),
+      SCORING_LEVELS_LABEL_KEYS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][
+        Math.max(activeScore.risk_level - 1, 0)
+      ] ?? activeScore.risk_level.toString(),
     );
   }
 

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -35,8 +35,8 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
             return ((segEnd - segStart) / totalRange) * 100;
           });
           const markerPositions = thresholds.map((v) => ((v - minValue) / totalRange) * 100);
-          const segStart = currentLevel === 1 ? minValue : thresholds[currentLevel - 1]!;
-          const segEnd = currentLevel > thresholds.length ? maxValue : thresholds[currentLevel]!;
+          const segStart = currentLevel === 0 ? minValue : thresholds[currentLevel - 1]!;
+          const segEnd = currentLevel >= thresholds.length ? maxValue : thresholds[currentLevel]!;
           const markerPct = (((segStart + segEnd) / 2 - minValue) / totalRange) * 100;
           return { segmentWidths, markerPositions, markerPct };
         })()
@@ -97,9 +97,10 @@ export function ScoreDetailPanel({
   const thresholds = rulesetQuery.data?.ruleset.thresholds;
 
   const maxRiskLevel = scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6;
-  const scoreColor = SCORING_LEVELS_COLORS[maxRiskLevel][activeScore.risk_level] ?? 'inherit';
+  const scoreColor = SCORING_LEVELS_COLORS[maxRiskLevel][Math.max(activeScore.risk_level - 1, 0)] ?? 'inherit';
   const scoreLabel = t(
-    SCORING_LEVELS_LABEL_KEYS[maxRiskLevel][activeScore.risk_level] ?? activeScore.risk_level.toString(),
+    SCORING_LEVELS_LABEL_KEYS[maxRiskLevel][Math.max(activeScore.risk_level - 1, 0)] ??
+      activeScore.risk_level.toString(),
   );
 
   return (
@@ -132,7 +133,11 @@ export function ScoreDetailPanel({
             <span className="text-s font-medium text-grey-primary">
               {t('client360:client_detail.score_panel.score_scale')}
             </span>
-            <ScoreScale maxRiskLevel={maxRiskLevel} currentLevel={activeScore.risk_level} thresholds={thresholds} />
+            <ScoreScale
+              maxRiskLevel={maxRiskLevel}
+              currentLevel={Math.max(activeScore.risk_level - 1, 0)}
+              thresholds={thresholds}
+            />
           </div>
         </PanelContent>
       </PanelContainer>

--- a/packages/app-builder/src/components/UserScoring/RulesTable.tsx
+++ b/packages/app-builder/src/components/UserScoring/RulesTable.tsx
@@ -154,6 +154,7 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
         name: ruleset.name,
         thresholds: ruleset.thresholds,
         cooldownSeconds: ruleset.cooldownSeconds,
+        scoringIntervalSeconds: ruleset.scoringIntervalSeconds,
         rules: ruleset.rules.map((r) =>
           r.stableId === stableId
             ? {
@@ -178,6 +179,7 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
         name: ruleset.name,
         thresholds: ruleset.thresholds,
         cooldownSeconds: ruleset.cooldownSeconds,
+        scoringIntervalSeconds: ruleset.scoringIntervalSeconds,
         rules: [
           ...ruleset.rules.map((r) => ({
             stableId: r.stableId,
@@ -210,6 +212,7 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
         name: ruleset.name,
         thresholds: ruleset.thresholds,
         cooldownSeconds: ruleset.cooldownSeconds,
+        scoringIntervalSeconds: ruleset.scoringIntervalSeconds,
         rules: ruleset.rules
           .filter((r) => r.stableId !== stableId)
           .map((r) => ({

--- a/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
@@ -102,9 +102,9 @@ function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; se
             .filter((item) => item.count > 0)
             .map((item) => ({
               id: item.risk_level,
-              label: t(labelKeys[item.risk_level] ?? item.risk_level.toString()),
+              label: t(labelKeys[Math.max(item.risk_level - 1, 0)] ?? item.risk_level.toString()),
               value: item.count,
-              color: colors[item.risk_level] ?? '#ccc',
+              color: colors[Math.max(item.risk_level - 1, 0)] ?? '#ccc',
             }));
 
           return (


### PR DESCRIPTION
## Summary

  - Fix general settings (scoringIntervalSeconds) being reset when adding, editing, or deleting a rule — the POST to /scoring/rulesets/{recordType} replaces the full draft, and scoringIntervalSeconds was missing from the payload in
  RulesTable.tsx
  - Fix risk level display off-by-one: the API returns 1-based risk_level but the frontend color/label arrays are 0-indexed. Applied risk_level - 1 in ClientDetailPage, ScoreDetailPanel, and ScoringOverviewPage

See also https://linear.app/marble-eu/issue/MAR-1808/after-initial-scoring-wrong-risk-level