### PR TITLE
fix the nationality

### DIFF
--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
@@ -122,15 +122,29 @@ export const FreeformSearchForm: FunctionComponent<FreeformSearchFormProps> = ({
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {/* Search by name input with button */}
       <div className="flex gap-2">
-        <form.Field name="fields.name">
+        <form.Field
+          name="fields.name"
+          validators={{
+            onSubmit: ({ value }) => {
+              const v = (value as string) ?? '';
+              return v.trim().length >= 1 ? undefined : t('screenings:freeform_search.name_required');
+            },
+          }}
+        >
           {(formField) => (
-            <Input
-              name={formField.name}
-              value={(formField.state.value as string) ?? ''}
-              onChange={(e) => formField.handleChange(e.target.value)}
-              className="flex-1"
-              placeholder={t('screenings:freeform_search.name_placeholder')}
-            />
+            <div className="flex flex-1 flex-col gap-1">
+              <Input
+                name={formField.name}
+                value={(formField.state.value as string) ?? ''}
+                onChange={(e) => formField.handleChange(e.target.value)}
+                className="w-full"
+                borderColor={formField.state.meta.errors.length > 0 ? 'redfigma-47' : 'greyfigma-90'}
+                placeholder={t('screenings:freeform_search.name_placeholder')}
+              />
+              {formField.state.meta.errors.length > 0 && (
+                <span className="text-red-primary text-xs">{formField.state.meta.errors[0]}</span>
+              )}
+            </div>
           )}
         </form.Field>
         <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
@@ -205,7 +219,7 @@ export const FreeformSearchForm: FunctionComponent<FreeformSearchFormProps> = ({
                     }
                   >
                     {(formField) => {
-                      if (fieldName === 'country') {
+                      if (fieldName === 'country' || fieldName === 'nationality') {
                         return (
                           <SelectCountry
                             name={formField.name}

--- a/packages/app-builder/src/locales/ar/screenings.json
+++ b/packages/app-builder/src/locales/ar/screenings.json
@@ -113,6 +113,7 @@
   "freeform_search.limit_label": "حد النتائج",
   "freeform_search.limit_warning": "قد يكون هناك المزيد من النتائج. قم بزيادة الحد لرؤية جميع المطابقات.",
   "freeform_search.name_placeholder": "أدخل الاسم للبحث...",
+  "freeform_search.name_required": "الاسم مطلوب",
   "freeform_search.new_search": "بحث جديد",
   "freeform_search.no_results_description": "حاول تعديل معايير البحث أو خفض حد التشابه.",
   "freeform_search.no_results_title": "لم يتم العثور على مطابقات",

--- a/packages/app-builder/src/locales/en/screenings.json
+++ b/packages/app-builder/src/locales/en/screenings.json
@@ -113,6 +113,7 @@
   "freeform_search.limit_label": "Results Limit",
   "freeform_search.limit_warning": "There may be more results. Increase the limit to see all matches.",
   "freeform_search.name_placeholder": "Enter name to search...",
+  "freeform_search.name_required": "Name is required",
   "freeform_search.new_search": "New Search",
   "freeform_search.no_results_description": "Try adjusting your search criteria or lowering the similarity threshold.",
   "freeform_search.no_results_title": "No matches found",

--- a/packages/app-builder/src/locales/fr/screenings.json
+++ b/packages/app-builder/src/locales/fr/screenings.json
@@ -113,6 +113,7 @@
   "freeform_search.limit_label": "Limite de résultats",
   "freeform_search.limit_warning": "Il peut y avoir plus de résultats. Augmentez la limite pour voir toutes les correspondances.",
   "freeform_search.name_placeholder": "Entrez le nom à rechercher...",
+  "freeform_search.name_required": "Le nom est requis",
   "freeform_search.new_search": "Nouvelle recherche",
   "freeform_search.no_results_description": "Essayez d'ajuster vos critères de recherche ou de baisser le seuil de similarité.",
   "freeform_search.no_results_title": "Aucune correspondance trouvée",


### PR DESCRIPTION
add the country selector for 'nationality field'
add a validator to the name which is required to avoid the error toaster

country selector with filter
<img width="377" height="406" alt="Capture d’écran 2026-04-29 à 08 58 09" src="https://github.com/user-attachments/assets/d0135982-dba4-42b4-9540-c3b6e5bed22d" />

also accept free value
<img width="370" height="191" alt="Capture d’écran 2026-04-29 à 08 58 21" src="https://github.com/user-attachments/assets/6e00fd77-ee2e-4a53-95f9-d76a9fafdf57" />

name validator
<img width="368" height="100" alt="Capture d’écran 2026-04-29 à 08 58 27" src="https://github.com/user-attachments/assets/214672ee-c7bd-44ff-8d5b-28056f13933e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation to the name field requiring a non-empty value with localized error messages
  * Expanded field selection to support both country and nationality options  
  * Validation errors now display with visual highlighting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->