### PR TITLE
fix display of screening status tag with number of hits

### DIFF
--- a/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
+++ b/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
@@ -126,7 +126,12 @@ export function DecisionPanel({ setDrawerContentMode, decision, dataModel }: Dec
                     }
                   }}
                 >
-                  <ScreeningStatusBadge status={screening.status} decisionId={decision.id} screeningId={screening.id} />
+                  <ScreeningStatusBadge
+                    status={screening.status}
+                    decisionId={decision.id}
+                    screeningId={screening.id}
+                    nbHits={screening.count}
+                  />
                 </div>
               </div>
             ))}

--- a/packages/app-builder/src/components/Cases/CaseAlerts.tsx
+++ b/packages/app-builder/src/components/Cases/CaseAlerts.tsx
@@ -9,7 +9,6 @@ import { useFormatDateTime } from '@app-builder/utils/format';
 import { parseUnknownData } from '@app-builder/utils/parse';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import * as R from 'remeda';
 import { map, pipe, take } from 'remeda';
 import { match } from 'ts-pattern';
 import { Button, cn } from 'ui-design-system';
@@ -212,6 +211,7 @@ export const AlertCard = ({
                           status={screening.status}
                           decisionId={decision.id}
                           screeningId={screening.id}
+                          nbHits={screening.count}
                         />
                       </div>
                     </div>
@@ -406,10 +406,12 @@ export const ScreeningStatusBadge = ({
   status,
   decisionId,
   screeningId,
+  nbHits,
 }: {
   status: ScreeningStatus;
   decisionId: string;
   screeningId: string;
+  nbHits: number;
 }) => {
   const { t } = useTranslation(casesI18n);
   const screeningQuery = useScreeningDetailQuery(decisionId, screeningId, true);
@@ -438,18 +440,10 @@ export const ScreeningStatusBadge = ({
           if (!screeningData) {
             return <div className="text-grey-secondary p-8 text-center text-s">{t('common:global_error')}</div>;
           }
-          const matchCount = R.pipe(
-            screeningData.matches,
-            R.groupBy((m) => m.status),
-            R.mapValues((group) => group.length),
-          );
+
           return (
             <>
-              {Object.entries(matchCount)
-                .filter(([, count]) => count > 0)
-                .map(([status, count]) => (
-                  <div key={status}>{t(`screenings:status.${status}`, { count })}</div>
-                ))}
+              <div key={status}>{t(`screenings:status.${status}`, { count: nbHits })}</div>
               <Icon icon="eye" className="size-4 shrink-0" />
             </>
           );

--- a/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
@@ -17,7 +17,11 @@ export function ScreeningDetail({ screening }: { screening: Screening }) {
       <Collapsible.Title>
         <div className="flex grow items-center justify-between">
           <span>{screening.config.name}</span>
-          <ScreeningStatusTag status={screening.status} className="h-8" />
+          <ScreeningStatusTag
+            status={screening.status}
+            pendingHitCount={screening.matches.filter((m) => m.status === 'pending').length}
+            className="h-8"
+          />
         </div>
       </Collapsible.Title>
       <Collapsible.Content>

--- a/packages/app-builder/src/components/Screenings/RefineSearchModal.tsx
+++ b/packages/app-builder/src/components/Screenings/RefineSearchModal.tsx
@@ -124,7 +124,7 @@ export function RefineSearchModal({
                         t={t}
                         i18nKey="screenings:refine_modal.no_match_callout"
                         components={{
-                          Status: <ScreeningStatusTag status="no_hit" />,
+                          Status: <ScreeningStatusTag status="no_hit" pendingHitCount={0} />,
                         }}
                       />
                     </div>

--- a/packages/app-builder/src/components/Screenings/ScreeningPanel/ScreeningHitsPanel.tsx
+++ b/packages/app-builder/src/components/Screenings/ScreeningPanel/ScreeningHitsPanel.tsx
@@ -173,7 +173,10 @@ export function ScreeningHitsPanel({
           />
           <div className="flex flex-1 items-center gap-2">
             <h2 className="text-xl font-semibold text-grey-primary tracking-[-0.8px] leading-0">{currentName}</h2>
-            <ScreeningStatusTag status={currentStatus} />
+            <ScreeningStatusTag
+              status={currentStatus}
+              pendingHitCount={screeningQuery.data?.matches.filter((m) => m.status === 'pending').length}
+            />
           </div>
           <div className="flex items-center gap-2 shrink-0">
             {showBulkButton ? (

--- a/packages/app-builder/src/components/Screenings/ScreeningStatusTag.tsx
+++ b/packages/app-builder/src/components/Screenings/ScreeningStatusTag.tsx
@@ -18,13 +18,22 @@ const screeningStatusMapping = {
   }
 >;
 
-export function ScreeningStatusTag({ status, className }: { status: ScreeningStatus; className?: string }) {
+export function ScreeningStatusTag({
+  status,
+  pendingHitCount,
+  className,
+}: {
+  status: ScreeningStatus;
+  pendingHitCount?: number;
+  className?: string;
+}) {
   const { t } = useTranslation(screeningsI18n);
   const screeningStatus = screeningStatusMapping[status];
 
   return (
     <Tag color={screeningStatus.color} className={className}>
-      {t(screeningStatus.tKey)}
+      {/* <Trans t={t} i18nKey={screeningStatus.tKey} values={{ count: pendingHitCount ?? 0 }} /> */}
+      {t(screeningStatus.tKey, { count: pendingHitCount ?? 0 })}
     </Tag>
   );
 }

--- a/packages/app-builder/src/locales/ar/screenings.json
+++ b/packages/app-builder/src/locales/ar/screenings.json
@@ -278,9 +278,8 @@
   "start_reviewing": "ابدأ المراجعة",
   "status.confirmed_hit": "مطابقة مؤكدة",
   "status.error": "خطأ",
-  "status.in_review": "مطابقات للمراجعة",
-  "status.no_hit": "({{count}}) لا تطابق",
-  "status.pending": "({{count}}) مطابقات للمراجعة",
+  "status.in_review": "({{count}}) مطابقات للمراجعة",
+  "status.no_hit": "لا تطابق",
   "status.skipped": "تم تجاهلها",
   "success.match_enriched": "تم إثراء المطابقة بنجاح"
 }

--- a/packages/app-builder/src/locales/en/screenings.json
+++ b/packages/app-builder/src/locales/en/screenings.json
@@ -278,9 +278,8 @@
   "start_reviewing": "Start reviewing",
   "status.confirmed_hit": "Confirmed hit",
   "status.error": "Error",
-  "status.in_review": "Hits to review",
-  "status.no_hit": "No match ({{count}})",
-  "status.pending": "Hits to review ({{count}})",
+  "status.in_review": "Hits to review ({{count}})",
+  "status.no_hit": "No match",
   "status.skipped": "Skipped",
   "success.match_enriched": "Match successfully enriched"
 }

--- a/packages/app-builder/src/locales/fr/screenings.json
+++ b/packages/app-builder/src/locales/fr/screenings.json
@@ -278,9 +278,8 @@
   "start_reviewing": "Commencer l'examen",
   "status.confirmed_hit": "Correspondance confirmée",
   "status.error": "Erreur",
-  "status.in_review": "Correspondances à examiner",
-  "status.no_hit": "Aucune correspondance ({{count}})",
-  "status.pending": "Correspondances à examiner ({{count}})",
+  "status.in_review": "Correspondances à examiner ({{count}})",
+  "status.no_hit": "Aucune correspondance",
   "status.skipped": "Ignoré",
   "success.match_enriched": "Correspondance enrichie avec succès"
 }

--- a/packages/app-builder/src/routes/_app/_builder/cases/$caseId/d/$decisionId/screenings/$screeningId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/cases/$caseId/d/$decisionId/screenings/$screeningId.tsx
@@ -109,7 +109,10 @@ export const Route = createFileRoute('/_app/_builder/cases/$caseId/d/$decisionId
             >
               <span className="line-clamp-2 text-start">{screening.config.name}</span>
             </BreadCrumbLink>
-            <ScreeningStatusTag status={screening.status} />
+            <ScreeningStatusTag
+              status={screening.status}
+              pendingHitCount={screening.matches.filter((m) => m.status === 'pending').length}
+            />
           </div>
         );
       },


### PR DESCRIPTION
## Before
<img width="2176" height="320" alt="image" src="https://github.com/user-attachments/assets/1be3300c-2cb4-4121-896c-956d8e84155d" />


## After
<img width="667" height="187" alt="Capture d’écran 2026-05-26 à 22 38 24" src="https://github.com/user-attachments/assets/b5337bb0-5a9a-4864-bdb0-83fe1ea685e0" />
<img width="684" height="199" alt="Capture d’écran 2026-05-26 à 22 38 08" src="https://github.com/user-attachments/assets/062de580-6df2-409d-96ab-58ce4e863f4a" />
<img width="1252" height="635" alt="Capture d’écran 2026-05-26 à 22 37 52" src="https://github.com/user-attachments/assets/3e2216bf-846c-47d2-9ba8-8001bd8d0324" />

## Remarks
Note that in one situation I show the number of hits _remaining to review_ (because I have access to it) while in the other I show the initial number of hits on the screening. Acceptable discrepancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced screening status indicators to consistently display pending hit counts across the application.

* **Localization**
  * Updated screening status message translations to properly reflect pending match counts in Arabic, English, and French.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->