### PR TITLE
Display LN entity notes in a readable way

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/updateTable-adapter.ts
@@ -39,7 +39,6 @@ export function adaptUpdateTableValue(
       return stillUsed ? [] : [link];
     });
 
-  console.log('tableState', { entityType: tableState.entityType, subEntity: tableState.subEntity });
   const adaptedTable: EditSemanticTablePayload = {
     tableId: tableState.tableId,
     ...(changedProperties.includes('alias') ? { alias: tableState.alias || tableState.name } : {}),

--- a/packages/app-builder/src/components/Screenings/EntityProperties.tsx
+++ b/packages/app-builder/src/components/Screenings/EntityProperties.tsx
@@ -87,7 +87,7 @@ export function EntityProperties<T extends OpenSanctionEntity>({
                         }}
                         className="text-purple-primary font-semibold cursor-pointer hover:text-purple-hover"
                       >
-                        + {restItemsCount} more
+                        {t('common:more_remains', { count: restItemsCount })}
                       </button>
                     </>
                   ) : null}

--- a/packages/app-builder/src/components/Screenings/EntityProperties.tsx
+++ b/packages/app-builder/src/components/Screenings/EntityProperties.tsx
@@ -68,7 +68,7 @@ export function EntityProperties<T extends OpenSanctionEntity>({
                 defaultValue: property,
               })}
             </span>
-            <span className="break-all">
+            <span className="break-words">
               {values.length > 0 ? (
                 <>
                   {values.map((v, i) => (

--- a/packages/app-builder/src/components/Screenings/HighlightText.tsx
+++ b/packages/app-builder/src/components/Screenings/HighlightText.tsx
@@ -13,12 +13,12 @@ interface HighlightTextProps {
  * - "Vladimir Putin" highlights "Vladimir", "Putin", or "Vladimir Putin"
  */
 export function HighlightText({ text, highlight, className }: HighlightTextProps): ReactNode {
-  if (!text) return null;
   const isMatch = useMemo(() => {
     if (!highlight || highlight.length === 0) {
       return false;
     }
 
+    if (!text) return null;
     const textLower = text.toLowerCase();
     const highlightLower = highlight.toLowerCase();
 

--- a/packages/app-builder/src/components/Screenings/HighlightText.tsx
+++ b/packages/app-builder/src/components/Screenings/HighlightText.tsx
@@ -13,6 +13,7 @@ interface HighlightTextProps {
  * - "Vladimir Putin" highlights "Vladimir", "Putin", or "Vladimir Putin"
  */
 export function HighlightText({ text, highlight, className }: HighlightTextProps): ReactNode {
+  if (!text) return null;
   const isMatch = useMemo(() => {
     if (!highlight || highlight.length === 0) {
       return false;

--- a/packages/app-builder/src/components/Screenings/MatchCard/MatchCard.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/MatchCard.tsx
@@ -3,7 +3,7 @@ import { type ScreeningMatch } from '@app-builder/models/screening';
 import { type ScreeningAiSuggestion } from '@app-builder/models/screening-ai-suggestion';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CollapsibleV2, Tag } from 'ui-design-system';
+import { Collapsible, Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { MatchDetails } from '../MatchDetails';
 import { ReviewMatchPopover } from '../ReviewMatchPopover';
@@ -39,79 +39,69 @@ export const MatchCard = ({
   const canReview = match.status === 'pending' && !readonly && !unreviewable;
 
   return (
-    <div className="grid grid-cols-[max-content_1fr_max-content] gap-x-6 gap-y-2">
-      <CollapsibleV2.Provider defaultOpen={defaultOpen}>
-        <div className="border-grey-border col-span-full grid grid-cols-subgrid rounded-lg border">
-          <div className="col-span-full flex flex-col gap-2 p-4">
-            <div className="flex items-center justify-between gap-2">
-              <CollapsibleV2.Title className="focus-visible:text-purple-primary group flex grow items-center gap-2 rounded-sm outline-hidden transition-colors">
-                <Icon
-                  icon="smallarrow-up"
-                  aria-hidden
-                  className="size-4 rotate-90 transition-transform duration-200 group-aria-expanded:rotate-180 group-data-initial:rotate-180 rtl:-rotate-90 group-aria-expanded:rtl:-rotate-180 group-data-initial:rtl:-rotate-180"
-                />
-                <span className="text-s font-medium">{entity.caption}</span>
-                {aiSuggestion && match.status === 'pending' ? (
-                  <Tag color="grey">
-                    {t(`screenings:match.ai_suggestion.${aiSuggestion.confidence}`)}
-                    <Icon icon="wand" className="size-4" />
-                  </Tag>
-                ) : null}
-                <Tag color="grey">
-                  {t('screenings:match.similarity', {
-                    percent: Math.round(entity.score * 100),
-                  })}
-                </Tag>
-              </CollapsibleV2.Title>
-              {!hideEnrich && !match.enriched ? <EnrichMatchButton matchId={match.id} /> : null}
-              {!hideReview ? (
-                <div className="inline-flex h-8 shrink-0 text-nowrap">
-                  {unreviewable ? (
-                    <Tag color="grey">{t('screenings:match.not_reviewable')}</Tag>
-                  ) : canReview ? (
-                    <ReviewMatchPopover screeningMatch={match} open={isPopoverOpen} onOpenChange={setIsPopoverOpen} />
-                  ) : (
-                    <StatusTag status={match.status} disabled />
-                  )}
-                </div>
-              ) : null}
-            </div>
-            {entity.properties['topics']?.length ? (
-              <div className="flex flex-wrap gap-1 ps-6">
-                {entity.properties['topics'].map((topic) => (
-                  <TopicTag key={`${match.id}-${topic}`} topic={topic} />
-                ))}
+    <Collapsible.Container defaultOpen={defaultOpen}>
+      <Collapsible.Title size="small">
+        <div className="flex grow items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-s font-medium">{entity.caption}</span>
+            {aiSuggestion && match.status === 'pending' ? (
+              <Tag color="grey">
+                {t(`screenings:match.ai_suggestion.${aiSuggestion.confidence}`)}
+                <Icon icon="wand" className="size-4" />
+              </Tag>
+            ) : null}
+            <Tag color="grey">
+              {t('screenings:match.similarity', {
+                percent: Math.round(entity.score * 100),
+              })}
+            </Tag>
+          </div>
+          <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            {!hideEnrich && !match.enriched ? <EnrichMatchButton matchId={match.id} /> : null}
+            {!hideReview ? (
+              <div className="inline-flex h-8 shrink-0 text-nowrap">
+                {unreviewable ? (
+                  <Tag color="grey">{t('screenings:match.not_reviewable')}</Tag>
+                ) : canReview ? (
+                  <ReviewMatchPopover screeningMatch={match} open={isPopoverOpen} onOpenChange={setIsPopoverOpen} />
+                ) : (
+                  <StatusTag status={match.status} disabled />
+                )}
               </div>
             ) : null}
           </div>
-
-          <CollapsibleV2.Content className="col-span-full">
-            <div className="mx-4 mb-4">
-              <div className="bg-grey-background-light border-grey-border text-s flex flex-col gap-2 rounded-lg border p-2">
-                {entitySchema === 'person' && entity.datasets?.length ? (
-                  <div className="grid grid-cols-[146px_1fr] gap-3">
-                    <div className="text-xs opacity-50">{t('screenings:match.datasets.title')}</div>
-                    <div>
-                      <ul className="list-disc ps-4">
-                        {entity?.datasets?.map((name, index) => (
-                          <li className="break-all text-xs" key={`dataset-${index}`}>
-                            {name}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </div>
-                ) : null}
-
-                {match.comments.map((comment) => {
-                  return <CommentLine key={comment.id} comment={comment} />;
-                })}
-                <MatchDetails entity={entity} />
+        </div>
+      </Collapsible.Title>
+      {entity.properties['topics']?.length ? (
+        <div className="flex flex-wrap gap-1 px-4 pb-3">
+          {entity.properties['topics'].map((topic) => (
+            <TopicTag key={`${match.id}-${topic}`} topic={topic} />
+          ))}
+        </div>
+      ) : null}
+      <Collapsible.Content>
+        <div className="bg-grey-background-light border-grey-border flex flex-col gap-2 rounded-lg border p-2">
+          {entitySchema === 'person' && entity.datasets?.length ? (
+            <div className="grid grid-cols-[146px_1fr] gap-3">
+              <div className="text-xs opacity-50">{t('screenings:match.datasets.title')}</div>
+              <div>
+                <ul className="list-disc ps-4">
+                  {entity?.datasets?.map((name, index) => (
+                    <li className="break-all text-xs" key={`dataset-${index}`}>
+                      {name}
+                    </li>
+                  ))}
+                </ul>
               </div>
             </div>
-          </CollapsibleV2.Content>
+          ) : null}
+
+          {match.comments.map((comment) => {
+            return <CommentLine key={comment.id} comment={comment} />;
+          })}
+          <MatchDetails entity={entity} />
         </div>
-      </CollapsibleV2.Provider>
-    </div>
+      </Collapsible.Content>
+    </Collapsible.Container>
   );
 };

--- a/packages/app-builder/src/constants/screening-entity.tsx
+++ b/packages/app-builder/src/constants/screening-entity.tsx
@@ -241,12 +241,12 @@ export function createPropertyTransformer(ctx: { language: string; formatLanguag
       case 'string':
         return value.includes('\n') ? (
           value.split('\n').map((v, index) => (
-            <p key={`chunk-${index}`} className="break-words">
+            <p key={`chunk-${index}`}>
               <HighlightText text={v} highlight={ctx.highlightText} />
             </p>
           ))
         ) : (
-          <HighlightText text={value} highlight={ctx.highlightText} className="break-words" />
+          <HighlightText text={value} highlight={ctx.highlightText} />
         );
       case 'url':
         return <ExternalLink href={value}>{value}</ExternalLink>;

--- a/packages/app-builder/src/constants/screening-entity.tsx
+++ b/packages/app-builder/src/constants/screening-entity.tsx
@@ -241,12 +241,12 @@ export function createPropertyTransformer(ctx: { language: string; formatLanguag
       case 'string':
         return value.includes('\n') ? (
           value.split('\n').map((v, index) => (
-            <p key={`chunk-${index}`}>
+            <p key={`chunk-${index}`} className="break-words">
               <HighlightText text={v} highlight={ctx.highlightText} />
             </p>
           ))
         ) : (
-          <HighlightText text={value} highlight={ctx.highlightText} />
+          <HighlightText text={value} highlight={ctx.highlightText} className="break-words" />
         );
       case 'url':
         return <ExternalLink href={value}>{value}</ExternalLink>;

--- a/packages/app-builder/src/constants/screening-entity.tsx
+++ b/packages/app-builder/src/constants/screening-entity.tsx
@@ -239,7 +239,15 @@ export function createPropertyTransformer(ctx: { language: string; formatLanguag
     const dataType = propertyMetadata[property].type;
     switch (dataType) {
       case 'string':
-        return <HighlightText text={value} highlight={ctx.highlightText} />;
+        return value.includes('\n') ? (
+          value.split('\n').map((v, index) => (
+            <p key={`chunk-${index}`}>
+              <HighlightText text={v} highlight={ctx.highlightText} />
+            </p>
+          ))
+        ) : (
+          <HighlightText text={value} highlight={ctx.highlightText} />
+        );
       case 'url':
         return <ExternalLink href={value}>{value}</ExternalLink>;
       case 'country':


### PR DESCRIPTION
# Related to the MAR-1825

create chunks of text when it contains \n and generate `<p>` elements for each of them

<img width="1216" height="670" alt="Capture d’écran 2026-04-23 à 17 27 33" src="https://github.com/user-attachments/assets/132e403c-2bc1-4ee4-be67-d5917c2e6777" />


## additional change

updated deprecated collapsible component on this page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when highlighting empty or missing text
  * Improved multi-line property rendering so newline-separated text displays as separate paragraphs

* **Style**
  * Reworked match card header layout for clearer separation of title, topics, and action/status controls; click behavior refined to avoid unintended toggles

* **Chores**
  * Localized "show more" label for truncated values
  * Removed stray debug logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->