### PR TITLE
fix adaptSemanticField bug

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
+++ b/packages/app-builder/src/components/Data/SemanticTables/CreateTable/createTable-types.ts
@@ -165,7 +165,7 @@ export function adaptSemanticField(
           .with('middle_name', () => 'middle_name' as const)
           .with('last_name', () => 'last_name' as const)
           .with('caption', () => 'name' as const)
-          .exhaustive(),
+          .otherwise(() => undefined),
       )
       .with('enum', () => 'enum' as const)
       .with('currency_code', () => 'currency' as const)
@@ -179,7 +179,7 @@ export function adaptSemanticField(
           .with('url', () => 'url' as const)
           .with('email', () => 'email' as const)
           .with('phone', () => 'phone_number' as const)
-          .exhaustive(),
+          .otherwise(() => undefined),
       )
       .with('account_identifier', () =>
         match(subType as SemanticSubTypeFieldMap['account_identifier'] | undefined)
@@ -187,7 +187,7 @@ export function adaptSemanticField(
           .with('account_number', () => 'account_number' as const)
           .with('iban', () => 'iban' as const)
           .with('bic', () => 'bic' as const)
-          .exhaustive(),
+          .otherwise(() => undefined),
       )
       .with('timestamp', () => undefined)
       .with('date_of_birth', () => 'date_of_birth' as const)


### PR DESCRIPTION
fix: replace .exhaustive() with .otherwise() in adaptSemanticField to handle undefined cases
Add guards for subcases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error resilience by gracefully handling edge cases in semantic field type processing, allowing the application to continue functioning when unexpected data types are encountered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->