### PR TITLE
fix a width limit to the datafield name to prevent overflow

### DIFF
--- a/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
@@ -105,9 +105,9 @@ export function DataFields({ table, object, preset, customFields, className, opt
       <div
         className={cn(
           'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-4 gap-y-2 break-all',
-          options?.layout === '2-columns' && 'grid-cols-[repeat(2,max(50%,max-content)_1fr)]',
-          options?.layout === '3-columns' && 'grid-cols-[repeat(3,max(50%,max-content)_1fr)]',
-          (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[max(50%,max-content)_1fr]',
+          options?.layout === '2-columns' && 'grid-cols-[repeat(2,min(1fr,max-content)_1fr)]',
+          options?.layout === '3-columns' && 'grid-cols-[repeat(3,min(1fr,max-content)_1fr)]',
+          (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[min(1fr,max-content)_1fr]',
           className,
         )}
       >

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
@@ -105,9 +105,9 @@ export function DataFields({ table, object, preset, customFields, className, opt
       <div
         className={cn(
           'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-4 gap-y-2 break-all',
-          options?.layout === '2-columns' && 'grid-cols-[max-content_1fr_max-content_1fr]',
-          options?.layout === '3-columns' && 'grid-cols-[max-content_1fr_max-content_1fr_max-content_1fr]',
-          (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[max-content_1fr]',
+          options?.layout === '2-columns' && 'grid-cols-[repeat(2,max(50%,max-content)_1fr)]',
+          options?.layout === '3-columns' && 'grid-cols-[repeat(3,max(50%,max-content)_1fr)]',
+          (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[max(50%,max-content)_1fr]',
           className,
         )}
       >


### PR DESCRIPTION
## before
<img width="599" height="986" alt="Capture d’écran 2026-05-04 à 11 29 00" src="https://github.com/user-attachments/assets/176e7045-eba6-4e2e-bb9e-0fd9e4f83ddd" />

## after
<img width="458" height="812" alt="Capture d’écran 2026-05-04 à 11 26 56" src="https://github.com/user-attachments/assets/2ff443fb-a6fc-4aa5-96ab-178c23ae9ce4" />

<img width="453" height="787" alt="Capture d’écran 2026-05-04 à 11 29 47" src="https://github.com/user-attachments/assets/5cf6be67-1794-488a-b5a0-5f78d8472169" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved data field grid layout rendering for better responsive behavior across single, dual, and triple column configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->