### PR TITLE
docs: update skills and CLAUDE.md for TanStack Start migration

### DIFF
--- a/.claude/rules/page-routes.md
+++ b/.claude/rules/page-routes.md
@@ -1,13 +1,15 @@
 ---
 paths:
-  - "**/routes/_builder+/**"
-  - "**/routes/_auth+/**"
+  - "**/routes/_app/_builder/**"
+  - "**/routes/_app/_auth/**"
 ---
 
 # Page Route Conventions
 
-- Use `createServerFn` from `core/requests.ts` + `authMiddleware` from `middlewares/auth-middleware.ts` for loaders and actions
-- `_builder+/` page loaders do NOT need `handleRedirectMiddleware` — the browser handles redirects natively during full page loads
-- Flat routes with `+` folders: `_builder+/cases+/$caseId.tsx`
-- Use `handle` export for breadcrumbs
-- Reference: `routes/_builder+/settings+/data-display.tsx` (loader + action)
+- Define routes with `createFileRoute('/path')({ staticData, loader, component })` from `@tanstack/react-router`
+- Loaders: inline `createServerFn().middleware([authMiddleware]).handler(async ({ context }) => { ... })` from `@tanstack/react-start`, then pass via `loader: () => myLoader()`
+- Auth context via `context.authInfo` (repositories, user, entitlements); services via `context.services`
+- `authMiddleware` already handles auth redirects internally — no separate redirect middleware is needed for `_app/_builder` pages
+- Use `staticData.BreadCrumbs` (array of render functions receiving `{ isLast }`) for breadcrumbs; access loader data inside the component via `Route.useLoaderData()`
+- File-name conventions: `_name.tsx` = layout route, `$param` = dynamic segment, dot-separated filenames = nested URL path (`cases.$caseId.tsx` → `/cases/:caseId`)
+- Reference: `routes/_app/_builder/cases.tsx`

--- a/.claude/rules/resource-routes.md
+++ b/.claude/rules/resource-routes.md
@@ -1,14 +1,30 @@
 ---
 paths:
-  - "**/ressources+/**"
+  - "**/routes/ressources/**"
+  - "**/server-fns/**"
 ---
 
-# Resource Route Conventions
+# Server Endpoint Conventions
 
-- Use `createServerFn` from `core/requests.ts` + `authMiddleware` from `middlewares/auth-middleware.ts` — NOT legacy `initServerServices`/`ActionFunctionArgs`/`json()`
-- **Default to `[handleRedirectMiddleware, authMiddleware]`** for routes called via React Query/useFetcher — the redirect middleware intercepts auth redirects (3xx to `/sign-in`) and converts them to `{ redirectTo }` so the client can navigate properly
-- Use `[authMiddleware]` alone for mutation actions (delete, create, revoke) or data-fetching endpoints that handle auth errors programmatically
-- Access auth context via `context.authInfo` (repositories, user) and services via `context.services`
-- Use `data()` from `core/requests.ts` instead of Remix's `json()` for responses with headers
+Two patterns coexist for server endpoints called from the client:
+
+## Server Functions (preferred for new React Query endpoints)
+
+- Export from `server-fns/{domain}.ts` using `createServerFn({ method: 'POST' })` from `@tanstack/react-start`
+- Chain: `.middleware([authMiddleware]).inputValidator(zodSchema).handler(async ({ context, data }) => { ... })`
+- Call from React Query: `mutationFn: (payload) => myServerFn({ data: payload })`
+- Access auth via `context.authInfo` (repositories, user); services via `context.services`
+- Set response headers via `setResponseHeaders(new Headers({ ... }))` from `@tanstack/react-start/server` — no `data()` helper exists
+- Redirects: `throw redirect({ href, statusCode })` from `@tanstack/react-router`; `authMiddleware` already handles auth-redirect cases
+- Reference: `server-fns/cases.ts`, `server-fns/auth.ts`
+
+## Resource File Routes (downloads, streams, file-typed responses)
+
+- File at `routes/ressources/{domain}/...ts` using `createFileRoute('/ressources/...')({ server: { handlers: { GET: async ({ request, params }) => new Response(...) } } })`
+- Return raw `Response` objects (e.g., for CSV downloads, file streaming)
+- Reference: `routes/ressources/lists/download-csv-file.$listId.ts`
+
+## General
+
 - `apiClient` on `context.authInfo` is deprecated — add repository methods instead
-- References: `routes/ressources+/lists+/create.tsx` (with redirect middleware), `routes/ressources+/data+/deleteTable.tsx` (auth only)
+- Do NOT use `initServerServices` / `ActionFunctionArgs` / `LoaderFunctionArgs` / Remix `handle` / Remix `json()` for new code — a few legacy download routes still use `initServerServices` but new code should not

--- a/.claude/skills/frontend-dev-guidelines/SKILL.md
+++ b/.claude/skills/frontend-dev-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-dev-guidelines
-description: Use when writing, editing, or creating components, pages, routes, forms, tables, modals, queries, hooks, loaders, or actions in packages/app-builder or packages/ui-design-system. Covers React patterns, TanStack Query/Form, Radix UI, virtual tables, MenuCommand, Tailwind color tokens, file organization, and TypeScript standards. Basic conventions (imports, styling, i18n, resource route middleware) are in .claude/rules/ — this skill provides the deep reference patterns and code examples.
+description: Use when writing, editing, or creating components, pages, routes, forms, tables, modals, queries, hooks, loaders, or server functions in packages/app-builder or packages/ui-design-system. Covers TanStack Start + TanStack Router (createFileRoute, staticData, file-based routing), createServerFn, React patterns, TanStack Query/Form, Radix UI, virtual tables, MenuCommand, Tailwind color tokens, file organization, and TypeScript standards. Basic conventions (imports, styling, i18n, route middleware) are in .claude/rules/ — this skill provides the deep reference patterns and code examples.
 ---
 
 # Frontend Development Guidelines
@@ -62,8 +62,8 @@ Read these when working on specific areas:
 | Topic | Resource | When to read |
 |-------|----------|-------------|
 | Component patterns | [component-patterns.md](resources/component-patterns.md) | Writing/editing components |
-| Data fetching | [data-fetching.md](resources/data-fetching.md) | Queries, mutations, loaders, actions |
-| Routing | [routing-guide.md](resources/routing-guide.md) | Routes, breadcrumbs, navigation |
+| Data fetching | [data-fetching.md](resources/data-fetching.md) | Queries, mutations, loaders, server functions |
+| Routing | [routing-guide.md](resources/routing-guide.md) | TanStack Router routes, breadcrumbs, navigation |
 | Styling | [styling-guide.md](resources/styling-guide.md) | Color tokens, surface tokens, dark mode |
 | Tables & selects | [tables-and-selects.md](resources/tables-and-selects.md) | Virtual tables, MenuCommand dropdowns |
 | Forms & modals | [forms-and-modals.md](resources/forms-and-modals.md) | TanStack Form, Modal, Panel |

--- a/.claude/skills/frontend-dev-guidelines/resources/common-patterns.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/common-patterns.md
@@ -101,20 +101,11 @@ export function MyComponent() {
 }
 ```
 
-### In Route Handles
-
-Declare namespaces in `handle.i18n`:
-
-```typescript
-export const handle = {
-  i18n: ['common', 'cases', 'navigation'] satisfies Namespace,
-};
-```
-
 ### Server-Side Translation
 
 ```typescript
 const { i18nextService: { getFixedT } } = context.services;
+const request = getRequest(); // from '@tanstack/react-start/server'
 const t = await getFixedT(request, ['common', 'data']);
 
 setToastMessage(session, {
@@ -122,6 +113,8 @@ setToastMessage(session, {
   message: t('data:apply_archetype.success'),
 });
 ```
+
+i18n namespaces no longer live in a `handle` export — each component just calls `useTranslation([...])` with the namespaces it needs. Server functions get the request via `getRequest()` to resolve the per-request `t`.
 
 ### Adding i18n Keys
 
@@ -181,10 +174,15 @@ setToastMessage(toastSession, {
   message: t('common:errors.unknown'),
 });
 
-// Return with Set-Cookie header to persist toast
-return data({ success: false, errors: [] }, [
-  ['Set-Cookie', await toastSessionService.commitSession(toastSession)],
-]);
+// Return with Set-Cookie header to persist toast (TanStack Start pattern)
+import { setResponseHeaders } from '@tanstack/react-start/server';
+
+setResponseHeaders(
+  new Headers({
+    'Set-Cookie': await toastSessionService.commitSession(toastSession),
+  }),
+);
+return { success: false, errors: [] };
 ```
 
 ---

--- a/.claude/skills/frontend-dev-guidelines/resources/common-patterns.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/common-patterns.md
@@ -108,11 +108,10 @@ const { i18nextService: { getFixedT } } = context.services;
 const request = getRequest(); // from '@tanstack/react-start/server'
 const t = await getFixedT(request, ['common', 'data']);
 
-setToastMessage(session, {
-  type: 'success',
-  message: t('data:apply_archetype.success'),
-});
+throw new Error(t('data:apply_archetype.error.invalid_payload'));
 ```
+
+Use server-side `t` for messages embedded in thrown errors or returned data. Toasts themselves are surfaced client-side from mutation callbacks (see [Toast Notifications](#toast-notifications) below).
 
 i18n namespaces no longer live in a `handle` export — each component just calls `useTranslation([...])` with the namespaces it needs. Server functions get the request via `getRequest()` to resolve the per-request `t`.
 
@@ -145,45 +144,35 @@ Size with `size-{n}`, color via `text-{color}`.
 
 ## Toast Notifications
 
-### Client-Side (react-hot-toast)
+Toasts are **client-side only**, fired from React Query mutation callbacks (`onSuccess` / `onError`) or `mutateAsync().then(...).catch(...)`. There is no server-side flash session — server functions throw errors, the client decides what to show.
 
 ```typescript
 import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 
-toast.success('Case created successfully');
-toast.error('Failed to create case');
-toast.error(t('common:errors.unknown'));
+const { t } = useTranslation(['common']);
+const createMutation = useCreateTagMutation();
+
+// In a form submit / handler:
+createMutation
+  .mutateAsync(value)
+  .then(() => {
+    toast.success(t('common:success.save'));
+    onSuccess();
+  })
+  .catch(() => {
+    toast.error(t('common:errors.unknown'));
+  });
+
+// Or via useMutation options:
+useMutation({
+  mutationFn: createTagFn,
+  onSuccess: () => toast.success(t('common:success.save')),
+  onError: () => toast.error(t('common:errors.unknown')),
+});
 ```
 
-### Server-Side (session flash)
-
-Used in actions to show toasts after redirect:
-
-```typescript
-import { setToastMessage } from '@app-builder/components/MarbleToaster';
-
-// With i18n key (preferred)
-setToastMessage(toastSession, {
-  type: 'success',
-  messageKey: 'common:success.save',
-});
-
-// With direct message
-setToastMessage(toastSession, {
-  type: 'error',
-  message: t('common:errors.unknown'),
-});
-
-// Return with Set-Cookie header to persist toast (TanStack Start pattern)
-import { setResponseHeaders } from '@tanstack/react-start/server';
-
-setResponseHeaders(
-  new Headers({
-    'Set-Cookie': await toastSessionService.commitSession(toastSession),
-  }),
-);
-return { success: false, errors: [] };
-```
+For server-side errors that need to surface specific messages, throw a typed error from the server function and inspect it in the client `onError` handler.
 
 ---
 

--- a/.claude/skills/frontend-dev-guidelines/resources/common-patterns.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/common-patterns.md
@@ -104,8 +104,10 @@ export function MyComponent() {
 ### Server-Side Translation
 
 ```typescript
+import { getRequest } from '@tanstack/react-start/server';
+
 const { i18nextService: { getFixedT } } = context.services;
-const request = getRequest(); // from '@tanstack/react-start/server'
+const request = getRequest();
 const t = await getFixedT(request, ['common', 'data']);
 
 throw new Error(t('data:apply_archetype.error.invalid_payload'));

--- a/.claude/skills/frontend-dev-guidelines/resources/data-fetching.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/data-fetching.md
@@ -49,7 +49,7 @@ export const Route = createFileRoute('/_app/_builder/cases/')({
 Key points:
 - Chain syntax: `createServerFn().middleware([...]).handler(async ({ context }) => {...})`
 - `context.authInfo` provides authenticated user, repositories, entitlements
-- `context.services` provides `toastSessionService`, `i18nextService`, `authService`
+- `context.services` provides `authService`, `featureAccessService`, `i18nextService` (no `toastSessionService` — toasts are client-side)
 - Need the raw request? `import { getRequest } from '@tanstack/react-start/server'` then call `getRequest()` inside the handler
 - `authMiddleware` already handles auth redirects (throws `redirect()` from `@tanstack/react-router`) — no separate `handleRedirectMiddleware`
 
@@ -65,7 +65,6 @@ import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import { redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
-import { setResponseHeaders } from '@tanstack/react-start/server';
 import { z } from 'zod/v4';
 
 const createListPayloadSchema = z.object({ name: z.string().min(1) });
@@ -74,36 +73,18 @@ export const createListFn = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(createListPayloadSchema)
   .handler(async ({ context, data }) => {
-    const { toastSessionService } = context.services;
-    try {
-      const result = await context.authInfo.customListsRepository.createCustomList(data);
-      throw redirect({
-        href: `/detection/lists/${fromUUIDtoSUUID(result.id)}`,
-      });
-    } catch (error) {
-      if (isStatusConflictHttpError(error)) {
-        const toastSession = await toastSessionService.getSession();
-        setToastMessage(toastSession, {
-          type: 'error',
-          messageKey: 'common:errors.list.duplicate_list_name',
-        });
-        setResponseHeaders(
-          new Headers({
-            'Set-Cookie': await toastSessionService.commitSession(toastSession),
-          }),
-        );
-        return { success: false, errors: [] };
-      }
-      throw error;
-    }
+    const result = await context.authInfo.customListsRepository.createCustomList(data);
+    throw redirect({
+      href: `/detection/lists/${fromUUIDtoSUUID(result.id)}`,
+    });
   });
 ```
 
 Key points:
 - `.inputValidator(schema)` validates `data` on the server before the handler runs; the handler receives `{ context, data }` where `data` is the parsed result
 - `redirect()` from `@tanstack/react-router` is thrown (not returned) to trigger navigation
-- `setResponseHeaders(new Headers({ ... }))` from `@tanstack/react-start/server` sets headers like `Set-Cookie` — there is no `data()` helper
-- For Set-Cookie patterns, set the header then return a plain object
+- `setResponseHeaders(new Headers({ ... }))` from `@tanstack/react-start/server` sets headers like `Set-Cookie` — there is no `data()` helper. Used for things like persisted preferences, **not** for toast flash sessions (those no longer exist)
+- For error feedback, let the server function throw; surface the message client-side via the mutation's `onError` (see [common-patterns#toast-notifications](common-patterns.md#toast-notifications))
 - Call from the client: `createListFn({ data: { name: 'My List' } })`
 
 ### Calling from React Query
@@ -288,7 +269,7 @@ queryClient.invalidateQueries({ queryKey: ['cases'] }); // all case queries
 | Middleware | Purpose |
 |-----------|---------|
 | `authMiddleware` | Auth check, redirects to `/sign-in` on failure; provides `context.authInfo` (user, repositories, entitlements) |
-| `servicesMiddleware` | Provides `context.services` (toastSessionService, i18nextService, authService) |
+| `servicesMiddleware` | Provides `context.services` (authService, featureAccessService, i18nextService) and `context.appConfig` |
 | `caseDetailMiddleware` | Adds case-detail context for case-scoped server functions |
 
 Compose middleware via the chain: `createServerFn().middleware([servicesMiddleware, authMiddleware]).handler(...)`. `authMiddleware` already includes `servicesMiddleware` internally, so most handlers only need `[authMiddleware]`.

--- a/.claude/skills/frontend-dev-guidelines/resources/data-fetching.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/data-fetching.md
@@ -1,33 +1,35 @@
 # Data Fetching Patterns
 
-Data fetching architecture: loaders, actions, queries, mutations, and repositories.
+Data fetching architecture in TanStack Start: route loaders, server functions, queries, mutations, and repositories.
 
 ---
 
 ## Architecture
 
 ```
-Route loader/action -> Repository -> API Client
-Component -> Query Hook -> fetch(resource route) -> Route loader -> Repository -> API Client
+Route loader (createServerFn)        -> Repository -> API Client     (SSR data for page render)
+Component -> Query Hook -> fetch(    -> server-fn (createServerFn)    -> Repository -> API Client
+                              OR
+                           resource route in routes/ressources/)
 ```
 
-- **Loaders/Actions**: Server-side, access repositories via middleware context
-- **Query Hooks**: Client-side, fetch from Remix resource routes (`ressources+/`)
-- **Repositories**: Abstract API calls, transform DTOs with adapters
+- **Route loaders**: server-side, inline `createServerFn` chains, passed via `createFileRoute({ loader })`, accessed in components via `Route.useLoaderData()`
+- **Server functions** (`server-fns/{domain}.ts`): server-side handlers called from React Query (mutations, on-demand fetches)
+- **Resource file routes** (`routes/ressources/...`): for downloads, streams, anything returning a raw `Response`
+- **Repositories**: abstract API calls, transform DTOs with adapters
 
 ---
 
-## Loaders
-
-### With createServerFn + Middleware (preferred for new code)
+## Route Loaders
 
 ```typescript
-import { createServerFn } from '@app-builder/core/requests';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
+import { createFileRoute } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
 
-export const loader = createServerFn(
-  [authMiddleware],
-  async function casesLoader({ request, context }) {
+const casesLoader = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
     const { user, entitlements, inbox: inboxRepository } = context.authInfo;
     const inboxes = await inboxRepository.listInboxesMetadata();
 
@@ -36,101 +38,85 @@ export const loader = createServerFn(
       inboxes,
       entitlements: { autoAssignment: entitlements.autoAssignment },
     };
-  },
-);
+  });
+
+export const Route = createFileRoute('/_app/_builder/cases/')({
+  loader: () => casesLoader(),
+  component: CasesPage,
+});
 ```
 
 Key points:
+- Chain syntax: `createServerFn().middleware([...]).handler(async ({ context }) => {...})`
 - `context.authInfo` provides authenticated user, repositories, entitlements
-- `context.services` provides toastSessionService, i18nextService, etc.
-- Middleware chain builds context: `[handleRedirectMiddleware, authMiddleware]`
-
-### Plain Remix Loader (legacy pattern, still common)
-
-```typescript
-import { type LoaderFunctionArgs } from '@remix-run/node';
-import { initServerServices } from '@app-builder/services/init.server';
-
-export async function loader({ request }: LoaderFunctionArgs) {
-  const { authService } = initServerServices(request);
-  const { inbox } = await authService.isAuthenticated(request, {
-    failureRedirect: getRoute('/sign-in'),
-  });
-
-  const inboxes = await inbox.listInboxesMetadata();
-  return Response.json(inboxes);
-}
-```
+- `context.services` provides `toastSessionService`, `i18nextService`, `authService`
+- Need the raw request? `import { getRequest } from '@tanstack/react-start/server'` then call `getRequest()` inside the handler
+- `authMiddleware` already handles auth redirects (throws `redirect()` from `@tanstack/react-router`) — no separate `handleRedirectMiddleware`
 
 ---
 
-## Actions
+## Server Functions (mutations & on-demand fetches)
 
-### With createServerFn + Middleware + Toast
+Server functions live in `packages/app-builder/src/server-fns/{domain}.ts` and are called by React Query hooks.
 
 ```typescript
-import { createServerFn, data } from '@app-builder/core/requests';
+// server-fns/lists.ts
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
-import { handleRedirectMiddleware } from '@app-builder/middlewares/handle-redirect-middleware';
-import { setToastMessage } from '@app-builder/components/MarbleToaster';
+import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
+import { redirect } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { setResponseHeaders } from '@tanstack/react-start/server';
 import { z } from 'zod/v4';
 
-export const action = createServerFn(
-  [handleRedirectMiddleware, authMiddleware],
-  async function createListAction({ request, context }) {
+const createListPayloadSchema = z.object({ name: z.string().min(1) });
+
+export const createListFn = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(createListPayloadSchema)
+  .handler(async ({ context, data }) => {
     const { toastSessionService } = context.services;
-    const toastSession = await toastSessionService.getSession(request);
-    const rawPayload = await request.json();
-
-    const payload = createListPayloadSchema.safeParse(rawPayload);
-    if (!payload.success) {
-      return { success: false, errors: z.treeifyError(payload.error) };
-    }
-
     try {
-      const result = await context.authInfo.customListsRepository.createCustomList(payload.data);
-      return redirect(
-        getRoute('/detection/lists/:listId', { listId: fromUUIDtoSUUID(result.id) }),
-      );
-    } catch (error) {
-      setToastMessage(toastSession, {
-        type: 'error',
-        messageKey: isStatusConflictHttpError(error)
-          ? 'common:errors.list.duplicate_list_name'
-          : 'common:errors.unknown',
+      const result = await context.authInfo.customListsRepository.createCustomList(data);
+      throw redirect({
+        href: `/detection/lists/${fromUUIDtoSUUID(result.id)}`,
       });
-
-      return data({ success: false, errors: [] }, [
-        ['Set-Cookie', await toastSessionService.commitSession(toastSession)],
-      ]);
+    } catch (error) {
+      if (isStatusConflictHttpError(error)) {
+        const toastSession = await toastSessionService.getSession();
+        setToastMessage(toastSession, {
+          type: 'error',
+          messageKey: 'common:errors.list.duplicate_list_name',
+        });
+        setResponseHeaders(
+          new Headers({
+            'Set-Cookie': await toastSessionService.commitSession(toastSession),
+          }),
+        );
+        return { success: false, errors: [] };
+      }
+      throw error;
     }
-  },
-);
+  });
 ```
 
 Key points:
-- `data(payload, headers)` returns data with custom headers (e.g., Set-Cookie)
-- `setToastMessage()` flashes a toast into the session
-- `z.treeifyError()` converts Zod errors to a structured tree
-- Common middleware stack: `[handleRedirectMiddleware, authMiddleware]`
+- `.inputValidator(schema)` validates `data` on the server before the handler runs; the handler receives `{ context, data }` where `data` is the parsed result
+- `redirect()` from `@tanstack/react-router` is thrown (not returned) to trigger navigation
+- `setResponseHeaders(new Headers({ ... }))` from `@tanstack/react-start/server` sets headers like `Set-Cookie` — there is no `data()` helper
+- For Set-Cookie patterns, set the header then return a plain object
+- Call from the client: `createListFn({ data: { name: 'My List' } })`
 
-### Plain Remix Action (simpler cases)
+### Calling from React Query
 
 ```typescript
-import { type ActionFunctionArgs } from '@remix-run/node';
+import { useMutation } from '@tanstack/react-query';
+import { createListFn } from '@app-builder/server-fns/lists';
 
-export async function action({ request }: ActionFunctionArgs) {
-  const { authService } = initServerServices(request);
-  const [raw, { cases }] = await Promise.all([
-    request.json(),
-    authService.isAuthenticated(request, { failureRedirect: getRoute('/sign-in') }),
-  ]);
-
-  const { success, data, error } = editNamePayloadSchema.safeParse(raw);
-  if (!success) return { success: false, errors: z.treeifyError(error) };
-
-  await cases.updateCase({ caseId: data.caseId, body: { name: data.name } });
-  return { success: true, errors: [] };
+export function useCreateListMutation() {
+  return useMutation({
+    mutationKey: ['lists', 'create'],
+    mutationFn: (payload: { name: string }) => createListFn({ data: payload }),
+  });
 }
 ```
 
@@ -138,25 +124,19 @@ export async function action({ request }: ActionFunctionArgs) {
 
 ## Query Hooks
 
-One file per query in `queries/{domain}/`. Queries fetch from resource routes.
+One file per query in `queries/{domain}/`. Queries call server functions directly, or fetch from resource file routes for downloads.
 
-### Basic Query
+### Basic Query (server function)
 
 ```typescript
 // queries/scenarios/scenario-iteration-rules.ts
+import { getScenarioIterationRulesFn } from '@app-builder/server-fns/scenarios';
 import { useQuery } from '@tanstack/react-query';
-import { getRoute } from '@app-builder/utils/routes';
-
-const endpoint = (id: string) =>
-  getRoute('/ressources/scenarios/:scenarioIterationId/rules', { scenarioIterationId: id });
 
 export function useScenarioIterationRules(scenarioIterationId: string) {
   return useQuery({
     queryKey: ['scenario-iteration-rules', scenarioIterationId],
-    queryFn: async () => {
-      const response = await fetch(endpoint(scenarioIterationId));
-      return response.json() as Promise<{ rules: ScenarioIterationRule[] }>;
-    },
+    queryFn: () => getScenarioIterationRulesFn({ data: { scenarioIterationId } }),
   });
 }
 ```
@@ -165,6 +145,7 @@ export function useScenarioIterationRules(scenarioIterationId: string) {
 
 ```typescript
 // queries/cases/get-cases.ts
+import { getCasesFn } from '@app-builder/server-fns/cases';
 import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
 
 export function useGetCasesQuery(
@@ -175,14 +156,8 @@ export function useGetCasesQuery(
 ) {
   return useInfiniteQuery({
     queryKey: ['cases', 'get-cases', inboxId, filters, limit, order],
-    queryFn: async ({ pageParam }) => {
-      const qs = QueryString.stringify(
-        { ...filters, offsetId: pageParam, limit, order },
-        { skipNulls: true, addQueryPrefix: true },
-      );
-      const response = await fetch(endpoint(inboxId, qs));
-      return response.json() as Promise<PaginatedResponse<Case>>;
-    },
+    queryFn: ({ pageParam }) =>
+      getCasesFn({ data: { inboxId, filters, limit, order, offsetId: pageParam } }),
     initialPageParam: null as string | null,
     getNextPageParam: (page) =>
       page?.hasNextPage ? page.items[page.items.length - 1]?.id : null,
@@ -197,6 +172,7 @@ export function useGetCasesQuery(
 
 ```typescript
 // queries/cases/edit-name.ts
+import { editCaseNameFn } from '@app-builder/server-fns/cases';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod/v4';
 
@@ -211,13 +187,7 @@ export function useEditNameMutation() {
 
   return useMutation({
     mutationKey: ['cases', 'edit-name'],
-    mutationFn: async (payload: EditNamePayload) => {
-      const response = await fetch(endpoint, {
-        method: 'PATCH',
-        body: JSON.stringify(payload),
-      });
-      return response.json();
-    },
+    mutationFn: (payload: EditNamePayload) => editCaseNameFn({ data: payload }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cases'] });
     },
@@ -227,22 +197,16 @@ export function useEditNameMutation() {
 
 ### Mutation with Navigation
 
-Some mutations redirect based on server response:
-
 ```typescript
+import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
+
 export function useCreateScenarioMutation() {
   const navigate = useAgnosticNavigation();
 
   return useMutation({
-    mutationFn: async (data: CreateScenarioPayload) => {
-      const response = await fetch(endpoint, { method: 'POST', body: JSON.stringify(data) });
-      const result = await response.json();
-
-      if (result.redirectTo) {
-        navigate(result.redirectTo);
-        return;
-      }
-      return result;
+    mutationFn: (data: CreateScenarioPayload) => createScenarioFn({ data }),
+    onSuccess: (result) => {
+      if (result?.redirectTo) navigate(result.redirectTo);
     },
   });
 }
@@ -262,7 +226,6 @@ export interface CaseRepository {
   updateCase(args: { caseId: string; body: CaseUpdateBody }): Promise<CaseDetail>;
 }
 
-// Factory function receives API client
 export function makeGetCaseRepository() {
   return (marbleCoreApiClient: MarbleCoreApi): CaseRepository => ({
     listCases: async ({ dateRange, inboxIds, statuses, ...rest }) => {
@@ -324,6 +287,8 @@ queryClient.invalidateQueries({ queryKey: ['cases'] }); // all case queries
 
 | Middleware | Purpose |
 |-----------|---------|
-| `authMiddleware` | Auth check, provides `context.authInfo` (user, repositories, entitlements) |
-| `handleRedirectMiddleware` | Handles redirects in server functions |
-| `servicesMiddleware` | Provides `context.services` (toast, i18n, auth session) |
+| `authMiddleware` | Auth check, redirects to `/sign-in` on failure; provides `context.authInfo` (user, repositories, entitlements) |
+| `servicesMiddleware` | Provides `context.services` (toastSessionService, i18nextService, authService) |
+| `caseDetailMiddleware` | Adds case-detail context for case-scoped server functions |
+
+Compose middleware via the chain: `createServerFn().middleware([servicesMiddleware, authMiddleware]).handler(...)`. `authMiddleware` already includes `servicesMiddleware` internally, so most handlers only need `[authMiddleware]`.

--- a/.claude/skills/frontend-dev-guidelines/resources/data-fetching.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/data-fetching.md
@@ -6,7 +6,7 @@ Data fetching architecture in TanStack Start: route loaders, server functions, q
 
 ## Architecture
 
-```
+```text
 Route loader (createServerFn)        -> Repository -> API Client     (SSR data for page render)
 Component -> Query Hook -> fetch(    -> server-fn (createServerFn)    -> Repository -> API Client
                               OR
@@ -151,10 +151,15 @@ export function useGetCasesQuery(
 
 ## Mutations
 
+Mutation hooks live in `queries/{domain}/`. They wrap a server function with `useMutation`, invalidate queries in `onSuccess`, and surface user feedback via `react-hot-toast` in `onSuccess` / `onError` (see [common-patterns#toast-notifications](common-patterns.md#toast-notifications)).
+
 ```typescript
 // queries/cases/edit-name.ts
 import { editCaseNameFn } from '@app-builder/server-fns/cases';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import { z } from 'zod/v4';
 
 export const editNamePayloadSchema = z.object({
@@ -164,17 +169,30 @@ export const editNamePayloadSchema = z.object({
 type EditNamePayload = z.infer<typeof editNamePayloadSchema>;
 
 export function useEditNameMutation() {
+  const editCaseName = useServerFn(editCaseNameFn);
   const queryClient = useQueryClient();
+  const { t } = useTranslation(['common']);
 
   return useMutation({
     mutationKey: ['cases', 'edit-name'],
-    mutationFn: (payload: EditNamePayload) => editCaseNameFn({ data: payload }),
+    mutationFn: (payload: EditNamePayload) => editCaseName({ data: payload }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cases'] });
+      toast.success(t('common:success.save'));
+    },
+    onError: (error) => {
+      // Use error.message when the server function throws a typed/translated message
+      // Fall back to a generic key for unexpected failures
+      toast.error(error.message ?? t('common:errors.unknown'));
     },
   });
 }
 ```
+
+Key points:
+- Wrap the server function with `useServerFn` so client-side middleware (request context, headers) runs correctly
+- Invalidate the broadest relevant query prefix in `onSuccess` to refresh derived UI
+- For error messages with i18n keys, throw a translated string from the server function and re-display it client-side, or branch on the error in `onError` to pick a specific i18n key
 
 ### Mutation with Navigation
 

--- a/.claude/skills/frontend-dev-guidelines/resources/file-organization.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/file-organization.md
@@ -8,7 +8,8 @@ Layered architecture and naming conventions for the Marble app-builder.
 
 ```
 packages/app-builder/src/
-  routes/            # Remix routes (flat structure with + folders)
+  routes/            # TanStack Router file-based routes (_app/, ressources/)
+  server-fns/        # createServerFn handlers called via React Query
   components/        # App-specific UI components (by domain)
   queries/           # TanStack Query hooks (one file per query)
   repositories/      # Data access layer (interfaces + factory functions)
@@ -21,8 +22,7 @@ packages/app-builder/src/
   types/             # TypeScript types
   constants/         # Constants
   locales/           # i18n translations (en/, fr/, ar/)
-  middlewares/       # Server middleware (auth, redirect)
-  core/              # Framework core (requests, middleware types)
+  middlewares/       # Server middleware (auth, services, case detail)
 ```
 
 ---
@@ -31,15 +31,16 @@ packages/app-builder/src/
 
 | Layer | Purpose | Example |
 |-------|---------|---------|
-| **routes/** | Remix routes, loaders, actions | `_builder+/cases+/$caseId+/_index.tsx` |
+| **routes/** | TanStack Router file-based routes + inline loaders | `_app/_builder/cases.$caseId.tsx` |
+| **server-fns/** | `createServerFn` handlers called via React Query | `cases.ts`, `lists.ts`, `auth.ts` |
 | **components/** | UI components grouped by domain | `Cases/CaseDetails.tsx`, `AstBuilder/Root.tsx` |
 | **queries/** | TanStack Query hooks (one per file) | `cases/get-cases.ts`, `cases/edit-name.ts` |
 | **repositories/** | API call abstraction + DTO transforms | `CaseRepository.ts` (interface + factory) |
 | **services/** | Business logic | `init.server.ts` (service initialization) |
 | **models/** | Types + adapters | `cases.ts` (Case interface + adaptCase) |
-| **middlewares/** | Server middleware | `auth-middleware.ts`, `handle-redirect-middleware.ts` |
+| **middlewares/** | Server middleware | `auth-middleware.ts`, `services-middleware.ts`, `case-detail-middleware.ts` |
 
-Data flows: `routes -> components -> queries -> fetch(resource routes) -> repositories -> API`
+Data flows: `route loaders -> repositories -> API` for SSR data; `components -> query hooks -> server-fns (or resource routes) -> repositories -> API` for on-demand data and mutations.
 
 ---
 
@@ -131,7 +132,7 @@ models/
 | Repositories | PascalCase.ts | `CaseRepository.ts` |
 | Models | kebab-case.ts | `cases.ts` |
 | Hooks | camelCase.ts | `useCurrentUser.ts` |
-| Routes | Remix convention | `_builder+/cases+/$caseId+/_index.tsx` |
+| Routes | TanStack Router convention | `_app/_builder/cases.$caseId.tsx` |
 | Schemas | kebab-case.ts | `lists.ts` |
 | Server utils | `.server.ts` suffix | `update-rule.server.ts` |
 

--- a/.claude/skills/frontend-dev-guidelines/resources/routing-guide.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/routing-guide.md
@@ -16,9 +16,16 @@ packages/app-builder/src/routes/
 │   ├── _builder.tsx                 # Main builder layout (sidebar, nav)
 │   ├── _builder/
 │   │   ├── cases.tsx                # /cases layout
-│   │   ├── cases.$caseId.tsx        # /cases/:caseId
-│   │   ├── detection.lists.tsx      # /detection/lists
-│   │   └── settings.api-keys.tsx    # /settings/api-keys
+│   │   ├── cases/
+│   │   │   ├── index.tsx            # /cases
+│   │   │   ├── $caseId.tsx          # /cases/:caseId
+│   │   │   └── inboxes.$inboxId.tsx # /cases/inboxes/:inboxId
+│   │   ├── detection.tsx            # /detection layout
+│   │   ├── detection/
+│   │   │   └── lists.tsx            # /detection/lists
+│   │   ├── settings.tsx             # /settings layout
+│   │   └── settings/
+│   │       └── api-keys.tsx         # /settings/api-keys
 │   ├── _auth.tsx                    # Auth layout
 │   └── _auth/
 │       ├── sign-in.tsx              # /sign-in
@@ -37,8 +44,10 @@ Mutation endpoints called via React Query live in `packages/app-builder/src/serv
 | Pattern | Meaning | Example |
 |---------|---------|---------|
 | `_name.tsx` | Layout route (renders `<Outlet />` for children) | `_app.tsx`, `_builder.tsx` |
-| `$param` | Dynamic segment | `cases.$caseId.tsx` → `/cases/:caseId` |
-| `dot.separated.tsx` | Nested URL path under the parent layout | `detection.lists.tsx` → `/detection/lists` |
+| `$param` | Dynamic segment | `cases/$caseId.tsx` → `/cases/:caseId` |
+| `parent/child.tsx` | Subdirectory nesting under a parent layout | `detection/lists.tsx` → `/detection/lists` |
+| `dot.separated.tsx` | Combine static + dynamic segments in one filename | `cases/inboxes.$inboxId.tsx` → `/cases/inboxes/:inboxId` |
+| `name_.tsx` (trailing underscore) | Break out of the parent layout while keeping the URL | `settings/webhooks_.$webhookId.tsx` |
 | `index.tsx` | Index route at parent's path | `_app/_builder/index.tsx` |
 | `$.tsx` | Catch-all splat route | `$.tsx` for 404 |
 | `.server.ts` | Pure server utility (not a route, no `createFileRoute`) | `update-rule.server.ts` |

--- a/.claude/skills/frontend-dev-guidelines/resources/routing-guide.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/routing-guide.md
@@ -6,7 +6,7 @@ TanStack Router file-based routing patterns used in the Marble app. Routes are a
 
 ## Route Structure
 
-```
+```text
 packages/app-builder/src/routes/
 ├── __root.tsx                       # Root route (createRootRouteWithContext)
 ├── index.tsx                        # /

--- a/.claude/skills/frontend-dev-guidelines/resources/routing-guide.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/routing-guide.md
@@ -1,6 +1,6 @@
 # Routing Guide
 
-Remix flat file routing patterns used in the Marble app.
+TanStack Router file-based routing patterns used in the Marble app. Routes are auto-discovered by the TanStack Router Vite plugin and types are generated into `routeTree.gen.ts`.
 
 ---
 
@@ -8,83 +8,78 @@ Remix flat file routing patterns used in the Marble app.
 
 ```
 packages/app-builder/src/routes/
-├── _index.tsx                          # Root redirect
-├── _auth+/                             # Auth layout segment
-│   ├── _layout.tsx                     # Auth layout wrapper
-│   ├── sign-in.tsx                     # /sign-in
-│   └── create-password.tsx             # /create-password
-├── _builder+/                          # Main app layout segment
-│   ├── _layout.tsx                     # App layout (sidebar, nav)
-│   ├── cases+/                         # /cases
-│   │   ├── _layout.tsx
-│   │   ├── $caseId+/                   # /cases/:caseId
-│   │   │   ├── _index.tsx
-│   │   │   └── d+/$decisionId+/...    # Nested dynamic segments
-│   │   └── overview.tsx
-│   ├── detection+/                     # /detection
-│   │   └── lists+/
-│   │       ├── _index.tsx              # /detection/lists
-│   │       └── $listId.tsx             # /detection/lists/:listId
-│   └── settings+/                      # /settings
-└── ressources+/                        # Server-only resource routes
-    ├── cases+/
-    │   ├── edit-name.tsx               # POST /ressources/cases/edit-name
-    │   └── $caseId.next-unassigned.tsx
-    ├── lists+/
-    │   ├── create.tsx                  # POST /ressources/lists/create
-    │   └── delete.tsx
-    └── workflows+/
-        └── rule+/$ruleId+/
-            ├── rename.ts
-            └── update-rule.server.ts   # Pure server utility (not a route)
+├── __root.tsx                       # Root route (createRootRouteWithContext)
+├── index.tsx                        # /
+├── $.tsx                            # Catch-all (404)
+├── _app.tsx                         # Authenticated app layout
+├── _app/
+│   ├── _builder.tsx                 # Main builder layout (sidebar, nav)
+│   ├── _builder/
+│   │   ├── cases.tsx                # /cases layout
+│   │   ├── cases.$caseId.tsx        # /cases/:caseId
+│   │   ├── detection.lists.tsx      # /detection/lists
+│   │   └── settings.api-keys.tsx    # /settings/api-keys
+│   ├── _auth.tsx                    # Auth layout
+│   └── _auth/
+│       ├── sign-in.tsx              # /sign-in
+│       └── create-password.tsx      # /create-password
+└── ressources/                      # Resource file routes (downloads, streams)
+    ├── lists/
+    │   └── download-csv-file.$listId.ts
+    └── cases/
+        └── download-file.$fileId.ts
 ```
+
+Mutation endpoints called via React Query live in `packages/app-builder/src/server-fns/` (not in `routes/`). See [data-fetching.md](data-fetching.md).
 
 ## Naming Conventions
 
 | Pattern | Meaning | Example |
 |---------|---------|---------|
-| `+/` | Segment folder (layout nesting) | `cases+/` |
-| `_layout.tsx` | Layout component (wraps children with `<Outlet />`) | `_builder+/_layout.tsx` |
-| `_index.tsx` | Index route (default child) | `cases+/_index.tsx` |
-| `$param` | Dynamic segment | `$caseId+/` |
-| `_prefix` | Pathless layout (groups routes without URL segment) | `_builder+/`, `_auth+/` |
-| `.server.ts` | Pure server utility (not a route, no route exports) | `update-rule.server.ts` |
-| `ressources+/` | Resource routes (API-like, no UI) | `ressources+/cases+/edit-name.tsx` |
+| `_name.tsx` | Layout route (renders `<Outlet />` for children) | `_app.tsx`, `_builder.tsx` |
+| `$param` | Dynamic segment | `cases.$caseId.tsx` → `/cases/:caseId` |
+| `dot.separated.tsx` | Nested URL path under the parent layout | `detection.lists.tsx` → `/detection/lists` |
+| `index.tsx` | Index route at parent's path | `_app/_builder/index.tsx` |
+| `$.tsx` | Catch-all splat route | `$.tsx` for 404 |
+| `.server.ts` | Pure server utility (not a route, no `createFileRoute`) | `update-rule.server.ts` |
+| `ressources/...` | Resource file routes (API-like, returns `Response`) | `ressources/lists/download-csv-file.$listId.ts` |
 
 ---
 
 ## Breadcrumbs
 
-Routes define breadcrumbs via the `handle` export:
+Routes declare breadcrumbs via `staticData.BreadCrumbs` inside `createFileRoute`:
 
 ```typescript
-import { type BreadCrumbProps, BreadCrumbLink } from '@app-builder/components/Breadcrumbs';
-import { getRoute } from '@app-builder/utils/routes';
-import { type Namespace } from 'i18next';
+import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
+import { createFileRoute } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { Icon } from 'ui-icons';
 
-export const handle = {
-  i18n: ['navigation'] satisfies Namespace,
-  BreadCrumbs: [
-    ({ isLast }: BreadCrumbProps) => {
-      const { t } = useTranslation(['navigation']);
-      return (
-        <BreadCrumbLink to={getRoute('/cases')} isLast={isLast}>
-          <Icon icon="case-manager" className="me-2 size-6" />
-          {t('navigation:case_manager')}
-        </BreadCrumbLink>
-      );
-    },
-  ],
-};
+export const Route = createFileRoute('/_app/_builder/cases')({
+  staticData: {
+    BreadCrumbs: [
+      ({ isLast }: BreadCrumbProps) => {
+        const { t } = useTranslation(['navigation']);
+        return (
+          <BreadCrumbLink to="/cases" isLast={isLast}>
+            <Icon icon="case-manager" className="me-2 size-6" />
+            {t('navigation:case_manager')}
+          </BreadCrumbLink>
+        );
+      },
+    ],
+  },
+  loader: () => casesLayoutLoader(),
+  component: CasesLayout,
+});
 ```
 
 Key points:
-- `handle.BreadCrumbs` is an array of React render functions
-- Each receives `{ isLast: boolean; data: any }` (data = loader data)
-- `handle.i18n` declares which namespaces the route needs
-- The `Breadcrumbs` component uses `useMatches()` to collect all breadcrumbs from parent routes
+- `staticData.BreadCrumbs` is an array of React render functions
+- Each receives `{ isLast: boolean }`
+- The `Breadcrumbs` component walks the matched routes and collects each route's `staticData.BreadCrumbs`
+- i18n namespaces are declared **per-component** via `useTranslation([...])` — no longer in a `handle` export
 
 ---
 
@@ -103,14 +98,13 @@ getRoute('/cases/:caseId', { caseId: fromUUIDtoSUUID(caseDetail.id) })
 getRoute('/detection/lists/:listId', { listId: fromUUIDtoSUUID(id) })
 
 // Resource routes
-getRoute('/ressources/lists/create')
-getRoute('/ressources/cases/:caseId/events', { caseId })
+getRoute('/ressources/lists/download-csv-file/:listId', { listId })
 ```
 
 ### Link Component
 
 ```typescript
-import { Link } from '@remix-run/react';
+import { Link } from '@tanstack/react-router';
 
 <Link to={getRoute('/cases/:caseId', { caseId: id })}>
   View Case
@@ -127,64 +121,90 @@ navigate(getRoute('/cases'));
 navigate(result.redirectTo); // from server response
 ```
 
-`useAgnosticNavigation` is preferred over Remix's `useNavigate` for SSR compatibility.
+`useAgnosticNavigation` wraps TanStack Router's navigation hook and is preferred across the codebase for consistent SSR/CSR behavior.
 
 ---
 
 ## Route Template
 
 ```typescript
-// routes/_builder+/cases+/_index.tsx
-import { createServerFn } from '@app-builder/core/requests';
+// routes/_app/_builder/cases.tsx
+import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
-import { useLoaderData } from '@remix-run/react';
-import { type Namespace } from 'i18next';
+import { DataModelContextProvider } from '@app-builder/services/data/data-model';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
 import { useTranslation } from 'react-i18next';
+import { Icon } from 'ui-icons';
 
-export const handle = {
-  i18n: ['common', 'cases'] satisfies Namespace,
-  BreadCrumbs: [
-    ({ isLast }: BreadCrumbProps) => {
-      const { t } = useTranslation(['navigation']);
-      return (
-        <BreadCrumbLink to={getRoute('/cases')} isLast={isLast}>
-          {t('navigation:cases')}
-        </BreadCrumbLink>
-      );
-    },
-  ],
-};
+const casesLayoutLoader = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    const { dataModelRepository } = context.authInfo;
+    const dataModel = await dataModelRepository.getDataModel();
+    return { dataModel };
+  });
 
-export const loader = createServerFn(
-  [authMiddleware],
-  async function casesLoader({ request, context }) {
-    const inboxes = await context.authInfo.inbox.listInboxes();
-    return { inboxes };
+export const Route = createFileRoute('/_app/_builder/cases')({
+  staticData: {
+    BreadCrumbs: [
+      ({ isLast }: BreadCrumbProps) => {
+        const { t } = useTranslation(['navigation']);
+        return (
+          <BreadCrumbLink to="/cases" isLast={isLast}>
+            <Icon icon="case-manager" className="me-2 size-6" />
+            {t('navigation:case_manager')}
+          </BreadCrumbLink>
+        );
+      },
+    ],
   },
-);
+  loader: () => casesLayoutLoader(),
+  component: CasesLayout,
+});
 
-export default function CasesPage() {
-  const { inboxes } = useLoaderData<typeof loader>();
-  const { t } = useTranslation(['cases']);
-
-  return <CasesList inboxes={inboxes} />;
+function CasesLayout() {
+  const { dataModel } = Route.useLoaderData();
+  return (
+    <DataModelContextProvider dataModel={dataModel}>
+      <Outlet />
+    </DataModelContextProvider>
+  );
 }
 ```
+
+Key points:
+- Loaders are defined as `createServerFn` chains and passed via the `loader` option
+- `Route.useLoaderData()` reads loader data inside the component
+- `authMiddleware` provides `context.authInfo` (repositories, user, entitlements) — no separate redirect middleware needed; auth redirects are handled inside `authMiddleware`
 
 ---
 
-## Resource Routes
+## Resource File Routes
 
-Server-only routes that return data (no UI component):
+For downloads, streams, or file-typed responses, use `createFileRoute(...)({ server: { handlers: { ... } } })`:
 
 ```typescript
-// routes/ressources+/cases+/edit-name.tsx
-export async function action({ request }: ActionFunctionArgs) {
-  // ... validate and process
-  return { success: true, errors: [] };
-}
+// routes/ressources/lists/download-csv-file.$listId.ts
+import { fromParams } from '@app-builder/utils/short-uuid';
+import { createFileRoute } from '@tanstack/react-router';
 
-// No default export - this is a resource route
+export const Route = createFileRoute('/ressources/lists/download-csv-file/$listId')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        // ... auth, fetch, etc.
+        const listId = fromParams(params, 'listId');
+        return new Response(fileContents, {
+          headers: {
+            'Content-Disposition': `attachment; filename="list-${listId}.csv"`,
+            'Content-Type': 'text/csv',
+          },
+        });
+      },
+    },
+  },
+});
 ```
 
-Client queries fetch from these routes via `fetch(getRoute('/ressources/...'))`.
+For JSON endpoints called from React Query, use `server-fns/` instead (see [data-fetching.md](data-fetching.md)).

--- a/.claude/skills/frontend-dev-guidelines/resources/tables-and-selects.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/tables-and-selects.md
@@ -10,12 +10,12 @@ Tables use TanStack React Table with virtual scrolling via `useVirtualTable` fro
 
 ### Canonical Example
 
-Reference: `routes/_builder+/detection+/lists+/_index.tsx`
+Reference: `routes/_app/_builder/detection.lists.tsx`
 
 ```typescript
 import { createColumnHelper, getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
 import { Table, useVirtualTable } from 'ui-design-system';
-import { Link } from '@remix-run/react';
+import { Link } from '@tanstack/react-router';
 
 const columnHelper = createColumnHelper<CustomList>();
 

--- a/.claude/skills/frontend-dev-guidelines/resources/tables-and-selects.md
+++ b/.claude/skills/frontend-dev-guidelines/resources/tables-and-selects.md
@@ -10,7 +10,7 @@ Tables use TanStack React Table with virtual scrolling via `useVirtualTable` fro
 
 ### Canonical Example
 
-Reference: `routes/_app/_builder/detection.lists.tsx`
+Reference: `routes/_app/_builder/detection/lists.tsx`
 
 ```typescript
 import { createColumnHelper, getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ cd packages/app-builder && bun run generate-routes
 
 ```
 packages/
-  app-builder/         # Main Remix application (routes, components, queries)
+  app-builder/         # Main TanStack Start application (routes, components, queries, server-fns)
   backoffice/          # Backoffice application
   ui-design-system/    # Reusable UI components (Button, Modal, Select, etc.)
   ui-icons/            # Icon components
@@ -43,7 +43,8 @@ packages/
 ## Tech Stack
 
 - **Bun** - Package manager and runtime
-- **Remix** - Full-stack React framework
+- **TanStack Start** - SSR React framework (Vite + Nitro)
+- **TanStack Router** - File-based routing
 - **React 18** - UI library
 - **Radix UI** - Headless UI primitives
 - **Tailwind CSS 4** - Styling
@@ -56,10 +57,10 @@ packages/
 
 ```
 packages/app-builder/src/
-  routes/           # Remix flat routes (_builder+, _auth+, ressources+)
+  routes/           # TanStack Router file-based routes (_app/, ressources/)
+  server-fns/       # createServerFn handlers called via React Query (auth, cases, etc.)
   components/       # Feature components (Cases/, Decisions/, etc.)
-  core/             # createServerFn, data(), request utilities
-  middlewares/      # authMiddleware, handleRedirectMiddleware
+  middlewares/      # authMiddleware, servicesMiddleware, caseDetailMiddleware
   contexts/         # React contexts
   queries/          # TanStack Query hooks (one file per query)
   repositories/     # Data access layer
@@ -88,9 +89,10 @@ import { match } from 'ts-pattern';
 ```
 
 ### Routes
-- Flat routes with `+` folders: `_builder+/cases+/$caseId.tsx`
-- Use `handle` for breadcrumbs
-- Loaders for data fetching
+- File-based routing: `_app/_builder/cases.$caseId.tsx` (underscore prefix = layout route, `$param` = dynamic segment, dot-separated filename = nested URL path)
+- Define routes with `createFileRoute('/_app/_builder/cases')({ staticData, loader, component })`
+- Use `staticData.BreadCrumbs` (array of render functions) for breadcrumbs
+- Loaders: inline `createServerFn().middleware([authMiddleware]).handler(...)` passed to the route's `loader` option
 
 ## Task Management
 


### PR DESCRIPTION
Sync project docs to reflect the Remix → TanStack Start migration: imports come from @tanstack/react-start and @tanstack/react-router, createServerFn uses the chain syntax (.middleware().handler()), routes use createFileRoute with staticData.BreadCrumbs, mutations live in server-fns/, and handleRedirectMiddleware / core/requests.ts / Remix flat-route conventions are removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer and architecture docs to reflect a migration to a new routing/server-functions model and revised file organization.
  * Clarified loader/server-function patterns and React Query usage for data fetching.
  * Changed breadcrumb and i18n handling to component-driven approaches.
  * Clarified that toasts are client-side only and removed server-side flash guidance.

---

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1531)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->