### PR TITLE
Pascal/mar 1832 investigate slow e2e tests post tanstack migration

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,13 +35,23 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - run: bun run -F tests test:install
-      - name: Pre-pull test container images in parallel with build
+      - name: Cache app build output
+        id: cache-output
+        uses: actions/cache@v5
+        with:
+          path: packages/app-builder/.output
+          key: ${{ runner.os }}-output-${{ hashFiles('packages/*/src/**', 'packages/*/package.json', 'packages/app-builder/vite.config.ts', 'packages/app-builder/tsconfig.json', 'bun.lock') }}
+      - name: Pre-pull test container images (and build if cache miss)
         run: |
           docker pull postgis/postgis:17-3.6-alpine &
           docker pull europe-west1-docker.pkg.dev/marble-infra/marble/firebase-emulator:latest &
           docker pull europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:latest &
-          bun run -F tests test:ci
+          if [ "${{ steps.cache-output.outputs.cache-hit }}" != "true" ]; then
+            bun run -F app-builder build
+          fi
           wait
+      - name: Run E2E tests
+        run: bun run -F tests test:run:prod
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - run: bun run -F tests test:install
-      - run: bun run -F tests test:ci
+      - name: Pre-pull test container images in parallel with build
+        run: |
+          docker pull postgis/postgis:17-3.6-alpine &
+          docker pull europe-west1-docker.pkg.dev/marble-infra/marble/firebase-emulator:latest &
+          docker pull europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:latest &
+          bun run -F tests test:ci
+          wait
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - run: bun run -F tests test:install
-      - run: bun run -F tests test
+      - run: bun run -F tests test:ci
       - uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,12 +35,18 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - run: bun run -F tests test:install
+      # Cache the production build output. The key hashes everything that can affect
+      # the build: all of packages/app-builder/**, the src/ of every package it depends
+      # on, the lockfile, and the runtime version. The globs are intentionally broad —
+      # the cache mostly helps re-runs of the same commit (flake retries), so
+      # over-invalidation is cheap and "I added a new build input" is unlikely to drift.
+      # If you add a NEW dependent package, add its src/ to the hashFiles list below.
       - name: Cache app build output
         id: cache-output
         uses: actions/cache@v5
         with:
           path: packages/app-builder/.output
-          key: ${{ runner.os }}-output-${{ hashFiles('packages/*/src/**', 'packages/*/package.json', 'packages/app-builder/vite.config.ts', 'packages/app-builder/tsconfig.json', 'bun.lock') }}
+          key: ${{ runner.os }}-output-${{ hashFiles('packages/app-builder/**', 'packages/shared/src/**', 'packages/ui-design-system/src/**', 'packages/ui-icons/src/**', 'packages/marble-api/src/**', 'packages/tailwind-preset/src/**', 'packages/typescript-utils/src/**', '!**/node_modules/**', '!**/.output/**', 'bun.lock', '.tool-versions') }}
       - name: Pre-pull test container images (and build if cache miss)
         run: |
           docker pull postgis/postgis:17-3.6-alpine &

--- a/packages/app-builder/package.json
+++ b/packages/app-builder/package.json
@@ -10,7 +10,7 @@
     "lint": "biome lint",
     "type-check": "tsc --noEmit",
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "NODE_ENV=production vite build",
     "start": "node .output/server/index.mjs",
     "unit-tests": "vitest run"
   },

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "test:install": "playwright install",
     "test": "DEBUG=testcontainers:containers NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test",
+    "test:prod": "rm -rf ../app-builder/.output && NODE_ENV=production bun run -F app-builder build && DEBUG=testcontainers:containers NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test --config=playwright.ci.config.ts",
+    "test:ci": "bun run test:prod",
     "test:ui": "NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test --ui",
     "lint": "eslint ."
   },

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test:install": "playwright install",
     "test": "DEBUG=testcontainers:containers NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test",
-    "test:prod": "rm -rf ../app-builder/.output && NODE_ENV=production bun run -F app-builder build && DEBUG=testcontainers:containers NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test --config=playwright.ci.config.ts",
-    "test:ci": "bun run test:prod",
+    "test:run:prod": "DEBUG=testcontainers:containers NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test --config=playwright.ci.config.ts",
+    "test:prod": "bun run -F app-builder build && bun run test:run:prod",
     "test:ui": "NODE_OPTIONS=--disable-warning=ExperimentalWarning playwright test --ui",
     "lint": "eslint ."
   },

--- a/packages/tests/playwright.base.config.ts
+++ b/packages/tests/playwright.base.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test';
+
+import setup from './e2e/setup';
+
+await setup();
+
+type Mode = 'dev' | 'ci';
+
+export function createConfig(mode: Mode): PlaywrightTestConfig {
+  const isDev = mode === 'dev';
+
+  return defineConfig({
+    testDir: './e2e',
+    reporter: 'html',
+    fullyParallel: true,
+    // In dev, Vite's single-process dev server is the bottleneck; concurrent workers
+    // serialize on it and slow everything down. In prod, we serve bundled chunks
+    // and parallelism scales with cores.
+    workers: isDev ? 1 : 4,
+    use: {
+      headless: !process.env['PW_DEBUG'],
+      baseURL: 'http://localhost:3000',
+      trace: 'retain-on-failure',
+      screenshot: 'only-on-failure',
+      ...(isDev ? { launchOptions: { slowMo: 250 } } : {}),
+    },
+    projects: [
+      {
+        name: 'auth',
+        use: { ...devices['Desktop Chrome'] },
+        testMatch: 'auth.spec.ts',
+      },
+      {
+        name: 'chromium',
+        use: {
+          ...devices['Desktop Chrome'],
+          storageState: 'auth.json',
+        },
+        testMatch: /.spec.ts/,
+        testIgnore: 'auth.spec.ts',
+        dependencies: ['auth'],
+      },
+    ],
+    webServer: {
+      // Skip the Bun workspace wrapper in prod — it elides subprocess stderr,
+      // which makes startup failures invisible.
+      command: isDev ? 'bun run -F app-builder dev' : 'node ../app-builder/.output/server/index.mjs',
+      url: 'http://localhost:3000',
+      reuseExistingServer: isDev,
+      timeout: isDev ? 60_000 : 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ENV: 'development',
+        NODE_ENV: isDev ? 'development' : 'production',
+        SESSION_SECRET: 'SOMETHING_LIKE_A_LONG_SESSION_SECRET_KEY',
+        SESSION_MAX_AGE: '43200',
+        MARBLE_API_URL: `http://localhost:${process.env['API_PORT']}`,
+        TEST_FIREBASE_AUTH_EMULATOR_HOST: `localhost:${process.env['FIREBASE_PORT']}`,
+      },
+    },
+  });
+}

--- a/packages/tests/playwright.ci.config.ts
+++ b/packages/tests/playwright.ci.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from './playwright.base.config';
 
-export default createConfig('dev');
+export default createConfig('ci');


### PR DESCRIPTION
## Summary
Following the tanstack migration, the dev server is significantly slower (not the prod server), especially under a lot of concurrent requests. Most E2E tests became slow, often timing out, especially with 4 workers.

## Solution
- 2 modes for E2E tests, dev (with local dev server and 1 worker), and prod (for CI, with proper prod build, which is really better for what we want to test anyway)
- added some cache in the CI while i'm at it, for retried CI jobs
- and pre-fetching of docker images, for slightly faster tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Accelerated E2E test execution through build caching and parallel Docker image preparation
  * Enforced explicit production mode for build and test processes
  * Refactored test configurations into reusable factory pattern for dev and CI environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->