### PR TITLE
fix decision page query filters

### DIFF
--- a/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
@@ -55,29 +55,28 @@ const emptyDecisionFilters: DecisionFiltersForm = {
   triggerObjectId: null,
 };
 
-function adaptFilterValues({ dateRange, ...otherFilters }: DecisionFilters): DecisionFiltersForm {
-  const adaptedFilterValues: DecisionFiltersForm = {
-    ...emptyDecisionFilters,
-    ...otherFilters,
-    scenarioId: otherFilters.scenarioId ?? [],
-    scheduledExecutionId: otherFilters.scheduledExecutionId ?? [],
-    caseInboxId: otherFilters.caseInboxId ?? [],
-    triggerObject: otherFilters.triggerObject ?? [],
-  };
-  if (dateRange?.type === 'static') {
-    adaptedFilterValues.dateRange = {
+function adaptFilterValues(filterValues: DecisionFilters): DecisionFiltersForm {
+  let dateRange: DateRangeFilterForm = null;
+  if (filterValues.dateRange?.type === 'static') {
+    dateRange = {
       type: 'static',
-      startDate: dateRange.startDate ?? '',
-      endDate: dateRange.endDate ?? '',
+      startDate: filterValues.dateRange.startDate ?? '',
+      endDate: filterValues.dateRange.endDate ?? '',
     };
+  } else if (filterValues.dateRange?.type === 'dynamic' && filterValues.dateRange.fromNow) {
+    dateRange = { type: 'dynamic', fromNow: filterValues.dateRange.fromNow };
   }
-  if (dateRange?.type === 'dynamic' && dateRange.fromNow) {
-    adaptedFilterValues.dateRange = {
-      type: 'dynamic',
-      fromNow: dateRange.fromNow,
-    };
-  }
-  return adaptedFilterValues;
+  return {
+    dateRange,
+    hasCase: filterValues.hasCase ?? null,
+    outcomeAndReviewStatus: filterValues.outcomeAndReviewStatus ?? null,
+    pivotValue: filterValues.pivotValue ?? null,
+    scenarioId: filterValues.scenarioId ?? [],
+    scheduledExecutionId: filterValues.scheduledExecutionId ?? [],
+    caseInboxId: filterValues.caseInboxId ?? [],
+    triggerObject: filterValues.triggerObject ?? [],
+    triggerObjectId: filterValues.triggerObjectId ?? null,
+  };
 }
 
 export function DecisionFiltersProvider({

--- a/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
+++ b/packages/app-builder/src/components/Decisions/Filters/DecisionFiltersContext.tsx
@@ -59,6 +59,10 @@ function adaptFilterValues({ dateRange, ...otherFilters }: DecisionFilters): Dec
   const adaptedFilterValues: DecisionFiltersForm = {
     ...emptyDecisionFilters,
     ...otherFilters,
+    scenarioId: otherFilters.scenarioId ?? [],
+    scheduledExecutionId: otherFilters.scheduledExecutionId ?? [],
+    caseInboxId: otherFilters.caseInboxId ?? [],
+    triggerObject: otherFilters.triggerObject ?? [],
   };
   if (dateRange?.type === 'static') {
     adaptedFilterValues.dateRange = {
@@ -108,6 +112,10 @@ export function DecisionFiltersProvider({
       hasCase: formValues.hasCase ?? undefined,
       pivotValue: formValues.pivotValue ?? undefined,
       triggerObjectId: formValues.triggerObjectId ?? undefined,
+      scenarioId: formValues.scenarioId?.length ? formValues.scenarioId : undefined,
+      scheduledExecutionId: formValues.scheduledExecutionId?.length ? formValues.scheduledExecutionId : undefined,
+      caseInboxId: formValues.caseInboxId?.length ? formValues.caseInboxId : undefined,
+      triggerObject: formValues.triggerObject?.length ? formValues.triggerObject : undefined,
     });
   });
   const onDecisionFilterClose = useCallbackRef(() => {

--- a/packages/app-builder/src/components/Decisions/PivotDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/PivotDetail.tsx
@@ -1,7 +1,6 @@
 import { Callout, decisionsI18n } from '@app-builder/components';
 import { type Pivot } from '@app-builder/models';
 import { type DataModelObject } from '@app-builder/models/data-model';
-import { DecisionFilters } from '@app-builder/schemas/decisions';
 import { getPivotDisplayValue } from '@app-builder/services/data/pivot';
 import { pivotValuesDocHref } from '@app-builder/services/documentation-href';
 import { Link } from '@tanstack/react-router';
@@ -122,7 +121,7 @@ function PivotList({ pivotValues }: Pick<PivotDetailProps, 'pivotValues'>) {
           size: 240,
           cell: ({ getValue }) => (
             <Tooltip.Default content={t('decisions:pivot_detail.pivot_value.tooltip')}>
-              <Link to={getDecisionRoute({ pivotValue: getValue().value })}>
+              <Link to="/detection/decisions" search={{ pivotValue: getValue().value }}>
                 <PivotDetails value={getValue().value} table={getValue().table} object={getValue().object} />
               </Link>
             </Tooltip.Default>
@@ -151,11 +150,6 @@ function PivotList({ pivotValues }: Pick<PivotDetailProps, 'pivotValues'>) {
       </Table.Body>
     </Table.Container>
   );
-}
-
-function getDecisionRoute(decisionFilters: Pick<DecisionFilters, 'pivotValue'>) {
-  const searchParams = new URLSearchParams(decisionFilters);
-  return `/detection/decisions?${searchParams.toString()}`;
 }
 
 function PivotDetails({ value, table, object }: { value: string; table: string; object: DataModelObject | null }) {

--- a/packages/app-builder/src/models/feature-access.ts
+++ b/packages/app-builder/src/models/feature-access.ts
@@ -51,7 +51,6 @@ export function adaptFeatureAccesses(dto: FeatureAccessDto): FeatureAccesses {
     caseAiAssist: dto.case_ai_assist,
     continuousScreening: dto.continuous_screening,
     aiRuleBuilding: dto.ai_rule_building,
-    // TODO: restore to the commented code after the release, once the updated license server is rolled out.
-    userScoring: 'allowed', // dto.user_scoring,
+    userScoring: dto.user_scoring,
   };
 }


### PR DESCRIPTION
## Fix array filters broken on decisions page (MAR-1824)

  After the Remix → TanStack Router migration, filters on scenario, trigger object, scheduled execution, and inbox all failed with ARRAY_MAX_LENGTH.

##  Root cause
Two issues compounded:

  1. adaptFilterValues spread otherFilters (from getDecisionFilters) over emptyDecisionFilters. Because getDecisionFilters explicitly sets all fields in its return object — including absent ones as undefined — the spread overrode the []
  defaults with undefined. So after any navigation that didn't include an array filter in the URL, the form would initialize those fields as undefined instead of [].
  2. With selectedValue={undefined}, SelectWithCombobox called onSelectedValueChange with a plain string (the clicked item) rather than a string[]. That string went into the form, was passed unencoded to navigate (stringifyValue passes raw
  strings through), producing ?scenarioId=<uuid> in the URL. TanStack Router's parseSearch couldn't JSON-parse a bare UUID, left it as a string, and validateSearch failed — the page never reached the loader.

  Fix: Replace the spread-based adaptFilterValues with explicit field mapping using ?? [] / ?? null defaults. Each field's default is now stated directly, making the bug class impossible and the intent obvious. emptyDecisionFilters is kept for
  the form type inference helper and useClearFilter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter form handling to ensure proper normalization of empty filter selections and date range configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->