### PR TITLE
feat: add new webhook type in settings

### DIFF
--- a/packages/app-builder/src/models/webhook.ts
+++ b/packages/app-builder/src/models/webhook.ts
@@ -11,13 +11,16 @@ export const eventTypes = [
   'case.updated',
   'case.created_manually',
   'case.created_from_workflow',
+  'case.created_from_continuous_screening',
   'case.decisions_updated',
   'case.tags_updated',
   'case.comment_created',
   'case.file_created',
   'case.rule_snooze_created',
   'case.decision_reviewed',
+  'case.continuous_screening_match_reviewed',
   'decision.created',
+  'async_decision.failed',
 ] as const;
 export type EventType = (typeof eventTypes)[number];
 

--- a/packages/app-builder/src/models/webhook.ts
+++ b/packages/app-builder/src/models/webhook.ts
@@ -4,23 +4,23 @@ import {
   type WebhookSecretDto,
   type WebhookUpdateBodyDto,
   type WebhookWithSecretDto,
-} from 'marble-api/generated/marblecore-api';
-import invariant from 'tiny-invariant';
+} from "marble-api/generated/marblecore-api";
+import invariant from "tiny-invariant";
 
 export const eventTypes = [
-  'case.updated',
-  'case.created_manually',
-  'case.created_from_workflow',
-  'case.created_from_continuous_screening',
-  'case.decisions_updated',
-  'case.tags_updated',
-  'case.comment_created',
-  'case.file_created',
-  'case.rule_snooze_created',
-  'case.decision_reviewed',
-  'case.continuous_screening_match_reviewed',
-  'decision.created',
-  'async_decision.failed',
+  "case.updated",
+  "case.created_manually",
+  "case.created_from_workflow",
+  "case.decisions_updated",
+  "case.tags_updated",
+  "case.comment_created",
+  "case.file_created",
+  "case.rule_snooze_created",
+  "case.decision_reviewed",
+  "decision.created",
+  "async_decision.failed",
+  "continuous_screening.created",
+  "continuous_screening.match_reviewed",
 ] as const;
 export type EventType = (typeof eventTypes)[number];
 
@@ -39,14 +39,18 @@ export interface Webhook {
 
 export function adaptWebhook(dto: WebhookDto): Webhook {
   const eventTypes = dto.event_types ?? [];
-  invariant(eventTypes.every(isEventType), `Invalid event types: ${eventTypes.join(', ')}`);
+  invariant(
+    eventTypes.every(isEventType),
+    `Invalid event types: ${eventTypes.join(", ")}`
+  );
   return {
     id: dto.id,
     eventTypes,
     url: dto.url,
     httpTimeout: dto.http_timeout !== 0 ? dto.http_timeout : undefined,
     rateLimit: dto.rate_limit !== 0 ? dto.rate_limit : undefined,
-    rateLimitDuration: dto.rate_limit_duration !== 0 ? dto.rate_limit_duration : undefined,
+    rateLimitDuration:
+      dto.rate_limit_duration !== 0 ? dto.rate_limit_duration : undefined,
   };
 }
 
@@ -60,9 +64,9 @@ export interface WebhookSecret {
 }
 
 export function adaptWebhookSecret(dto: WebhookSecretDto): WebhookSecret {
-  invariant(dto.id, 'Webhook secret id is required');
-  invariant(dto.created_at, 'Webhook secret created_at is required');
-  invariant(dto.value, 'Webhook secret value is required');
+  invariant(dto.id, "Webhook secret id is required");
+  invariant(dto.created_at, "Webhook secret created_at is required");
+  invariant(dto.value, "Webhook secret value is required");
   return {
     id: dto.id,
     createdAt: dto.created_at,
@@ -77,7 +81,9 @@ export interface WebhookWithSecret extends Webhook {
   secrets: WebhookSecret[];
 }
 
-export function adaptWebhookWithSecret(dto: WebhookWithSecretDto): WebhookWithSecret {
+export function adaptWebhookWithSecret(
+  dto: WebhookWithSecretDto
+): WebhookWithSecret {
   return {
     ...adaptWebhook(dto),
     secrets: dto.secrets?.map(adaptWebhookSecret) ?? [],
@@ -92,7 +98,9 @@ export interface WebhookCreateBody {
   rateLimitDuration?: number;
 }
 
-export function adaptWebhookRegisterBodyDto(body: WebhookCreateBody): WebhookRegisterBodyDto {
+export function adaptWebhookRegisterBodyDto(
+  body: WebhookCreateBody
+): WebhookRegisterBodyDto {
   return {
     event_types: body.eventTypes,
     url: body.url,
@@ -114,7 +122,9 @@ export interface WebhookUpdateBody {
   rateLimitDuration?: number;
 }
 
-export function adaptWebhookUpdateBodyDto(body: WebhookUpdateBody): WebhookUpdateBodyDto {
+export function adaptWebhookUpdateBodyDto(
+  body: WebhookUpdateBody
+): WebhookUpdateBodyDto {
   return {
     event_types: body.eventTypes,
     url: body.url,

--- a/packages/app-builder/src/models/webhook.ts
+++ b/packages/app-builder/src/models/webhook.ts
@@ -4,23 +4,23 @@ import {
   type WebhookSecretDto,
   type WebhookUpdateBodyDto,
   type WebhookWithSecretDto,
-} from "marble-api/generated/marblecore-api";
-import invariant from "tiny-invariant";
+} from 'marble-api/generated/marblecore-api';
+import invariant from 'tiny-invariant';
 
 export const eventTypes = [
-  "case.updated",
-  "case.created_manually",
-  "case.created_from_workflow",
-  "case.decisions_updated",
-  "case.tags_updated",
-  "case.comment_created",
-  "case.file_created",
-  "case.rule_snooze_created",
-  "case.decision_reviewed",
-  "decision.created",
-  "async_decision.failed",
-  "continuous_screening.created",
-  "continuous_screening.match_reviewed",
+  'case.updated',
+  'case.created_manually',
+  'case.created_from_workflow',
+  'case.decisions_updated',
+  'case.tags_updated',
+  'case.comment_created',
+  'case.file_created',
+  'case.rule_snooze_created',
+  'case.decision_reviewed',
+  'decision.created',
+  'async_decision.failed',
+  'continuous_screening.created',
+  'continuous_screening.match_reviewed',
 ] as const;
 export type EventType = (typeof eventTypes)[number];
 
@@ -39,18 +39,14 @@ export interface Webhook {
 
 export function adaptWebhook(dto: WebhookDto): Webhook {
   const eventTypes = dto.event_types ?? [];
-  invariant(
-    eventTypes.every(isEventType),
-    `Invalid event types: ${eventTypes.join(", ")}`
-  );
+  invariant(eventTypes.every(isEventType), `Invalid event types: ${eventTypes.join(', ')}`);
   return {
     id: dto.id,
     eventTypes,
     url: dto.url,
     httpTimeout: dto.http_timeout !== 0 ? dto.http_timeout : undefined,
     rateLimit: dto.rate_limit !== 0 ? dto.rate_limit : undefined,
-    rateLimitDuration:
-      dto.rate_limit_duration !== 0 ? dto.rate_limit_duration : undefined,
+    rateLimitDuration: dto.rate_limit_duration !== 0 ? dto.rate_limit_duration : undefined,
   };
 }
 
@@ -64,9 +60,9 @@ export interface WebhookSecret {
 }
 
 export function adaptWebhookSecret(dto: WebhookSecretDto): WebhookSecret {
-  invariant(dto.id, "Webhook secret id is required");
-  invariant(dto.created_at, "Webhook secret created_at is required");
-  invariant(dto.value, "Webhook secret value is required");
+  invariant(dto.id, 'Webhook secret id is required');
+  invariant(dto.created_at, 'Webhook secret created_at is required');
+  invariant(dto.value, 'Webhook secret value is required');
   return {
     id: dto.id,
     createdAt: dto.created_at,
@@ -81,9 +77,7 @@ export interface WebhookWithSecret extends Webhook {
   secrets: WebhookSecret[];
 }
 
-export function adaptWebhookWithSecret(
-  dto: WebhookWithSecretDto
-): WebhookWithSecret {
+export function adaptWebhookWithSecret(dto: WebhookWithSecretDto): WebhookWithSecret {
   return {
     ...adaptWebhook(dto),
     secrets: dto.secrets?.map(adaptWebhookSecret) ?? [],
@@ -98,9 +92,7 @@ export interface WebhookCreateBody {
   rateLimitDuration?: number;
 }
 
-export function adaptWebhookRegisterBodyDto(
-  body: WebhookCreateBody
-): WebhookRegisterBodyDto {
+export function adaptWebhookRegisterBodyDto(body: WebhookCreateBody): WebhookRegisterBodyDto {
   return {
     event_types: body.eventTypes,
     url: body.url,
@@ -122,9 +114,7 @@ export interface WebhookUpdateBody {
   rateLimitDuration?: number;
 }
 
-export function adaptWebhookUpdateBodyDto(
-  body: WebhookUpdateBody
-): WebhookUpdateBodyDto {
+export function adaptWebhookUpdateBodyDto(body: WebhookUpdateBody): WebhookUpdateBodyDto {
   return {
     event_types: body.eventTypes,
     url: body.url,


### PR DESCRIPTION
This pull request adds support for new webhook event types related to continuous screening and asynchronous decisions in the `webhook.ts` model. These additions will allow the system to handle and respond to these new types of events.

**New webhook event types:**

* Added `case.created_from_continuous_screening` to the `eventTypes` array to support cases created via continuous screening.
* Added `case.continuous_screening_match_reviewed` to the `eventTypes` array to capture reviews of continuous screening matches.
* Added `async_decision.failed` to the `eventTypes` array to handle failures in asynchronous decision processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhooks now support three additional event types: async decision failures, continuous screening case creation, and continuous screening match review notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->