### PR TITLE
silence sentry errors on missing topic

### DIFF
--- a/packages/app-builder/src/components/Screenings/TopicTag.tsx
+++ b/packages/app-builder/src/components/Screenings/TopicTag.tsx
@@ -1,5 +1,4 @@
 import { SCREENING_CATEGORY_COLORS, SCREENING_TOPICS_MAP } from '@app-builder/models/screening';
-import * as Sentry from '@sentry/tanstackstart-react';
 import { useTranslation } from 'react-i18next';
 import { Tag } from 'ui-design-system';
 
@@ -8,7 +7,7 @@ export const TopicTag = ({ topic, className }: { topic: string; className?: stri
 
   const category = SCREENING_TOPICS_MAP.get(topic);
   if (!category) {
-    Sentry.captureMessage(`No category found for topic: ${topic}`, 'warning');
+    // Sentry.captureMessage(`No category found for topic: ${topic}`, 'warning');
     console.warn(`No category found for topic: ${topic}`);
     return null;
   }


### PR DESCRIPTION
Until a better PR comes, so we stop getting noise and wasting error budget in staging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal cleanup to the topic tag component; no user-facing changes.
  * Behavior unchanged: topics without a matching category still produce a warning and do not render a tag.
  * Tag appearance and translations remain the same (category colors and localized labels unaffected).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->