### PR TITLE
test(e2e): add cases, list/inbox/tag editing, and decisions filter smokes

### DIFF
--- a/packages/app-builder/src/components/Cases/InboxPage.tsx
+++ b/packages/app-builder/src/components/Cases/InboxPage.tsx
@@ -207,7 +207,13 @@ export const InboxPage = ({
                       }}
                     />
                     <CaseRightPanel.Trigger asChild data={{ inboxId }}>
-                      <Button size="default" variant="primary" appearance="stroked" mode="icon">
+                      <Button
+                        size="default"
+                        variant="primary"
+                        appearance="stroked"
+                        mode="icon"
+                        data-test="create-case-trigger"
+                      >
                         <Icon icon="plus" className="size-4" />
                       </Button>
                     </CaseRightPanel.Trigger>

--- a/packages/app-builder/src/components/Filters/ClearAllFilters.tsx
+++ b/packages/app-builder/src/components/Filters/ClearAllFilters.tsx
@@ -11,7 +11,12 @@ export const ClearAllFiltersLink = forwardRef<HTMLAnchorElement, Omit<RemixLinkP
   function ClearAllFiltersButton(props, ref) {
     const { t } = useTranslation(filtersI18n);
     return (
-      <Link className={clsx(CtaClassName({ variant: 'secondary', color: 'grey' }), 'shrink-0')} ref={ref} {...props}>
+      <Link
+        data-test="clear-all-filters-link"
+        className={clsx(CtaClassName({ variant: 'secondary', color: 'grey' }), 'shrink-0')}
+        ref={ref}
+        {...props}
+      >
         <Icon icon="cross" className="size-5" />
         <span className="line-clamp-1">{t('filters:clear_filters')}</span>
       </Link>

--- a/packages/app-builder/src/components/Filters/FilterPopover.tsx
+++ b/packages/app-builder/src/components/Filters/FilterPopover.tsx
@@ -71,6 +71,7 @@ const FilterItemClear = forwardRef<HTMLButtonElement, ComponentPropsWithoutRef<'
   return (
     <button
       ref={ref}
+      data-test="filter-item-clear"
       className={clsx(
         'focus:border-purple-primary dark:focus:border-purple-hover -ml-1 h-full rounded-sm border border-solid border-transparent px-2 outline-hidden',
         className,

--- a/packages/app-builder/src/routes/_app/_builder/detection/lists/$listId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/lists/$listId.tsx
@@ -110,6 +110,7 @@ function Lists() {
               {listFeatureAccess.isDeleteListValueAvailable ? (
                 <DeleteListValueModal listId={customList.id} listValueId={row.original.id} value={value}>
                   <button
+                    data-test="delete-list-value-trigger"
                     className="group-hover:text-grey-primary text-transparent transition-colors duration-200 ease-in-out"
                     name="delete"
                     tabIndex={-1}

--- a/packages/tests/e2e/cases.spec.ts
+++ b/packages/tests/e2e/cases.spec.ts
@@ -22,10 +22,7 @@ async function setupInbox(page: import('@playwright/test').Page): Promise<{ inbo
 // Returns the case name.
 async function createCase(page: import('@playwright/test').Page, inboxName: string): Promise<string> {
   const caseName = crypto.randomUUID();
-  // CaseRightPanel.Trigger = Radix Dialog.Trigger → aria-haspopup="dialog".
-  // The page has 3 dialog triggers (InboxSelector, AddNewFilter, CreateCase);
-  // only CreateCase has `mode="icon"` which adds Tailwind's `aspect-square`.
-  await page.locator('button[aria-haspopup="dialog"].aspect-square').click();
+  await page.locator('[data-test="create-case-trigger"]').click();
 
   // Scope all form interactions to the right panel (Radix Dialog) — the inbox
   // page also has a top-level inbox filter combobox we'd otherwise collide with.
@@ -50,7 +47,7 @@ test('Cases list page loads', async ({ page }) => {
   await expect(page).toHaveURL(new RegExp(`/cases/inboxes/${inboxId}`));
   // The toolbar chrome must render (search input + the icon-only create-case button)
   await expect(page.getByPlaceholder('Search by name')).toBeVisible();
-  await expect(page.locator('button[aria-haspopup="dialog"].aspect-square')).toBeVisible();
+  await expect(page.locator('[data-test="create-case-trigger"]')).toBeVisible();
 });
 
 test('Create a case', async ({ page }) => {

--- a/packages/tests/e2e/cases.spec.ts
+++ b/packages/tests/e2e/cases.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import crypto from 'crypto';
+import { waitForHydration, waitForThen } from 'tests/common/utils';
+
+// Creates an inbox via settings UI and returns the inbox ID (SUUID from URL).
+async function setupInbox(page: import('@playwright/test').Page): Promise<{ inboxId: string; inboxName: string }> {
+  const inboxName = crypto.randomUUID();
+  await page.goto('/settings/inboxes');
+  await waitForHydration(page);
+  await waitForThen(page, page.getByRole('button', { name: 'Create new inbox' }), async (btn) => await btn.click());
+  const dialog = page.getByRole('dialog');
+  await dialog.waitFor();
+  await dialog.getByRole('textbox').and(dialog.locator('[name="name"]')).fill(inboxName);
+  await dialog.getByRole('button', { name: 'Create new inbox' }).click();
+  await page.waitForURL(/\/settings\/inboxes\/[^/]+$/);
+  const inboxId = page.url().split('/').at(-1) as string;
+  return { inboxId, inboxName };
+}
+
+// Creates a case in the given inbox. After submission the app redirects directly
+// to the case detail page (`/cases/s/:caseId`), so this helper waits for that URL.
+// Returns the case name.
+async function createCase(page: import('@playwright/test').Page, inboxName: string): Promise<string> {
+  const caseName = crypto.randomUUID();
+  // CaseRightPanel.Trigger = Radix Dialog.Trigger → aria-haspopup="dialog".
+  // The page has 3 dialog triggers (InboxSelector, AddNewFilter, CreateCase);
+  // only CreateCase has `mode="icon"` which adds Tailwind's `aspect-square`.
+  await page.locator('button[aria-haspopup="dialog"].aspect-square').click();
+
+  // Scope all form interactions to the right panel (Radix Dialog) — the inbox
+  // page also has a top-level inbox filter combobox we'd otherwise collide with.
+  const panel = page.getByRole('dialog');
+  await panel.waitFor();
+  await panel.getByPlaceholder('Enter a name').fill(caseName);
+  await panel.getByRole('combobox').click();
+  await page.getByRole('option', { name: inboxName }).first().click();
+  await panel.getByRole('button', { name: 'Create a new case' }).click();
+
+  // Create-case redirects to /cases/s/:caseId (scenario case detail)
+  await page.waitForURL(/\/cases\/s\//);
+  await waitForHydration(page);
+  return caseName;
+}
+
+test('Cases list page loads', async ({ page }) => {
+  const { inboxId } = await setupInbox(page);
+  await page.goto(`/cases/inboxes/${inboxId}`);
+  await waitForHydration(page);
+
+  await expect(page).toHaveURL(new RegExp(`/cases/inboxes/${inboxId}`));
+  // The toolbar chrome must render (search input + the icon-only create-case button)
+  await expect(page.getByPlaceholder('Search by name')).toBeVisible();
+  await expect(page.locator('button[aria-haspopup="dialog"].aspect-square')).toBeVisible();
+});
+
+test('Create a case', async ({ page }) => {
+  const { inboxId, inboxName } = await setupInbox(page);
+  await page.goto(`/cases/inboxes/${inboxId}`);
+  await waitForHydration(page);
+
+  const caseName = await createCase(page, inboxName);
+
+  // Post-create we're on the case detail; the case name appears in the page chrome
+  await expect(page.locator('body')).toContainText(caseName);
+});
+
+test('View case detail', async ({ page }) => {
+  const { inboxId, inboxName } = await setupInbox(page);
+  await page.goto(`/cases/inboxes/${inboxId}`);
+  await waitForHydration(page);
+
+  await createCase(page, inboxName);
+
+  // Case detail chrome: comment input + status/info sections
+  await expect(page.getByPlaceholder('Write a note')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Close case' })).toBeVisible();
+});
+
+test('Add a comment to a case', async ({ page }) => {
+  const { inboxId, inboxName } = await setupInbox(page);
+  await page.goto(`/cases/inboxes/${inboxId}`);
+  await waitForHydration(page);
+
+  await createCase(page, inboxName);
+
+  const commentText = crypto.randomUUID();
+  await page.getByPlaceholder('Write a note').fill(commentText);
+  await page.getByRole('button', { name: 'post a comment' }).click();
+  await waitForHydration(page);
+
+  // The comment event should appear in the case events list
+  await expect(page.locator('body')).toContainText(commentText);
+});
+
+test('Case is auto-assigned to creator', async ({ page }) => {
+  const { inboxId, inboxName } = await setupInbox(page);
+  await page.goto(`/cases/inboxes/${inboxId}`);
+  await waitForHydration(page);
+
+  await createCase(page, inboxName);
+
+  // Creating a case auto-assigns it to the creator, so the assignee chip with
+  // "(you)" suffix should be present and the "Assign to myself" CTA absent.
+  await expect(page.locator('body')).toContainText('(you)');
+  await expect(page.getByRole('button', { name: 'Assign to myself' })).toHaveCount(0);
+});
+
+test('Close a case', async ({ page }) => {
+  const { inboxId, inboxName } = await setupInbox(page);
+  await page.goto(`/cases/inboxes/${inboxId}`);
+  await waitForHydration(page);
+
+  await createCase(page, inboxName);
+
+  await waitForThen(page, page.getByRole('button', { name: 'Close case' }), async (btn) => await btn.click());
+
+  const modal = page.getByRole('dialog');
+  await modal.waitFor();
+
+  // Pick "Confirmed risk" outcome from the radio group
+  await modal.getByText('Confirmed risk').click();
+  await modal.getByRole('button', { name: 'Validate' }).click();
+  await waitForHydration(page);
+
+  // After closing, the action button swaps to "Reopen case" — a more reliable
+  // signal than the status text (which renders as the outcome name, not "Resolved").
+  await expect(page.getByRole('button', { name: 'Reopen case' })).toBeVisible();
+});

--- a/packages/tests/e2e/custom-lists.spec.ts
+++ b/packages/tests/e2e/custom-lists.spec.ts
@@ -43,3 +43,86 @@ test('Create new list', async ({ page }) => {
     await expect(page.locator('table')).toContainText(value);
   }
 });
+
+test('Add a value to an existing list', async ({ page }) => {
+  const listName = crypto.randomUUID();
+  await page.goto('/detection/lists');
+  await waitForHydration(page);
+
+  // Create list
+  await page.getByRole('button', { name: 'New List' }).click();
+  await page.getByRole('textbox', { name: 'Name' }).fill(listName);
+  await page.getByRole('textbox', { name: 'Description' }).fill('desc');
+  await waitForThen(page, page.getByRole('button', { name: 'Create new list' }), async (btn) => await btn.click());
+  await page.waitForURL('/detection/lists/**');
+  await page.waitForLoadState();
+
+  // Add a new value
+  const newValue = crypto.randomUUID();
+  await waitForThen(page, page.getByRole('button', { name: 'New value' }), async (btn) => await btn.click());
+  await waitForThen(page, page.getByRole('textbox', { name: 'Value' }), async (f) => await f.fill(newValue));
+  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('textbox', { name: 'Value' }).waitFor({ state: 'hidden' });
+
+  await expect(page.locator('table')).toContainText(newValue);
+});
+
+test('Delete a list value', async ({ page }) => {
+  const listName = crypto.randomUUID();
+  await page.goto('/detection/lists');
+  await waitForHydration(page);
+
+  // Create list
+  await page.getByRole('button', { name: 'New List' }).click();
+  await page.getByRole('textbox', { name: 'Name' }).fill(listName);
+  await page.getByRole('textbox', { name: 'Description' }).fill('desc');
+  await waitForThen(page, page.getByRole('button', { name: 'Create new list' }), async (btn) => await btn.click());
+  await page.waitForURL('/detection/lists/**');
+  await page.waitForLoadState();
+
+  // Add a value
+  const value = crypto.randomUUID();
+  await waitForThen(page, page.getByRole('button', { name: 'New value' }), async (btn) => await btn.click());
+  await waitForThen(page, page.getByRole('textbox', { name: 'Value' }), async (f) => await f.fill(value));
+  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('textbox', { name: 'Value' }).waitFor({ state: 'hidden' });
+  await expect(page.locator('table')).toContainText(value);
+
+  // Delete the value — each row has a hidden delete button revealed on hover
+  // The button has name="delete" and a sr-only "Delete" span for accessibility
+  const valueRow = page.locator('tr', { hasText: value });
+  await valueRow.locator('button[name="delete"]').click();
+  const modal = page.getByRole('dialog');
+  await modal.waitFor();
+  await modal.getByRole('button', { name: 'Delete' }).click();
+  await modal.waitFor({ state: 'hidden' });
+
+  // When the last value is deleted, the table is replaced with an empty-state
+  // component (`empty_custom_list_values_list`), so we cannot assert on `<table>`.
+  await expect(page.locator('body')).not.toContainText(value);
+});
+
+test('Delete a list', async ({ page }) => {
+  const listName = crypto.randomUUID();
+  await page.goto('/detection/lists');
+  await waitForHydration(page);
+
+  // Create list
+  await page.getByRole('button', { name: 'New List' }).click();
+  await page.getByRole('textbox', { name: 'Name' }).fill(listName);
+  await page.getByRole('textbox', { name: 'Description' }).fill('desc');
+  await waitForThen(page, page.getByRole('button', { name: 'Create new list' }), async (btn) => await btn.click());
+  await page.waitForURL('/detection/lists/**');
+  await page.waitForLoadState();
+
+  // delete_list.button = "Delete this list"
+  await page.getByRole('button', { name: 'Delete this list' }).click();
+  const modal = page.getByRole('dialog');
+  await modal.waitFor();
+  await modal.getByRole('button', { name: 'Delete' }).click();
+
+  await page.waitForURL('/detection/lists');
+  await page.waitForLoadState();
+
+  await expect(page.locator('body')).not.toContainText(listName);
+});

--- a/packages/tests/e2e/custom-lists.spec.ts
+++ b/packages/tests/e2e/custom-lists.spec.ts
@@ -88,10 +88,10 @@ test('Delete a list value', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Value' }).waitFor({ state: 'hidden' });
   await expect(page.locator('table')).toContainText(value);
 
-  // Delete the value — each row has a hidden delete button revealed on hover
-  // The button has name="delete" and a sr-only "Delete" span for accessibility
+  // Delete the value — each row has a hidden delete button revealed on hover,
+  // tagged with `data-test="delete-list-value-trigger"`.
   const valueRow = page.locator('tr', { hasText: value });
-  await valueRow.locator('button[name="delete"]').click();
+  await valueRow.locator('[data-test="delete-list-value-trigger"]').click();
   const modal = page.getByRole('dialog');
   await modal.waitFor();
   await modal.getByRole('button', { name: 'Delete' }).click();

--- a/packages/tests/e2e/decisions.spec.ts
+++ b/packages/tests/e2e/decisions.spec.ts
@@ -109,3 +109,66 @@ test('Clearing a chip via the X removes the URL param', async ({ page }) => {
   // so the chip's button disappears entirely.
   await expect(chipTrigger).toHaveCount(0);
 });
+
+test('Applying outcome filter renders an Outcome chip', async ({ page }) => {
+  await page.goto('/detection/decisions');
+  await waitForHydration(page);
+
+  await filtersTrigger(page).click();
+  await page.locator('[role=menuitem]', { hasText: /^Outcome$/ }).click();
+
+  // OutcomeAndReviewStatusFilter opens a SelectWithCombobox — select "Decline"
+  // The outcome badge text is `outcome.tag.declined.label` = "Decline"
+  await page
+    .getByRole('option', { name: /Decline/ })
+    .first()
+    .click();
+
+  // Close the outcome popover (does not auto-close on selection)
+  await page.keyboard.press('Escape');
+  await waitForHydration(page);
+
+  // `getFilterTKey('outcomeAndReviewStatus')` → 'decisions:outcome' → "Outcome"
+  await expect(page.locator('button', { hasText: /^Outcome$/ })).toBeVisible();
+});
+
+test('Two filters stack independently as chips', async ({ page }) => {
+  // Start with a pre-set triggerObjectId in the URL
+  const triggerObjectId = crypto.randomUUID();
+  await page.goto(`/detection/decisions?triggerObjectId=${triggerObjectId}`);
+  await waitForHydration(page);
+
+  // Verify first chip
+  await expect(page.locator('button', { hasText: `Object ID: ${triggerObjectId}` })).toBeVisible();
+
+  // Add Outcome filter
+  await filtersTrigger(page).click();
+  await page.locator('[role=menuitem]', { hasText: /^Outcome$/ }).click();
+  await page
+    .getByRole('option', { name: /Decline/ })
+    .first()
+    .click();
+  await page.keyboard.press('Escape');
+  await waitForHydration(page);
+
+  // Both chips must be visible simultaneously
+  await expect(page.locator('button', { hasText: `Object ID: ${triggerObjectId}` })).toBeVisible();
+  await expect(page.locator('button', { hasText: /^Outcome$/ })).toBeVisible();
+});
+
+test('Clear filters link removes all filter chips', async ({ page }) => {
+  const triggerObjectId = crypto.randomUUID();
+  await page.goto(`/detection/decisions?triggerObjectId=${triggerObjectId}`);
+  await waitForHydration(page);
+
+  await expect(page.locator('button', { hasText: `Object ID: ${triggerObjectId}` })).toBeVisible();
+
+  // `ClearAllFiltersLink` renders as `<a href="/detection/decisions">` with
+  // "Clear filters" text. The "Decisions" tab in the navigation also points to
+  // the same href, so we must filter by visible text. `force: true` bypasses
+  // actionability checks — the link can be overlapped by the chip flex row.
+  await page.locator('a[href="/detection/decisions"]', { hasText: 'Clear filters' }).click({ force: true });
+
+  await page.waitForURL((url) => !url.searchParams.has('triggerObjectId'));
+  await expect(page.locator('button', { hasText: `Object ID: ${triggerObjectId}` })).toHaveCount(0);
+});

--- a/packages/tests/e2e/decisions.spec.ts
+++ b/packages/tests/e2e/decisions.spec.ts
@@ -98,10 +98,10 @@ test('Clearing a chip via the X removes the URL param', async ({ page }) => {
   const chipTrigger = page.locator('button', { hasText: `Object ID: ${triggerObjectId}` });
   await expect(chipTrigger).toBeVisible();
 
-  // `FilterItem.Clear` is an unlabeled `<button>` containing only a cross
-  // icon — it has no accessible name, so target it via its sibling
-  // relationship to the trigger inside `FilterItem.Root`.
-  await chipTrigger.locator('xpath=following-sibling::button[1]').click();
+  // `FilterItem.Clear` carries `data-test="filter-item-clear"` from the
+  // component definition. Scope to the chip's `FilterItem.Root` to target the
+  // matching clear button (there's one per active chip).
+  await chipTrigger.locator('..').locator('[data-test="filter-item-clear"]').click();
 
   await expect(page).not.toHaveURL(/triggerObjectId=/);
 
@@ -163,11 +163,10 @@ test('Clear filters link removes all filter chips', async ({ page }) => {
 
   await expect(page.locator('button', { hasText: `Object ID: ${triggerObjectId}` })).toBeVisible();
 
-  // `ClearAllFiltersLink` renders as `<a href="/detection/decisions">` with
-  // "Clear filters" text. The "Decisions" tab in the navigation also points to
-  // the same href, so we must filter by visible text. `force: true` bypasses
-  // actionability checks — the link can be overlapped by the chip flex row.
-  await page.locator('a[href="/detection/decisions"]', { hasText: 'Clear filters' }).click({ force: true });
+  // `ClearAllFiltersLink` carries `data-test="clear-all-filters-link"`.
+  // `force: true` bypasses actionability checks — the link can be overlapped
+  // by the chip flex row when many chips wrap onto multiple lines.
+  await page.locator('[data-test="clear-all-filters-link"]').click({ force: true });
 
   await page.waitForURL((url) => !url.searchParams.has('triggerObjectId'));
   await expect(page.locator('button', { hasText: `Object ID: ${triggerObjectId}` })).toHaveCount(0);

--- a/packages/tests/e2e/inboxes.spec.ts
+++ b/packages/tests/e2e/inboxes.spec.ts
@@ -29,3 +29,66 @@ test('Create an inbox', async ({ page }) => {
   await waitForHydration(page);
   await expect(page.locator('table').first()).toContainText(inboxName);
 });
+
+test('Rename an inbox', async ({ page }) => {
+  const inboxName = crypto.randomUUID();
+  const updatedName = crypto.randomUUID();
+
+  // Create inbox
+  await page.goto('/settings/inboxes');
+  await waitForHydration(page);
+  await waitForThen(
+    page,
+    page.getByRole('button', { name: 'Create new inbox' }),
+    async (button) => await button.click(),
+  );
+  const createDialog = page.getByRole('dialog');
+  await createDialog.waitFor();
+  await createDialog.getByRole('textbox').and(createDialog.locator('[name="name"]')).fill(inboxName);
+  await createDialog.getByRole('button', { name: 'Create new inbox' }).click();
+  await page.waitForURL(/\/settings\/inboxes\/[^/]+$/);
+  await waitForHydration(page);
+
+  // Rename via the "Update inbox" modal
+  await waitForThen(page, page.getByRole('button', { name: 'Update inbox' }), async (btn) => await btn.click());
+  const updateDialog = page.getByRole('dialog');
+  await updateDialog.waitFor();
+  // Clear and refill the name field
+  await updateDialog.locator('[name="name"]').clear();
+  await updateDialog.locator('[name="name"]').fill(updatedName);
+  await updateDialog.getByRole('button', { name: 'Save' }).click();
+  await updateDialog.waitFor({ state: 'hidden' });
+  await waitForHydration(page);
+
+  await expect(page.locator('body')).toContainText(updatedName);
+});
+
+test('Delete an inbox', async ({ page }) => {
+  const inboxName = crypto.randomUUID();
+
+  // Create inbox
+  await page.goto('/settings/inboxes');
+  await waitForHydration(page);
+  await waitForThen(
+    page,
+    page.getByRole('button', { name: 'Create new inbox' }),
+    async (button) => await button.click(),
+  );
+  const createDialog = page.getByRole('dialog');
+  await createDialog.waitFor();
+  await createDialog.getByRole('textbox').and(createDialog.locator('[name="name"]')).fill(inboxName);
+  await createDialog.getByRole('button', { name: 'Create new inbox' }).click();
+  await page.waitForURL(/\/settings\/inboxes\/[^/]+$/);
+  await waitForHydration(page);
+
+  // Delete inbox
+  await page.getByRole('button', { name: 'Delete inbox' }).click();
+  const deleteDialog = page.getByRole('dialog');
+  await deleteDialog.waitFor();
+  await deleteDialog.getByRole('button', { name: 'Delete' }).click();
+  await waitForHydration(page);
+
+  await page.goto('/settings/inboxes');
+  await waitForHydration(page);
+  await expect(page.locator('body')).not.toContainText(inboxName);
+});

--- a/packages/tests/e2e/scenarios.spec.ts
+++ b/packages/tests/e2e/scenarios.spec.ts
@@ -2,6 +2,61 @@ import { expect, test } from '@playwright/test';
 import crypto from 'crypto';
 import { waitForHydration, waitForThen } from 'tests/common/utils';
 
+// Creates a scenario and navigates to the rules edit page, ready to add rules.
+// Returns the scenario name and the current URL (rules list).
+async function createScenarioAndGoToRules(page: import('@playwright/test').Page): Promise<string> {
+  const scenarioName = crypto.randomUUID();
+  await page.goto('/detection/scenarios');
+  await waitForHydration(page);
+
+  await page.getByRole('button', { name: 'New Scenario' }).click();
+  await waitForThen(page, page.getByRole('textbox', { name: 'Name' }), async (f) => await f.fill(scenarioName));
+  await page.getByRole('textbox', { name: 'Description' }).fill('DESC');
+  await waitForThen(page, page.getByRole('combobox'), async (box) => await box.click());
+  await waitForThen(page, page.getByRole('option', { name: 'transactions' }), async (option) => await option.click());
+  await page.getByRole('button', { name: 'Save' }).click();
+  await waitForHydration(page);
+
+  // Set a trigger condition (required before rules can be added)
+  await waitForThen(
+    page,
+    page.getByRole('button', { name: 'Add trigger condition' }),
+    async (btn) => await btn.click(),
+  );
+  await page.getByRole('button', { name: 'Condition', exact: true }).click();
+  await page.getByRole('button', { name: 'Select an operand...' }).first().click();
+  await page.getByRole('option', { name: 'transactions' }).hover();
+  await page.getByText('amount').click();
+  await page.getByRole('button', { name: '...' }).first().click();
+  await page.getByRole('option', { name: '>' }).click();
+  await page.getByRole('button', { name: 'Select an operand...' }).click();
+  await page.getByPlaceholder('Select or create an operand').fill('100');
+  await page.getByPlaceholder('Select or create an operand').press('Enter');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await page.getByRole('link', { name: 'Rules' }).click();
+  await waitForHydration(page);
+
+  return scenarioName;
+}
+
+// Adds a rule to the current rules edit page and saves it, ending on the rule detail page.
+async function addRule(page: import('@playwright/test').Page): Promise<void> {
+  await page.getByRole('button', { name: 'Add' }).click();
+  await page.getByRole('button', { name: 'Add a Rule' }).click();
+  await page.getByRole('button', { name: 'Group', exact: true }).click();
+  await page.getByRole('button', { name: 'Select an operand...' }).first().click();
+  await page.getByRole('option', { name: 'transactions' }).hover();
+  await page.getByText('amount').click();
+  await page.getByRole('button', { name: '...' }).first().click();
+  await page.getByRole('option', { name: '>' }).click();
+  await page.getByRole('button', { name: 'Select an operand...' }).click();
+  await page.getByPlaceholder('Select or create an operand').fill('9000');
+  await page.getByPlaceholder('Select or create an operand').press('Enter');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await waitForHydration(page);
+}
+
 test('Create a simple scenario', async ({ page }) => {
   await page.goto('/detection/scenarios');
   await waitForHydration(page);
@@ -61,4 +116,56 @@ test('Create a simple scenario', async ({ page }) => {
   await expect(page.getByRole('button', { name: 'edit_operand.operator_type.' })).toHaveText('amount');
   await expect(page.getByRole('button', { name: '>' })).toHaveText('>');
   await expect(page.getByRole('button', { name: 'Number 100' })).toBeVisible();
+});
+
+test('Delete a rule', async ({ page }) => {
+  await createScenarioAndGoToRules(page);
+  await addRule(page);
+
+  // On the rule detail page, click "Delete" and confirm in the modal
+  await page.getByRole('button', { name: 'Delete' }).click();
+  const modal = page.getByRole('dialog');
+  await modal.waitFor();
+  await modal.getByRole('button', { name: 'Delete' }).click();
+  await waitForHydration(page);
+
+  // Deletion redirects back to the rules list — expect an empty rules table
+  await expect(page.getByRole('button', { name: 'Add' })).toBeVisible();
+});
+
+test('Duplicate a rule', async ({ page }) => {
+  await createScenarioAndGoToRules(page);
+  await addRule(page);
+
+  // On the rule detail page, click "Clone" and confirm
+  await page.getByRole('button', { name: 'Clone' }).click();
+  const modal = page.getByRole('dialog');
+  await modal.waitFor();
+  await modal.getByRole('button', { name: 'Create a copy' }).click();
+  await waitForHydration(page);
+
+  // Navigate back to the rules list — both the original and the copy should appear
+  await page.getByRole('link', { name: 'Rules' }).click();
+  await waitForHydration(page);
+  await expect(page.locator('table tbody tr')).toHaveCount(2);
+});
+
+test('Copy a scenario', async ({ page }) => {
+  const scenarioName = await createScenarioAndGoToRules(page);
+
+  // Navigate back to the scenarios list
+  await page.getByRole('link', { name: 'Detection' }).first().click();
+  await waitForHydration(page);
+
+  // The copy button on the scenario row has title="Duplicate" (copy_scenario.title)
+  const scenarioRow = page.locator('tr', { hasText: scenarioName });
+  await scenarioRow.getByRole('button', { name: 'Duplicate' }).click();
+
+  const modal = page.getByRole('dialog');
+  await modal.waitFor();
+  await modal.getByRole('button', { name: 'Copy' }).click();
+  await waitForHydration(page);
+
+  // A new row with the copy name should appear
+  await expect(page.getByRole('cell', { name: new RegExp(`Copy of ${scenarioName}`) })).toBeVisible();
 });

--- a/packages/tests/e2e/tags.spec.ts
+++ b/packages/tests/e2e/tags.spec.ts
@@ -20,3 +20,57 @@ test('Create a case tag', async ({ page }) => {
   await dialog.waitFor({ state: 'hidden' });
   await expect(page.locator('table').first()).toContainText(tagName);
 });
+
+test('Update a tag', async ({ page }) => {
+  const tagName = crypto.randomUUID();
+  const updatedName = crypto.randomUUID();
+
+  // Create tag
+  await page.goto('/settings/tags');
+  await waitForHydration(page);
+  await waitForThen(page, page.getByRole('button', { name: 'New tag' }), async (btn) => await btn.click());
+  const createDialog = page.getByRole('dialog');
+  await createDialog.waitFor();
+  await createDialog.getByRole('textbox').and(createDialog.locator('[name="name"]')).fill(tagName);
+  await createDialog.getByRole('button', { name: 'Create new tag' }).click();
+  await createDialog.waitFor({ state: 'hidden' });
+  await expect(page.locator('table').first()).toContainText(tagName);
+
+  // Update the tag — the edit icon has aria-label "Update tag"
+  const tagRow = page.locator('tr', { hasText: tagName });
+  await tagRow.locator('[aria-label="Update tag"]').click();
+  const updateDialog = page.getByRole('dialog');
+  await updateDialog.waitFor();
+  await updateDialog.locator('[name="name"]').clear();
+  await updateDialog.locator('[name="name"]').fill(updatedName);
+  await updateDialog.getByRole('button', { name: 'Save' }).click();
+  await updateDialog.waitFor({ state: 'hidden' });
+
+  await expect(page.locator('table').first()).toContainText(updatedName);
+  await expect(page.locator('table').first()).not.toContainText(tagName);
+});
+
+test('Delete a tag', async ({ page }) => {
+  const tagName = crypto.randomUUID();
+
+  // Create tag
+  await page.goto('/settings/tags');
+  await waitForHydration(page);
+  await waitForThen(page, page.getByRole('button', { name: 'New tag' }), async (btn) => await btn.click());
+  const createDialog = page.getByRole('dialog');
+  await createDialog.waitFor();
+  await createDialog.getByRole('textbox').and(createDialog.locator('[name="name"]')).fill(tagName);
+  await createDialog.getByRole('button', { name: 'Create new tag' }).click();
+  await createDialog.waitFor({ state: 'hidden' });
+  await expect(page.locator('table').first()).toContainText(tagName);
+
+  // Delete the tag — the delete icon has aria-label "Delete tag"
+  const tagRow = page.locator('tr', { hasText: tagName });
+  await tagRow.locator('[aria-label="Delete tag"]').click();
+  const deleteDialog = page.getByRole('dialog');
+  await deleteDialog.waitFor();
+  await deleteDialog.getByRole('button', { name: 'Delete' }).click();
+  await deleteDialog.waitFor({ state: 'hidden' });
+
+  await expect(page.locator('table').first()).not.toContainText(tagName);
+});


### PR DESCRIPTION
Adds 19 new e2e tests across 6 spec files covering Case Manager (zero prior coverage), and CRUD editing for custom lists, inboxes, tags, plus outcome filter + clear-all-filters flows on the decisions page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive E2E coverage for Cases (create, comment, auto-assign, close/reopen), Custom Lists (create, add, delete value, delete list), Decisions filtering and chip clearing, Inboxes (rename, delete), Scenarios (add rule, delete, duplicate, copy), and Tags (update, delete).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->