### PR TITLE
build(deps-dev): bump @tanstack/react-form-devtools 0.2.24 → 0.2.27

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/devtools-vite": "^0.6.0",
         "@tanstack/react-devtools": "^0.10.2",
-        "@tanstack/react-form-devtools": "^0.2.24",
+        "@tanstack/react-form-devtools": "^0.2.27",
         "@tanstack/react-query-devtools": "5.83.1",
         "@tanstack/react-router-devtools": "1.166.13",
         "@tanstack/router-plugin": "1.167.35",

--- a/packages/app-builder/package.json
+++ b/packages/app-builder/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@tanstack/devtools-vite": "^0.6.0",
     "@tanstack/react-devtools": "^0.10.2",
-    "@tanstack/react-form-devtools": "^0.2.24",
+    "@tanstack/react-form-devtools": "^0.2.27",
     "@tanstack/react-query-devtools": "5.83.1",
     "@tanstack/react-router-devtools": "1.166.13",
     "@tanstack/router-plugin": "1.167.35",


### PR DESCRIPTION
## Summary
Last applicable item from Dependabot patch group #1572 — the rest already landed in #1571. The newer devtools depends on `@tanstack/form-core@1.32.0`, which the lockfile already resolves via the caret on `@tanstack/react-form`, so this is effectively a declared-version cleanup with no transitive surprises.

### Remaining items in #1572 (still deferred — close #1572 after this merges)
- `@preact/signals-react` 3.10.0 → 3.10.1 — pulls in `@preact/signals-core` 1.14.2 which tightens `Signal<T>.value` to potentially undefined, surfacing 36 strict-null errors via `sharpstate`. Needs a focused PR.
- `@tanstack/react-start` 1.167.39 → 1.167.65 — same override-cluster trap as before (`start-plugin-core` doesn't export `./vite` at the pinned version).

## Test plan
- [x] `bun install` clean
- [x] `bun run -F app-builder type-check` passes
- [x] `bun run -F app-builder build` succeeds
- [x] `bunx vitest run` 33/33 in app-builder
- [ ] CI green