### PR TITLE
fix: missing familyRelative field in screening

### DIFF
--- a/packages/app-builder/src/components/Screenings/MatchCard/Associations.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/Associations.tsx
@@ -31,12 +31,13 @@ export const Associations = ({ associations }: { associations: AssociationEntity
                 </div>
                 <div className="flex flex-row items-start gap-2 rounded-sm p-2 bg-surface-card">
                   <div className="flex flex-col gap-2">
-                    <div className="col-span-full flex w-full flex-wrap gap-1">
-                      <span>
-                        {properties.firstName?.slice(0, 3).join(' ')} {properties['secondName']?.[0]}
-                      </span>
-                      <span className="font-semibold">{properties.lastName?.slice(0, 3).join(' ') ?? 'unknown'}</span>
-                    </div>
+                    {properties.caption?.length > 0 ? (
+                      <div className="text-sm text-grey-70 font-medium">{properties.caption}</div>
+                    ) : (
+                      <div className="col-span-full flex w-full flex-wrap gap-1">
+                        <span>{properties.alias?.[0] ?? properties.name?.[0]}</span>
+                      </div>
+                    )}
                     <div className="text-sm text-grey-70 font-medium">{rel}</div>
                     <div className="col-span-full flex w-full flex-wrap gap-1">
                       {properties.topics?.map((topic: string) => (

--- a/packages/app-builder/src/components/Screenings/MatchCard/FamilyDetail.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/FamilyDetail.tsx
@@ -1,11 +1,21 @@
-import { FamilyPersonEntity } from '@app-builder/models/screening';
+import { FamilyPersonEntity, FamilyRelativeEntity, PersonEntity } from '@app-builder/models/screening';
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Collapsible } from 'ui-design-system';
 import { TopicTag } from '../TopicTag';
 
-export const FamilyDetail = ({ familyMembers }: { familyMembers: FamilyPersonEntity[] }) => {
+export type RelationType = 'familyPerson' | 'familyRelative';
+export type RelationEntity<T extends RelationType> = T extends 'familyPerson'
+  ? FamilyPersonEntity[]
+  : FamilyRelativeEntity[];
+
+export type FamilyDetailProps<T extends RelationType> = {
+  relation: T;
+  familyMembers: RelationEntity<T>;
+};
+
+export function FamilyDetail<T extends RelationType>({ familyMembers, relation }: FamilyDetailProps<T>) {
   const formatDateTime = useFormatDateTime();
 
   const { t } = useTranslation(['screenings']);
@@ -20,7 +30,9 @@ export const FamilyDetail = ({ familyMembers }: { familyMembers: FamilyPersonEnt
         <Collapsible.Content>
           <div className="flex flex-col gap-2">
             {familyMembers.map((member, memberIndex) => {
-              return member.properties.relative?.map(({ id, properties }, idx) => {
+              const entities = member.properties[relation === 'familyPerson' ? 'relative' : 'person'] as PersonEntity[];
+
+              return entities?.map(({ id, properties }, idx) => {
                 if (!properties.name?.[0]) return null;
                 const rel =
                   member.properties.relationship
@@ -39,12 +51,7 @@ export const FamilyDetail = ({ familyMembers }: { familyMembers: FamilyPersonEnt
                           <div className="text-sm text-grey-70 font-medium">{properties.caption}</div>
                         ) : (
                           <div className="col-span-full flex w-full flex-wrap gap-1">
-                            <span>
-                              {properties.firstName?.slice(0, 3).join(' ')} {properties['secondName']?.[0]}
-                            </span>
-                            <span className="font-semibold">
-                              {properties.lastName?.slice(0, 3).join(' ') ?? 'unknown'}
-                            </span>
+                            <span>{properties.alias?.[0] ?? properties.name?.[0]}</span>
                           </div>
                         )}
                         <div className="text-sm text-grey-70 font-medium">
@@ -79,4 +86,4 @@ export const FamilyDetail = ({ familyMembers }: { familyMembers: FamilyPersonEnt
       </Collapsible.Container>
     </div>
   );
-};
+}

--- a/packages/app-builder/src/components/Screenings/MatchDetails.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchDetails.tsx
@@ -96,7 +96,11 @@ export function MatchDetails({ entity, before, highlightText }: MatchDetailsProp
       ) : null}
 
       {entity.schema === 'Person' && entity.properties?.['familyPerson']?.length ? (
-        <FamilyDetail familyMembers={entity.properties['familyPerson']} />
+        <FamilyDetail relation="familyPerson" familyMembers={entity.properties['familyPerson']} />
+      ) : null}
+
+      {entity.schema === 'Person' && entity.properties?.['familyRelative']?.length ? (
+        <FamilyDetail relation="familyRelative" familyMembers={entity.properties['familyRelative']} />
       ) : null}
     </div>
   );

--- a/packages/app-builder/src/models/screening.ts
+++ b/packages/app-builder/src/models/screening.ts
@@ -93,6 +93,18 @@ export type FamilyPersonEntity = OpenSanctionEntity & {
   } & Record<string, string[]>;
 };
 
+export type FamilyRelativeEntity = OpenSanctionEntity & {
+  schema: 'Family';
+  properties: {
+    person?: PersonEntity[];
+    endData?: string[];
+    relative?: string[];
+    sourceUrl?: string[];
+    startDate?: string[];
+    relationship?: string[];
+  } & Record<string, string[]>;
+};
+
 export type AssociationEntity = OpenSanctionEntity & {
   schema: 'Associate';
   target: boolean;
@@ -143,6 +155,7 @@ export type ScreeningMatchPayload = {
   properties: {
     sanctions?: ScreeningSanctionEntity[];
     familyPerson?: FamilyPersonEntity[];
+    familyRelative?: FamilyRelativeEntity[];
     associations?: AssociationEntity[];
     membershipMember?: MembershipMemberEntity[];
   } & Record<string, string[]>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Person labels now prefer captions and aliases over constructed name parts for clearer, more consistent display.

* **New Features**
  * Screening match details now show family-relative relationships alongside family-member relationships, improving family context visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->