### PR TITLE
Pascal/last improvements score display

### DIFF
--- a/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
@@ -66,12 +66,10 @@ export const ClientDetailPage = ({
 
   if (scoringSettings && activeScore) {
     scoreColor =
-      SCORING_LEVELS_COLORS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][Math.max(activeScore.risk_level - 1, 0)] ??
-      'inherit';
+      SCORING_LEVELS_COLORS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ?? 'inherit';
     scoreLabel = t(
-      SCORING_LEVELS_LABEL_KEYS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][
-        Math.max(activeScore.risk_level - 1, 0)
-      ] ?? activeScore.risk_level.toString(),
+      SCORING_LEVELS_LABEL_KEYS[scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6][activeScore.risk_level] ??
+        activeScore.risk_level.toString(),
     );
   }
 

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -40,7 +40,25 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
           const segStart = currentLevel === 0 ? minValue : thresholds[currentLevel - 1]!;
           const segEnd = currentLevel >= thresholds.length ? maxValue : thresholds[currentLevel]!;
           const markerPct = (((segStart + segEnd) / 2 - minValue) / totalRange) * 100;
-          return { segmentWidths, markerPositions, markerPct, showZeroLabel, zeroLabelPct };
+
+          // Build all labels (0 + thresholds) sorted by position, then stagger when too close
+          const allLabels: Array<{ value: string; pct: number; staggered: boolean }> = [];
+          if (showZeroLabel) {
+            allLabels.push({ value: '0', pct: zeroLabelPct, staggered: false });
+          }
+          for (let i = 0; i < thresholds.length; i++) {
+            allLabels.push({ value: String(thresholds[i]), pct: markerPositions[i]!, staggered: false });
+          }
+          allLabels.sort((a, b) => a.pct - b.pct);
+          const minGap = 8; // % of total bar width
+          for (let i = 1; i < allLabels.length; i++) {
+            if (allLabels[i]!.pct - allLabels[i - 1]!.pct < minGap) {
+              // Stagger if the previous wasn't already staggered; otherwise keep on the same row
+              allLabels[i]!.staggered = !allLabels[i - 1]!.staggered;
+            }
+          }
+
+          return { segmentWidths, markerPositions, markerPct, showZeroLabel, zeroLabelPct, allLabels };
         })()
       : undefined;
 
@@ -73,25 +91,21 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
         ) : null}
       </div>
       {proportional ? (
-        <div className="relative flex h-4 items-center mt-v2-xs">
-          {proportional.showZeroLabel ? (
+        <div
+          className="relative mt-v2-xs"
+          style={{ height: proportional.allLabels.some((l) => l.staggered) ? 32 : 16 }}
+        >
+          {proportional.allLabels.map((label) => (
             <div
+              key={label.value}
               className="absolute text-xs text-grey-secondary"
               style={{
-                left: `${proportional.zeroLabelPct}%`,
-                ...(proportional.zeroLabelPct > 0 && { transform: 'translateX(-50%)' }),
+                left: `${label.pct}%`,
+                top: label.staggered ? 16 : 0,
+                ...(label.pct > 0 && { transform: 'translateX(-50%)' }),
               }}
             >
-              0
-            </div>
-          ) : null}
-          {thresholds!.map((value, i) => (
-            <div
-              key={i}
-              className="absolute -translate-x-1/2 text-xs text-grey-secondary"
-              style={{ left: `${proportional.markerPositions[i]}%` }}
-            >
-              {value}
+              {label.value}
             </div>
           ))}
         </div>

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -26,9 +26,11 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
   const proportional =
     thresholds && thresholds.length === maxRiskLevel - 1
       ? (() => {
-          const minValue = thresholds[0]! >= 10 ? 0 : thresholds[0]! - 10;
+          const minValue = thresholds[0]! > 0 ? 0 : thresholds[0]! - 10;
           const maxValue = thresholds[thresholds.length - 1]! + 10;
           const totalRange = maxValue - minValue;
+          const showZeroLabel = thresholds[0]! !== 0;
+          const zeroLabelPct = ((0 - minValue) / totalRange) * 100;
           const segmentWidths = colors.map((_, i) => {
             const segStart = i === 0 ? minValue : thresholds[i - 1]!;
             const segEnd = i === thresholds.length ? maxValue : thresholds[i]!;
@@ -38,14 +40,14 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
           const segStart = currentLevel === 0 ? minValue : thresholds[currentLevel - 1]!;
           const segEnd = currentLevel >= thresholds.length ? maxValue : thresholds[currentLevel]!;
           const markerPct = (((segStart + segEnd) / 2 - minValue) / totalRange) * 100;
-          return { segmentWidths, markerPositions, markerPct };
+          return { segmentWidths, markerPositions, markerPct, showZeroLabel, zeroLabelPct };
         })()
       : undefined;
 
   return (
     <div className="flex flex-col gap-v2-xs">
       <div className="relative h-6">
-        <div className="flex w-full overflow-hidden rounded-lg gap-px mt-2">
+        <div className="relative flex w-full overflow-hidden rounded-lg gap-px mt-2">
           {colors.map((color, i) => (
             <div
               key={i}
@@ -56,6 +58,9 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
               }}
             />
           ))}
+          {proportional?.showZeroLabel ? (
+            <div className="absolute inset-y-0 w-px bg-white" style={{ left: `${proportional.zeroLabelPct}%` }} />
+          ) : null}
         </div>
         {proportional ? (
           <div
@@ -69,6 +74,17 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
       </div>
       {proportional ? (
         <div className="relative flex h-4 items-center mt-v2-xs">
+          {proportional.showZeroLabel ? (
+            <div
+              className="absolute text-xs text-grey-secondary"
+              style={{
+                left: `${proportional.zeroLabelPct}%`,
+                ...(proportional.zeroLabelPct > 0 && { transform: 'translateX(-50%)' }),
+              }}
+            >
+              0
+            </div>
+          ) : null}
           {thresholds!.map((value, i) => (
             <div
               key={i}

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -32,7 +32,7 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
   const proportional =
     thresholds && thresholds.length === maxRiskLevel - 1
       ? (() => {
-          const minValue = thresholds[0]! > 0 ? 0 : thresholds[0]! - 10;
+          const minValue = thresholds[0]! > 10 ? thresholds[0]! - 10 : 0;
           const maxValue = thresholds[thresholds.length - 1]! + 10;
           const totalRange = maxValue - minValue;
           const showZeroLabel = thresholds[0]! !== 0;
@@ -57,7 +57,7 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
             allLabels.push({ value: String(thresholds[i]), pct: markerPositions[i]!, staggered: false });
           }
           allLabels.sort((a, b) => a.pct - b.pct);
-          const minGap = 8; // % of total bar width
+          const minGap = 5; // % of total bar width
           for (let i = 1; i < allLabels.length; i++) {
             if (allLabels[i]!.pct - allLabels[i - 1]!.pct < minGap) {
               // Stagger if the previous wasn't already staggered; otherwise keep on the same row

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -1,4 +1,9 @@
-import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS, type ScoringSettings } from '@app-builder/models/scoring';
+import {
+  SCORING_LEVELS_COLORS,
+  SCORING_LEVELS_LABEL_KEYS,
+  type ScoringSettings,
+  scoringLevelEntries,
+} from '@app-builder/models/scoring';
 import { useGetScoringRulesetQuery } from '@app-builder/queries/scoring/get-ruleset';
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { type ScoringScore } from 'marble-api';
@@ -21,7 +26,8 @@ interface ScoreScaleProps {
 }
 
 function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps) {
-  const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
+  const colorMap = SCORING_LEVELS_COLORS[maxRiskLevel];
+  const colorEntries = scoringLevelEntries(colorMap);
 
   const proportional =
     thresholds && thresholds.length === maxRiskLevel - 1
@@ -31,14 +37,15 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
           const totalRange = maxValue - minValue;
           const showZeroLabel = thresholds[0]! !== 0;
           const zeroLabelPct = ((0 - minValue) / totalRange) * 100;
-          const segmentWidths = colors.map((_, i) => {
+          const segmentWidths = colorEntries.map((_, i) => {
             const segStart = i === 0 ? minValue : thresholds[i - 1]!;
             const segEnd = i === thresholds.length ? maxValue : thresholds[i]!;
             return ((segEnd - segStart) / totalRange) * 100;
           });
           const markerPositions = thresholds.map((v) => ((v - minValue) / totalRange) * 100);
-          const segStart = currentLevel === 0 ? minValue : thresholds[currentLevel - 1]!;
-          const segEnd = currentLevel >= thresholds.length ? maxValue : thresholds[currentLevel]!;
+          // currentLevel is 1-based
+          const segStart = currentLevel <= 1 ? minValue : thresholds[currentLevel - 2]!;
+          const segEnd = currentLevel > thresholds.length ? maxValue : thresholds[currentLevel - 1]!;
           const markerPct = (((segStart + segEnd) / 2 - minValue) / totalRange) * 100;
 
           // Build all labels (0 + thresholds) sorted by position, then stagger when too close
@@ -66,9 +73,9 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
     <div className="flex flex-col gap-v2-xs">
       <div className="relative h-6">
         <div className="relative flex w-full overflow-hidden rounded-lg gap-px mt-2">
-          {colors.map((color, i) => (
+          {colorEntries.map(([level, color], i) => (
             <div
-              key={i}
+              key={level}
               className="h-2"
               style={{
                 backgroundColor: color,
@@ -85,7 +92,7 @@ function ScoreScale({ maxRiskLevel, currentLevel, thresholds }: ScoreScaleProps)
             className="absolute top-1/2 size-6 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white shadow-sm"
             style={{
               left: `${proportional.markerPct}%`,
-              backgroundColor: colors[currentLevel],
+              backgroundColor: colorMap[currentLevel],
             }}
           />
         ) : null}
@@ -127,10 +134,9 @@ export function ScoreDetailPanel({
   const thresholds = rulesetQuery.data?.ruleset.thresholds;
 
   const maxRiskLevel = scoringSettings.maxRiskLevel as 3 | 4 | 5 | 6;
-  const scoreColor = SCORING_LEVELS_COLORS[maxRiskLevel][Math.max(activeScore.risk_level - 1, 0)] ?? 'inherit';
+  const scoreColor = SCORING_LEVELS_COLORS[maxRiskLevel][activeScore.risk_level] ?? 'inherit';
   const scoreLabel = t(
-    SCORING_LEVELS_LABEL_KEYS[maxRiskLevel][Math.max(activeScore.risk_level - 1, 0)] ??
-      activeScore.risk_level.toString(),
+    SCORING_LEVELS_LABEL_KEYS[maxRiskLevel][activeScore.risk_level] ?? activeScore.risk_level.toString(),
   );
 
   return (
@@ -163,11 +169,7 @@ export function ScoreDetailPanel({
             <span className="text-s font-medium text-grey-primary">
               {t('client360:client_detail.score_panel.score_scale')}
             </span>
-            <ScoreScale
-              maxRiskLevel={maxRiskLevel}
-              currentLevel={Math.max(activeScore.risk_level - 1, 0)}
-              thresholds={thresholds}
-            />
+            <ScoreScale maxRiskLevel={maxRiskLevel} currentLevel={activeScore.risk_level} thresholds={thresholds} />
           </div>
         </PanelContent>
       </PanelContainer>

--- a/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
+++ b/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
@@ -7,6 +7,7 @@ import {
   type ScoringRulesetWithRules,
   type ScoringSettings,
   SECONDS_PER_UNIT,
+  scoringLevelEntries,
   secondsToDisplay,
 } from '@app-builder/models/scoring';
 import { useCommitScoringRulesetMutation } from '@app-builder/queries/scoring/commit-ruleset';
@@ -273,20 +274,20 @@ function RiskLevelBadges({ maxRiskLevel, thresholds }: { maxRiskLevel: number; t
     return null;
   }
 
-  const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
+  const colorEntries = scoringLevelEntries(SCORING_LEVELS_COLORS[maxRiskLevel]);
   const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
   return (
     <div className="flex flex-col gap-v2-sm">
       <span className="text-s text-grey-secondary">{t('user-scoring:ruleset.risk_level')}</span>
       <div className="flex items-center gap-v2-sm">
-        {colors.map((color, i) => {
-          const isLast = i === maxRiskLevel - 1;
+        {colorEntries.map(([level, color], i) => {
+          const isLast = i === colorEntries.length - 1;
           return (
-            <Fragment key={color}>
+            <Fragment key={level}>
               <div className="flex items-center gap-v2-xs h-6 px-2 rounded-full border" style={{ borderColor: color }}>
                 <div className="size-3 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                <span className="text-xs text-grey-primary">{t(labelKeys[i] ?? '')}</span>
+                <span className="text-xs text-grey-primary">{t(labelKeys[level] ?? '')}</span>
               </div>
               {!isLast ? (
                 <span className="text-xs font-medium text-grey-placeholder">{`≤ ${thresholds[i]} <`}</span>

--- a/packages/app-builder/src/components/UserScoring/ScoringLevelThresholds.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringLevelThresholds.tsx
@@ -1,4 +1,9 @@
-import { isMaxRiskLevelInRange, SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS } from '@app-builder/models/scoring';
+import {
+  isMaxRiskLevelInRange,
+  SCORING_LEVELS_COLORS,
+  SCORING_LEVELS_LABEL_KEYS,
+  scoringLevelEntries,
+} from '@app-builder/models/scoring';
 import { useTranslation } from 'react-i18next';
 import { Input, NumberInput } from 'ui-design-system';
 
@@ -14,7 +19,7 @@ export function ScoringLevelThresholds({ maxRiskLevel, thresholds, onThresholdsC
     return null;
   }
 
-  const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
+  const colorEntries = scoringLevelEntries(SCORING_LEVELS_COLORS[maxRiskLevel]);
   const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
   const handleChange = (index: number, value: number) => {
@@ -28,19 +33,19 @@ export function ScoringLevelThresholds({ maxRiskLevel, thresholds, onThresholdsC
       <span className="text-s font-medium text-grey-primary">{t('user-scoring:thresholds.title')}</span>
       <div className="bg-surface-card border border-grey-border rounded-v2-md p-v2-md flex flex-col gap-v2-md">
         <span className="text-s text-grey-primary">{t('user-scoring:thresholds.risk_levels')}</span>
-        {colors.map((color, i) => {
+        {colorEntries.map(([level, color], i) => {
           const isFirst = i === 0;
-          const isLast = i === maxRiskLevel - 1;
+          const isLast = i === colorEntries.length - 1;
           const upperThreshold = thresholds[i];
           const lowerBound = i > 0 ? (thresholds[i - 1] ?? 0) + 1 : undefined;
           const hasError = i > 0 && !isLast && (upperThreshold ?? 0) <= (thresholds[i - 1] ?? 0);
 
           return (
-            <div key={color} className="flex items-center gap-v2-sm">
+            <div key={level} className="flex items-center gap-v2-sm">
               {/* Level name display */}
               <div className="flex items-center gap-v2-xs h-10 w-[195px] shrink-0 border border-grey-border rounded-sm px-2">
                 <div className="size-4 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                <span className="text-s font-medium flex-1 min-w-0 truncate">{t(labelKeys[i] ?? '')}</span>
+                <span className="text-s font-medium flex-1 min-w-0 truncate">{t(labelKeys[level] ?? '')}</span>
               </div>
 
               {isFirst ? (

--- a/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringOverviewPage.tsx
@@ -102,9 +102,9 @@ function ScoringRulesetCard({ ruleset, settings }: { ruleset: ScoringRuleset; se
             .filter((item) => item.count > 0)
             .map((item) => ({
               id: item.risk_level,
-              label: t(labelKeys[Math.max(item.risk_level - 1, 0)] ?? item.risk_level.toString()),
+              label: t(labelKeys[item.risk_level] ?? item.risk_level.toString()),
               value: item.count,
-              color: colors[Math.max(item.risk_level - 1, 0)] ?? '#ccc',
+              color: colors[item.risk_level] ?? '#ccc',
             }));
 
           return (

--- a/packages/app-builder/src/components/UserScoring/ScoringSettings.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSettings.tsx
@@ -6,6 +6,7 @@ import {
   SCORING_LEVELS_COLORS,
   SCORING_LEVELS_LABEL_KEYS,
   type ScoringSettings as ScoringSettingsModel,
+  scoringLevelEntries,
 } from '@app-builder/models/scoring';
 import { useUpdateScoringSettingsMutation } from '@app-builder/queries/scoring/update-settings';
 import { useState } from 'react';
@@ -89,15 +90,15 @@ function ScoringLevels({ maxLevel, className }: { maxLevel: number; className?: 
     return null;
   }
 
-  const scoringColors = SCORING_LEVELS_COLORS[maxLevel];
-  const scoringLabelKeys = SCORING_LEVELS_LABEL_KEYS[maxLevel];
+  const colorEntries = scoringLevelEntries(SCORING_LEVELS_COLORS[maxLevel]);
+  const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxLevel];
 
   return (
     <div className={cn(className)}>
-      {scoringColors.map((color, i) => (
-        <div key={color} className="flex gap-v2-sm items-center">
+      {colorEntries.map(([level, color]) => (
+        <div key={level} className="flex gap-v2-sm items-center">
           <div className="size-4 rounded-full" style={{ backgroundColor: color }} />
-          <span>{t(scoringLabelKeys[i] ?? '')}</span>
+          <span>{t(labelKeys[level] ?? '')}</span>
         </div>
       ))}
     </div>

--- a/packages/app-builder/src/components/UserScoring/SwitchNode/shared.tsx
+++ b/packages/app-builder/src/components/UserScoring/SwitchNode/shared.tsx
@@ -7,6 +7,7 @@ import {
   isMaxRiskLevelInRange,
   SCORING_LEVELS_COLORS,
   type ScoreImpact,
+  scoringLevelEntries,
 } from '@app-builder/models/scoring';
 import { type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -44,7 +45,7 @@ interface SwitchCaseRowProps {
 export function SwitchCaseRow({ impact, children, maxRiskLevel }: SwitchCaseRowProps) {
   const { t } = useTranslation(['user-scoring']);
 
-  const colors = isMaxRiskLevelInRange(maxRiskLevel) ? SCORING_LEVELS_COLORS[maxRiskLevel] : [];
+  const colors = isMaxRiskLevelInRange(maxRiskLevel) ? SCORING_LEVELS_COLORS[maxRiskLevel] : {};
 
   return (
     <li className="flex items-center gap-v2-sm">
@@ -62,7 +63,7 @@ export function SwitchCaseRow({ impact, children, maxRiskLevel }: SwitchCaseRowP
               <span>{t('user-scoring:switch.and')}</span>
               <Tag color="grey" className="gap-v2-xs">
                 <span>{t('user-scoring:switch.floor_label')}</span>
-                <div className="rounded-full size-3" style={{ backgroundColor: colors?.[impact.floor] }} />
+                <div className="rounded-full size-3" style={{ backgroundColor: colors[impact.floor] }} />
               </Tag>
             </>
           ) : null}
@@ -93,17 +94,19 @@ interface RiskLevelSelectProps {
 export function RiskLevelSelect({ floor, maxRiskLevel, onChange }: RiskLevelSelectProps) {
   const { t } = useTranslation(['user-scoring']);
 
-  const levels = isMaxRiskLevelInRange(maxRiskLevel) ? SCORING_LEVELS_COLORS[maxRiskLevel] : [];
+  const levelEntries = isMaxRiskLevelInRange(maxRiskLevel)
+    ? scoringLevelEntries(SCORING_LEVELS_COLORS[maxRiskLevel])
+    : [];
   const options: SelectOption<number | null>[] = [
     { label: t('user-scoring:switch.add_floor'), value: null },
-    ...levels.map((color, i) => ({
+    ...levelEntries.map(([level, color]) => ({
       label: (
         <span className="flex gap-v2-xs items-center">
           <span>{t('user-scoring:switch.floor_label')} </span>
           <div className="size-4 rounded-full shrink-0" style={{ backgroundColor: color }}></div>
         </span>
       ),
-      value: i,
+      value: level,
     })),
   ];
 

--- a/packages/app-builder/src/models/scoring/display.ts
+++ b/packages/app-builder/src/models/scoring/display.ts
@@ -1,23 +1,41 @@
 export const MAX_RISK_LEVELS = [3, 4, 5, 6] as const;
 export type MaxRiskLevel = (typeof MAX_RISK_LEVELS)[number];
 
-export const SCORING_LEVELS_COLORS: Record<MaxRiskLevel, string[]> = {
-  3: ['#18AA5F', '#EEA200', '#FF6600'],
-  4: ['#18AA5F', '#EEA200', '#FF6600', '#D2371D'],
-  5: ['#89D4AD', '#FFD57E', '#FDBD35', '#FF6600', '#D2371D'],
-  6: ['#89D4AD', '#FFD57E', '#FDBD35', '#FF6600', '#DB5F4A', '#D2371D'],
+/**
+ * Colors and labels are keyed by 1-based risk level to match the backend.
+ * e.g. risk_level=1 → SCORING_LEVELS_COLORS[3][1] for a 3-level config.
+ */
+export type ScoringLevelMap = Record<number, string>;
+
+export const SCORING_LEVELS_COLORS: Record<MaxRiskLevel, ScoringLevelMap> = {
+  3: { 1: '#18AA5F', 2: '#EEA200', 3: '#FF6600' },
+  4: { 1: '#18AA5F', 2: '#EEA200', 3: '#FF6600', 4: '#D2371D' },
+  5: { 1: '#89D4AD', 2: '#FFD57E', 3: '#FDBD35', 4: '#FF6600', 5: '#D2371D' },
+  6: { 1: '#89D4AD', 2: '#FFD57E', 3: '#FDBD35', 4: '#FF6600', 5: '#DB5F4A', 6: '#D2371D' },
 };
 
 /**
  * i18n keys for levels 3 and 4 (e.g. 'user-scoring:level.low').
  * Levels 5 and 6 use plain number strings (not translated).
  */
-export const SCORING_LEVELS_LABEL_KEYS: Record<MaxRiskLevel, string[]> = {
-  3: ['user-scoring:level.low', 'user-scoring:level.medium', 'user-scoring:level.high'],
-  4: ['user-scoring:level.low', 'user-scoring:level.medium', 'user-scoring:level.high', 'user-scoring:level.very_high'],
-  5: ['1', '2', '3', '4', '5'],
-  6: ['1', '2', '3', '4', '5', '6'],
+export const SCORING_LEVELS_LABEL_KEYS: Record<MaxRiskLevel, ScoringLevelMap> = {
+  3: { 1: 'user-scoring:level.low', 2: 'user-scoring:level.medium', 3: 'user-scoring:level.high' },
+  4: {
+    1: 'user-scoring:level.low',
+    2: 'user-scoring:level.medium',
+    3: 'user-scoring:level.high',
+    4: 'user-scoring:level.very_high',
+  },
+  5: { 1: '1', 2: '2', 3: '3', 4: '4', 5: '5' },
+  6: { 1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6' },
 };
+
+/** Returns entries as [level, value] pairs from a ScoringLevelMap, sorted by level. */
+export function scoringLevelEntries(map: ScoringLevelMap): Array<[number, string]> {
+  return Object.entries(map)
+    .map(([k, v]) => [Number(k), v] as [number, string])
+    .sort((a, b) => a[0] - b[0]);
+}
 
 export function isMaxRiskLevelInRange(maxRiskLevel: number): maxRiskLevel is MaxRiskLevel {
   return (MAX_RISK_LEVELS as readonly number[]).includes(maxRiskLevel);


### PR DESCRIPTION
## Summary
- Some small improvements to the user scoring score display panel, specifically the score bar.
- Fix once and for all the off by one errors on risk level configuration (including floor configuration) by changing from an array-based lookup to map, with keys starting at 1

### Before

<img width="497" height="317" alt="Capture d’écran 2026-04-22 à 10 28 57" src="https://github.com/user-attachments/assets/93a13ab5-414b-49d8-934e-9e00ce12edd6" />
<img width="494" height="305" alt="Capture d’écran 2026-04-22 à 10 28 28" src="https://github.com/user-attachments/assets/c32edbf8-4472-47b9-86ca-1f4fb10bd1be" />


### After
<img width="498" height="330" alt="Capture d’écran 2026-04-22 à 10 29 12" src="https://github.com/user-attachments/assets/23cd3d15-c2fc-421e-90dd-91923c82c834" />
<img width="493" height="342" alt="Capture d’écran 2026-04-22 à 10 28 13" src="https://github.com/user-attachments/assets/1df716f4-ddd3-4691-8557-cdd36f9a61fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional zero reference marker and label added to score scales.

* **Refactor**
  * Score level mappings unified to use explicit level keys, producing more consistent colors and labels across cards, badges, legends and selects.
  * Label placement now staggers overlapping labels and adjusts layout height when needed.

* **Bug Fixes**
  * Proportional scale and marker calculations corrected for more accurate segment sizing and current-score highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->