### PR TITLE
Display fields in the correct order in case manager

### DIFF
--- a/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
@@ -45,7 +45,7 @@ export function CaseDetailTriggerObject({
   onLinkClicked,
 }: {
   dataModel: TableModel[];
-  triggerObject: Record<string, unknown>;
+  triggerObject: Record<string, DataModelObjectValue>;
   triggerObjectType: string;
   className?: string;
   onLinkClicked: (tableName: string, objectId: string) => void;
@@ -66,26 +66,38 @@ export function CaseDetailTriggerObject({
         className,
       )}
     >
-      {parsedTriggerObject.map(([property, data]) => {
-        const fieldType = dataModelTable?.fields?.find((f) => f.name === property)?.dataType;
-        return (
-          <Fragment key={property}>
-            <span className="font-semibold">{property}</span>
-            <div className="inline-flex items-center gap-2">
-              {links[property] && !!data.value ? (
-                <button
-                  className="text-purple-primary group flex items-center gap-1 text-left"
-                  onClick={() => onLinkClicked(links[property] as string, data.value as string)}
-                >
+      {dataModelTable?.name ? (
+        <DataFields
+          // use the fancy display if possible
+          table={dataModelTable.name}
+          object={{
+            data: triggerObject,
+            metadata: { validFrom: (triggerObject['updated_at'] as string) ?? '' },
+          }}
+          options={{ hideLinks: true }}
+        />
+      ) : (
+        parsedTriggerObject.map(([property, data]) => {
+          const fieldType = dataModelTable?.fields?.find((f) => f.name === property)?.dataType;
+          return (
+            <Fragment key={property}>
+              <span className="font-semibold">{property}</span>
+              <div className="inline-flex items-center gap-2">
+                {links[property] && !!data.value ? (
+                  <button
+                    className="text-purple-primary group flex items-center gap-1 text-left"
+                    onClick={() => onLinkClicked(links[property] as string, data.value as string)}
+                  >
+                    <FormatData type={fieldType} data={data} mapHeight={200} />
+                  </button>
+                ) : (
                   <FormatData type={fieldType} data={data} mapHeight={200} />
-                </button>
-              ) : (
-                <FormatData type={fieldType} data={data} mapHeight={200} />
-              )}
-            </div>
-          </Fragment>
-        );
-      })}
+                )}
+              </div>
+            </Fragment>
+          );
+        })
+      )}
     </div>
   );
 }

--- a/packages/app-builder/src/models/data-model.ts
+++ b/packages/app-builder/src/models/data-model.ts
@@ -783,7 +783,8 @@ export function getTriggerObjectFields(
   const tableOptions = dataModelWithTableOptions.find(({ name }) => name === triggerObjectType);
 
   return R.pipe(
-    tableOptions?.options.fieldOrder ?? [],
+    // fields are already ordered
+    tableOptions?.fields.map((f) => f.id) ?? [],
     R.filter((id) =>
       tableOptions?.options.displayedFields ? tableOptions.options.displayedFields.includes(id) : true,
     ),


### PR DESCRIPTION
# What has been done

- the fields are already ordered in the new datamodel, ignore `options.fieldOrder` (deprecated)
- display the trigger object data in the new fancy way