### PR TITLE
Feat/screening provider context

### DIFF
--- a/packages/app-builder/src/components/ContinuousScreening/ConfigurationPanel.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/ConfigurationPanel.tsx
@@ -54,7 +54,7 @@ export const ConfigurationPanel = ({
   return (
     <PanelContainer size="max" className="p-0 bg-surface-page overflow-y-auto flex flex-col isolate">
       <ContinuousScreeningConfigurationStepper.Provider value={configurationStepper}>
-        <ListAndTopicDatasetConfigurationBridge>
+        <ListAndTopicDatasetConfigurationBridge useCase="continuous_monitoring">
           <ConfigurationPanelHeader />
           <div className="p-v2-lg grow">
             {match(configurationStepper.value.__internals.currentStep)

--- a/packages/app-builder/src/components/ContinuousScreening/CreationPage.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/CreationPage.tsx
@@ -43,7 +43,7 @@ export const CreationPage = ({ name, description }: { name: string; description:
 
   return (
     <ContinuousScreeningConfigurationStepper.Provider value={creationStepper}>
-      <ListAndTopicDatasetConfigurationBridge>
+      <ListAndTopicDatasetConfigurationBridge useCase="continuous_monitoring">
         <Page.Main>
           <Page.Header className="justify-between">
             <BreadCrumbs />

--- a/packages/app-builder/src/components/ContinuousScreening/context/ListAndTopicDatasetConfigurationBridge.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/context/ListAndTopicDatasetConfigurationBridge.tsx
@@ -2,6 +2,9 @@ import {
   getCanonicalSelectedKeys,
   ListAndTopicDatasetConfiguration,
 } from '@app-builder/components/ListAndTopicConfiguration';
+import { Spinner } from '@app-builder/components/Spinner';
+import { type AvailableFeatures, type ScreeningProviders } from '@app-builder/models/screening';
+import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
 import { type ReactNode, useEffect, useMemo } from 'react';
 import { ContinuousScreeningConfigurationStepper } from './CreationStepper';
 
@@ -13,7 +16,37 @@ function getDatasetsMapKey(datasets: Record<string, boolean>): string {
   return getCanonicalSelectedKeys(datasets).join(',');
 }
 
-export function ListAndTopicDatasetConfigurationBridge({ children }: { children: ReactNode }) {
+export function ListAndTopicDatasetConfigurationBridge({
+  useCase,
+  children,
+}: {
+  useCase: AvailableFeatures;
+  children: ReactNode;
+}) {
+  const listConfigQuery = useListConfigQuery(useCase);
+
+  if (!listConfigQuery.data) {
+    return (
+      <div className="flex items-center justify-center h-50">
+        <Spinner className="size-10" />
+      </div>
+    );
+  }
+
+  return (
+    <ListAndTopicDatasetConfigurationBridgeInner provider={listConfigQuery.data.provider}>
+      {children}
+    </ListAndTopicDatasetConfigurationBridgeInner>
+  );
+}
+
+function ListAndTopicDatasetConfigurationBridgeInner({
+  provider,
+  children,
+}: {
+  provider: ScreeningProviders;
+  children: ReactNode;
+}) {
   const wizard = ContinuousScreeningConfigurationStepper.useSharp();
   const wizardMode = ContinuousScreeningConfigurationStepper.select((s) => s.__internals.mode);
   const datasetsMap = wizard.value.data.datasets;
@@ -22,6 +55,7 @@ export function ListAndTopicDatasetConfigurationBridge({ children }: { children:
   const listSharp = ListAndTopicDatasetConfiguration.createSharp({
     datasets: datasetsMap,
     mode: wizardMode,
+    provider,
   });
 
   useEffect(() => {

--- a/packages/app-builder/src/components/ContinuousScreening/context/ListAndTopicDatasetConfigurationBridge.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/context/ListAndTopicDatasetConfigurationBridge.tsx
@@ -6,6 +6,8 @@ import { Spinner } from '@app-builder/components/Spinner';
 import { type AvailableFeatures, type ScreeningProviders } from '@app-builder/models/screening';
 import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
 import { type ReactNode, useEffect, useMemo } from 'react';
+import { Trans } from 'react-i18next';
+import { match } from 'ts-pattern';
 import { ContinuousScreeningConfigurationStepper } from './CreationStepper';
 
 /*
@@ -25,19 +27,24 @@ export function ListAndTopicDatasetConfigurationBridge({
 }) {
   const listConfigQuery = useListConfigQuery(useCase);
 
-  if (!listConfigQuery.data) {
-    return (
+  return match(listConfigQuery)
+    .with({ isError: true }, () => (
+      <div className="flex h-50 flex-col items-center justify-center gap-2">
+        <span className="text-s text-text-secondary">
+          <Trans i18nKey="common:generic_fetch_data_error" />
+        </span>
+      </div>
+    ))
+    .with({ isPending: true }, () => (
       <div className="flex items-center justify-center h-50">
         <Spinner className="size-10" />
       </div>
-    );
-  }
-
-  return (
-    <ListAndTopicDatasetConfigurationBridgeInner provider={listConfigQuery.data.provider}>
-      {children}
-    </ListAndTopicDatasetConfigurationBridgeInner>
-  );
+    ))
+    .otherwise(({ data }) => (
+      <ListAndTopicDatasetConfigurationBridgeInner provider={data.provider}>
+        {children}
+      </ListAndTopicDatasetConfigurationBridgeInner>
+    ));
 }
 
 function ListAndTopicDatasetConfigurationBridgeInner({

--- a/packages/app-builder/src/components/ContinuousScreening/form/recaps/DatasetSelectionRecap.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/form/recaps/DatasetSelectionRecap.tsx
@@ -12,7 +12,7 @@ export const DatasetSelectionRecap = () => {
   const listConfigQuery = useListConfigQuery('continuous_monitoring');
   const datasets = ContinuousScreeningConfigurationStepper.select((state) => state.data.datasets);
 
-  const enabledSections = Object.entries(listConfigQuery.data ?? {}).filter(
+  const enabledSections = Object.entries(listConfigQuery.data?.filters ?? {}).filter(
     ([key, section]) => !!datasets[key] && section != null,
   ) as [ScreeningCategory, SectionData][];
 

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -32,6 +32,7 @@ import {
   setDatasetKey,
   // setGlobalTopicSwitch,
   setTopicKey,
+  syncSectionEnabledFromLeaves,
 } from './dataset-selection-provider-utils';
 import {
   // type GlobalTopicConfig,
@@ -332,6 +333,7 @@ type SectionContentProps = { sectionKey: ScreeningCategory; section: SectionData
 const SectionContent = ({ sectionKey, section }: SectionContentProps) => {
   const { datasets, topics, conditionalTopics } = section;
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const [searchTerm, setSearchTerm] = useState('');
   const { formatDatasetTitle, t } = useDatasetTitle();
 
@@ -356,6 +358,7 @@ const SectionContent = ({ sectionKey, section }: SectionContentProps) => {
             }
           }
         }
+        if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
       });
     };
   }
@@ -403,6 +406,7 @@ const SectionContent = ({ sectionKey, section }: SectionContentProps) => {
             title={group.title}
             items={group.datasets}
             sectionKey={sectionKey}
+            section={section}
             forceOpen={hasSearch}
           />
         ))
@@ -412,6 +416,7 @@ const SectionContent = ({ sectionKey, section }: SectionContentProps) => {
           <FilterGroupRow
             key={key}
             sectionKey={sectionKey}
+            section={section}
             groupKey={key}
             items={items}
             onAfterChange={makeResetHandler(key)}
@@ -422,6 +427,7 @@ const SectionContent = ({ sectionKey, section }: SectionContentProps) => {
           <ConditionalFilterGroupRow
             key={name}
             sectionKey={sectionKey}
+            section={section}
             groupKey={name}
             allItems={items}
             dependsOnGroup={dependsOn}
@@ -436,16 +442,19 @@ const ItemGroup = ({
   title,
   items,
   sectionKey,
+  section,
   forceOpen = false,
 }: {
   title: string;
   items: { name: string; title?: string }[];
   sectionKey: ScreeningCategory;
+  section: SectionData;
   forceOpen?: boolean;
 }) => {
   const { formatDatasetTitle, t } = useDatasetTitle();
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const names = items.map((i) => i.name);
   const keys = names.map((n) => buildDatasetKey(sectionKey, n));
   const checkState = ListAndTopicDatasetConfiguration.select(
@@ -454,6 +463,7 @@ const ItemGroup = ({
   const selectedCount = ListAndTopicDatasetConfiguration.select(
     (state) => keys.filter((k) => state.datasets[k]).length,
   );
+
   const handleSelectAll = () => {
     const datasetsMap = listConfig.value.datasets;
     const selected = keys.filter((k) => datasetsMap[k]).length;
@@ -462,9 +472,7 @@ const ItemGroup = ({
       for (const name of names) {
         setDatasetKey(state.datasets, sectionKey, name, nextValue);
       }
-      if (nextValue) {
-        state.datasets[sectionKey] = true;
-      }
+      if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
     });
   };
 
@@ -503,7 +511,13 @@ const ItemGroup = ({
         <div className="flex flex-col gap-v2-sm">
           <div className="flex flex-col overflow-hidden border border-grey-border rounded-v2-md ">
             {items.map((item) => (
-              <ItemRow key={item.name} name={item.name} label={item.title ?? item.name} sectionKey={sectionKey} />
+              <ItemRow
+                key={item.name}
+                name={item.name}
+                label={item.title ?? item.name}
+                sectionKey={sectionKey}
+                section={section}
+              />
             ))}
           </div>
         </div>
@@ -512,9 +526,20 @@ const ItemGroup = ({
   );
 };
 
-const ItemRow = ({ name, label, sectionKey }: { name: string; label: string; sectionKey: ScreeningCategory }) => {
+const ItemRow = ({
+  name,
+  label,
+  sectionKey,
+  section,
+}: {
+  name: string;
+  label: string;
+  sectionKey: ScreeningCategory;
+  section: SectionData;
+}) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const isSelected = ListAndTopicDatasetConfiguration.select((state) =>
     isDatasetKeySelected(state.datasets, sectionKey, name),
   );
@@ -524,9 +549,7 @@ const ItemRow = ({ name, label, sectionKey }: { name: string; label: string; sec
     listConfig.update((state) => {
       const nextValue = !isDatasetKeySelected(state.datasets, sectionKey, name);
       setDatasetKey(state.datasets, sectionKey, name, nextValue);
-      if (nextValue) {
-        state.datasets[sectionKey] = true;
-      }
+      if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
     });
   };
 
@@ -589,12 +612,14 @@ type ConditionalTopicItem = NonNullable<SectionData['conditionalTopics']>[keyof 
 
 const ConditionalFilterGroupRow = ({
   sectionKey,
+  section,
   groupKey,
   allItems,
   dependsOnGroup,
   dependsOnItems,
 }: {
   sectionKey: ScreeningCategory;
+  section: SectionData;
   groupKey: string;
   allItems: ConditionalTopicItem[];
   dependsOnGroup: string;
@@ -614,16 +639,18 @@ const ConditionalFilterGroupRow = ({
 
   if (filteredItems.length === 0) return null;
 
-  return <FilterGroupRow sectionKey={sectionKey} groupKey={groupKey} items={filteredItems} />;
+  return <FilterGroupRow sectionKey={sectionKey} section={section} groupKey={groupKey} items={filteredItems} />;
 };
 
 const FilterGroupRow = ({
   sectionKey,
+  section,
   groupKey,
   items,
   onAfterChange,
 }: {
   sectionKey: ScreeningCategory;
+  section: SectionData;
   groupKey: string;
   items: TopicItem[];
   onAfterChange?: () => void;
@@ -639,7 +666,13 @@ const FilterGroupRow = ({
     <>
       {isSpecialTopic(sectionKey, groupKey) ? (
         <div className="px-v2-md py-v2-sm">
-          <SpecialTopicSwitch sectionKey={sectionKey} topicGroup={groupKey} mode={mode} onAfterChange={onAfterChange} />
+          <SpecialTopicSwitch
+            sectionKey={sectionKey}
+            section={section}
+            topicGroup={groupKey}
+            mode={mode}
+            onAfterChange={onAfterChange}
+          />
         </div>
       ) : (
         <div className="flex items-start gap-v2-md px-v2-md py-v2-sm">
@@ -649,6 +682,7 @@ const FilterGroupRow = ({
               <SingleItemToggle
                 item={singleItem}
                 sectionKey={sectionKey}
+                section={section}
                 topicGroup={groupKey}
                 mode={mode}
                 onAfterChange={onAfterChange}
@@ -657,6 +691,7 @@ const FilterGroupRow = ({
               <FilterGroupTags
                 items={items}
                 sectionKey={sectionKey}
+                section={section}
                 topicGroup={groupKey}
                 onAfterChange={onAfterChange}
               />
@@ -670,16 +705,19 @@ const FilterGroupRow = ({
 
 const SpecialTopicSwitch = ({
   sectionKey,
+  section,
   topicGroup,
   mode,
   onAfterChange,
 }: {
   sectionKey: ScreeningCategory;
+  section: SectionData;
   topicGroup: string;
   mode: string;
   onAfterChange?: () => void;
 }) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const topicValue = getSpecialTopicValue(sectionKey, topicGroup);
   const labelKey = getSpecialTopicLabel(sectionKey, topicGroup);
   const switchId = `special-topic-${sectionKey}-${topicGroup}-${topicValue}`;
@@ -697,9 +735,7 @@ const SpecialTopicSwitch = ({
         onCheckedChange={(checked) => {
           listConfig.update((state) => {
             setTopicKey(state.datasets, sectionKey, topicGroup, topicValue, checked);
-            if (checked) {
-              state.datasets[sectionKey] = true;
-            }
+            if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
           });
           onAfterChange?.();
         }}
@@ -716,17 +752,20 @@ const SpecialTopicSwitch = ({
 const SingleItemToggle = ({
   item,
   sectionKey,
+  section,
   topicGroup,
   mode,
   onAfterChange,
 }: {
   item: TopicItem;
   sectionKey: ScreeningCategory;
+  section: SectionData;
   topicGroup: string;
   mode: string;
   onAfterChange?: () => void;
 }) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const isSelected = ListAndTopicDatasetConfiguration.select((state) =>
     isTopicKeySelected(state.datasets, sectionKey, topicGroup, item.name),
   );
@@ -740,6 +779,7 @@ const SingleItemToggle = ({
           onRemove={() => {
             listConfig.update((state) => {
               setTopicKey(state.datasets, sectionKey, topicGroup, item.name, false);
+              if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
             });
             onAfterChange?.();
           }}
@@ -762,7 +802,7 @@ const SingleItemToggle = ({
       onClick={() => {
         listConfig.update((state) => {
           setTopicKey(state.datasets, sectionKey, topicGroup, item.name, true);
-          state.datasets[sectionKey] = true;
+          if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
         });
         onAfterChange?.();
       }}
@@ -776,17 +816,20 @@ const SingleItemToggle = ({
 const FilterGroupTags = ({
   items,
   sectionKey,
+  section,
   topicGroup,
   onAfterChange,
 }: {
   items: TopicItem[];
   sectionKey: ScreeningCategory;
+  section: SectionData;
   topicGroup: string;
   onAfterChange?: () => void;
 }) => {
   const { formatItemName, t } = useDatasetTitle();
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const variant = ListAndTopicDatasetConfiguration.select((state) => state.variant);
   const selectedItems = ListAndTopicDatasetConfiguration.select((state) =>
     items.filter((i) => isTopicKeySelected(state.datasets, sectionKey, topicGroup, i.name)),
@@ -806,6 +849,7 @@ const FilterGroupTags = ({
             onRemove={() => {
               listConfig.update((state) => {
                 setTopicKey(state.datasets, sectionKey, topicGroup, item.name, false);
+                if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
               });
               onAfterChange?.();
             }}
@@ -838,6 +882,7 @@ const FilterGroupTags = ({
         anchored
         items={items}
         sectionKey={sectionKey}
+        section={section}
         topicGroup={topicGroup}
         onAfterChange={onAfterChange}
       />
@@ -858,7 +903,13 @@ const FilterGroupTags = ({
         )}
       </div>
       {mode !== 'view' && variant === 'popover' && isMenuOpen && (
-        <FilterGroupMenu items={items} sectionKey={sectionKey} topicGroup={topicGroup} onAfterChange={onAfterChange} />
+        <FilterGroupMenu
+          items={items}
+          sectionKey={sectionKey}
+          section={section}
+          topicGroup={topicGroup}
+          onAfterChange={onAfterChange}
+        />
       )}
     </div>
   );
@@ -877,12 +928,14 @@ const FilterGroupTags = ({
 const FilterGroupMenu = ({
   items,
   sectionKey,
+  section,
   topicGroup,
   onAfterChange,
   anchored = false,
 }: {
   items: TopicItem[];
   sectionKey: ScreeningCategory;
+  section: SectionData;
   topicGroup: string;
   onAfterChange?: () => void;
   anchored?: boolean;
@@ -890,6 +943,7 @@ const FilterGroupMenu = ({
   const { formatItemName, t } = useDatasetTitle();
   const variant = ListAndTopicDatasetConfiguration.select((state) => state.variant);
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const datasets = ListAndTopicDatasetConfiguration.select((state) => state.datasets);
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
   const allSelected =
@@ -900,9 +954,7 @@ const FilterGroupMenu = ({
     listConfig.update((state) => {
       const nextValue = !isTopicKeySelected(state.datasets, sectionKey, topicGroup, item.name);
       setTopicKey(state.datasets, sectionKey, topicGroup, item.name, nextValue);
-      if (nextValue) {
-        state.datasets[sectionKey] = true;
-      }
+      if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
     });
     onAfterChange?.();
   }
@@ -913,9 +965,7 @@ const FilterGroupMenu = ({
       for (const item of items) {
         setTopicKey(state.datasets, sectionKey, topicGroup, item.name, nextValue);
       }
-      if (nextValue) {
-        state.datasets[sectionKey] = true;
-      }
+      if (provider === 'opensanctions') syncSectionEnabledFromLeaves(state.datasets, sectionKey, section);
     });
     onAfterChange?.();
   };

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -23,6 +23,7 @@ import {
 import { Icon } from 'ui-icons';
 import { ListAndTopicDatasetConfiguration } from './context/ListAndTopicDatasetConfiguration';
 import {
+  applyAliveDeceasedDefaults,
   buildDatasetKey,
   buildTopicKey,
   isDatasetKeySelected,
@@ -74,7 +75,7 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
     const data = listConfigQuery.data;
     if (!data) return;
     listConfig.update((state) => {
-      // applyAliveDeceasedDefaults(state.datasets, data, useCase);
+      applyAliveDeceasedDefaults(state.datasets, listConfig.value.datasets, useCase);
     });
   }, [listConfigQuery.data, useCase, listConfig]);
 

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -25,7 +25,6 @@ import { ListAndTopicDatasetConfiguration } from './context/ListAndTopicDatasetC
 import {
   buildDatasetKey,
   buildTopicKey,
-  clearSectionSelections,
   isDatasetKeySelected,
   // isGlobalTopicSwitchSelected,
   isTopicKeySelected,
@@ -226,15 +225,9 @@ const Section = ({ sectionKey, section, isActive, onSelect }: SectionProps) => {
                   onCheckedChange={() => {
                     listConfig.update((state) => {
                       const nextValue = !state.datasets[sectionKey];
-                      if (nextValue) {
-                        if (provider === 'opensanctions') {
-                          selectAllInSection(state.datasets, sectionKey, section, true);
-                        } else {
-                          state.datasets[sectionKey] = true;
-                        }
-                      } else {
-                        clearSectionSelections(state.datasets, sectionKey);
-                      }
+                      state.datasets[sectionKey] = nextValue;
+                      if (provider === 'opensanctions')
+                        selectAllInSection(state.datasets, sectionKey, section, nextValue);
                     });
                   }}
                 />
@@ -306,15 +299,8 @@ const SectionPanel = ({ sectionKey, section, onApply, onCancel }: SectionPanelPr
             disabled={mode === 'view'}
             onCheckedChange={(checked) => {
               listConfig.update((state) => {
-                if (checked) {
-                  if (provider === 'opensanctions') {
-                    selectAllInSection(state.datasets, sectionKey, section, true);
-                  } else {
-                    state.datasets[sectionKey] = true;
-                  }
-                } else {
-                  clearSectionSelections(state.datasets, sectionKey);
-                }
+                state.datasets[sectionKey] = checked;
+                if (provider === 'opensanctions') selectAllInSection(state.datasets, sectionKey, section, checked);
               });
             }}
           />

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -2,7 +2,6 @@ import { DatasetTag } from '@app-builder/components/Screenings/DatasetTag';
 import { Spinner } from '@app-builder/components/Spinner';
 import { type AvailableFeatures, type ScreeningCategory } from '@app-builder/models/screening';
 import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
-import { UseQueryResult } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { capitalize } from 'remeda';
@@ -24,7 +23,6 @@ import {
 import { Icon } from 'ui-icons';
 import { ListAndTopicDatasetConfiguration } from './context/ListAndTopicDatasetConfiguration';
 import {
-  applyAliveDeceasedDefaults,
   buildDatasetKey,
   buildTopicKey,
   clearSectionSelections,
@@ -47,7 +45,7 @@ import {
   useDatasetTitle,
 } from './dataset-utils';
 
-type ListConfig = NonNullable<Awaited<ReturnType<typeof useListConfigQuery>>['data']>;
+type ListConfig = NonNullable<Awaited<ReturnType<typeof useListConfigQuery>>['data']>['filters'];
 type SectionData = NonNullable<ListConfig[keyof ListConfig]>;
 
 function groupCheckState(keys: string[], datasetsMap: Record<string, boolean>): CheckedState {
@@ -75,7 +73,7 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
     const data = listConfigQuery.data;
     if (!data) return;
     listConfig.update((state) => {
-      applyAliveDeceasedDefaults(state.datasets, data, useCase);
+      // applyAliveDeceasedDefaults(state.datasets, data, useCase);
     });
   }, [listConfigQuery.data, useCase, listConfig]);
 
@@ -177,17 +175,17 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
               </Button>
             </div>
           ))
-          .with({ isSuccess: true }, ({ data }) => (data ? renderSections(data) : null))
+          .with({ isSuccess: true }, ({ data }) => (data ? renderSections(data.filters) : null))
           .exhaustive()}
       </ScrollAreaV2>
     </>
   );
 }
 
-const SelectedListsCount = ({ listConfigQuery }: { listConfigQuery: UseQueryResult<ListConfig, Error> }) => {
+const SelectedListsCount = ({ listConfigQuery }: { listConfigQuery: ReturnType<typeof useListConfigQuery> }) => {
   const { t } = useTranslation(['continuousScreening']);
   const datasets = ListAndTopicDatasetConfiguration.select((state) => state.datasets);
-  const sectionCount = Object.keys(listConfigQuery.data ?? {}).filter((k) => !!datasets[k]).length;
+  const sectionCount = Object.keys(listConfigQuery.data?.filters ?? {}).filter((k) => !!datasets[k]).length;
   return <span>{t('continuousScreening:creation.datasetSelection.list.count', { count: sectionCount })}</span>;
 };
 

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -1,4 +1,4 @@
-import { DatasetTag } from '@app-builder/components/Screenings/DatasetTag';
+import { DatasetTag, useDatasetTag } from '@app-builder/components/Screenings/DatasetTag';
 import { Spinner } from '@app-builder/components/Spinner';
 import { type AvailableFeatures, type ScreeningCategory } from '@app-builder/models/screening';
 import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
@@ -29,6 +29,7 @@ import {
   isDatasetKeySelected,
   // isGlobalTopicSwitchSelected,
   isTopicKeySelected,
+  selectAllInSection,
   setDatasetKey,
   // setGlobalTopicSwitch,
   setTopicKey,
@@ -200,6 +201,8 @@ const Section = ({ sectionKey, section, isActive, onSelect }: SectionProps) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
   const variant = ListAndTopicDatasetConfiguration.select((state) => state.variant);
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
+
   const { t } = useTranslation(['common', 'continuousScreening', 'scenarios', 'screenings']);
 
   const datasetNames = getDatasetNames(section);
@@ -224,7 +227,11 @@ const Section = ({ sectionKey, section, isActive, onSelect }: SectionProps) => {
                     listConfig.update((state) => {
                       const nextValue = !state.datasets[sectionKey];
                       if (nextValue) {
-                        state.datasets[sectionKey] = true;
+                        if (provider === 'opensanctions') {
+                          selectAllInSection(state.datasets, sectionKey, section, true);
+                        } else {
+                          state.datasets[sectionKey] = true;
+                        }
                       } else {
                         clearSectionSelections(state.datasets, sectionKey);
                       }
@@ -284,16 +291,10 @@ type SectionPanelProps = {
 const SectionPanel = ({ sectionKey, section, onApply, onCancel }: SectionPanelProps) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
+  const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
   const isEnabled = ListAndTopicDatasetConfiguration.select((state) => !!state.datasets[sectionKey]);
   const { t } = useTranslation(['common', 'continuousScreening', 'scenarios', 'screenings']);
-
-  const categoryLabel = match(sectionKey)
-    .with('peps', () => t('scenarios:sanction.lists.peps'))
-    .with('third-parties', () => t('scenarios:sanction.lists.third_parties'))
-    .with('sanctions', () => t('scenarios:sanction.lists.sanctions'))
-    .with('adverse-media', () => t('scenarios:sanction.lists.adverse_media'))
-    .with('global', () => t('scenarios:sanction.lists.global'))
-    .otherwise(() => t('scenarios:sanction.lists.other'));
+  const { getLaTagLabel } = useDatasetTag();
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -306,7 +307,11 @@ const SectionPanel = ({ sectionKey, section, onApply, onCancel }: SectionPanelPr
             onCheckedChange={(checked) => {
               listConfig.update((state) => {
                 if (checked) {
-                  state.datasets[sectionKey] = true;
+                  if (provider === 'opensanctions') {
+                    selectAllInSection(state.datasets, sectionKey, section, true);
+                  } else {
+                    state.datasets[sectionKey] = true;
+                  }
                 } else {
                   clearSectionSelections(state.datasets, sectionKey);
                 }
@@ -317,7 +322,9 @@ const SectionPanel = ({ sectionKey, section, onApply, onCancel }: SectionPanelPr
             htmlFor={`section-switch-${sectionKey}`}
             className={cn('text-s font-semibold', isEnabled ? 'text-purple-primary' : 'text-grey-primary')}
           >
-            {t('continuousScreening:creation.datasetSelection.section.activate', { category: categoryLabel })}
+            {t('continuousScreening:creation.datasetSelection.section.activate', {
+              category: getLaTagLabel(sectionKey),
+            })}
           </label>
         </div>
         {isEnabled && <SectionContent sectionKey={sectionKey} section={section} />}

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/context/ListAndTopicDatasetConfiguration.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/context/ListAndTopicDatasetConfiguration.ts
@@ -1,3 +1,4 @@
+import { type ScreeningProviders } from '@app-builder/models/screening';
 import { createSharpFactory } from 'sharpstate';
 
 export type ListAndTopicDatasetConfigurationMode = 'view' | 'edit' | 'create';
@@ -6,6 +7,7 @@ export type ListAndTopicDatasetConfigurationVariant = 'default' | 'popover';
 type ListAndTopicDatasetConfigurationParams = {
   datasets: Record<string, boolean>;
   mode: ListAndTopicDatasetConfigurationMode;
+  provider: ScreeningProviders;
   variant?: ListAndTopicDatasetConfigurationVariant;
 };
 
@@ -14,6 +16,7 @@ export const ListAndTopicDatasetConfiguration = createSharpFactory({
   initializer: (params: ListAndTopicDatasetConfigurationParams) => ({
     datasets: params.datasets,
     mode: params.mode,
+    provider: params.provider,
     variant: params.variant ?? 'default',
   }),
 }).withActions({

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
@@ -67,15 +67,6 @@ export function setTopicKey(
   datasets[buildTopicKey(sectionKey, topicGroup, value)] = selected;
 }
 
-export function clearSectionSelections(datasets: Record<string, boolean>, sectionKey: ScreeningCategory): void {
-  datasets[sectionKey] = false;
-  for (const key of Object.keys(datasets)) {
-    if (key.startsWith(`${sectionKey}:`)) {
-      datasets[key] = false;
-    }
-  }
-}
-
 type SelectableSection = {
   datasets?: { datasets: { name: string }[] }[];
   topics?: Record<string, { name: string }[]>;

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
@@ -76,6 +76,44 @@ export function clearSectionSelections(datasets: Record<string, boolean>, sectio
   }
 }
 
+type SelectableSection = {
+  datasets?: { datasets: { name: string }[] }[];
+  topics?: Record<string, { name: string }[]>;
+  conditionalTopics?: Record<string, { items: { name: string }[] }>;
+};
+
+/**
+ * Marks the section flag and every dataset / topic / conditional-topic available
+ * in `section` as `selected`. Unlike `setSectionSelections`, this enumerates the
+ * section's full catalogue rather than only flipping keys already in the map.
+ */
+export function selectAllInSection(
+  datasets: Record<string, boolean>,
+  sectionKey: ScreeningCategory,
+  section: SelectableSection,
+  selected: boolean,
+): void {
+  datasets[sectionKey] = selected;
+
+  for (const group of section.datasets ?? []) {
+    for (const item of group.datasets) {
+      datasets[buildDatasetKey(sectionKey, item.name)] = selected;
+    }
+  }
+
+  for (const [topicGroup, items] of Object.entries(section.topics ?? {})) {
+    for (const item of items) {
+      datasets[buildTopicKey(sectionKey, topicGroup, item.name)] = selected;
+    }
+  }
+
+  for (const [topicGroup, { items }] of Object.entries(section.conditionalTopics ?? {})) {
+    for (const item of items) {
+      datasets[buildTopicKey(sectionKey, topicGroup, item.name)] = selected;
+    }
+  }
+}
+
 export function syncSharpDatasets(datasets: Record<string, boolean>, selected: string[]): void {
   const nextDatasets = makeDatasetsMap(selected);
 

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
@@ -181,3 +181,36 @@ export function applyAliveDeceasedDefaults(
     }
   }
 }
+
+/** Keeps the bare section flag aligned with whether any leaf item in the section is selected. */
+export function syncSectionEnabledFromLeaves(
+  datasets: Record<string, boolean>,
+  sectionKey: ScreeningCategory,
+  section: SelectableSection,
+): void {
+  datasets[sectionKey] = getSelectableSectionLeafKeys(sectionKey, section).some((key) => datasets[key]);
+}
+
+function getSelectableSectionLeafKeys(sectionKey: ScreeningCategory, section: SelectableSection): string[] {
+  const keys: string[] = [];
+
+  for (const group of section.datasets ?? []) {
+    for (const item of group.datasets) {
+      keys.push(buildDatasetKey(sectionKey, item.name));
+    }
+  }
+
+  for (const [topicGroup, items] of Object.entries(section.topics ?? {})) {
+    for (const item of items) {
+      keys.push(buildTopicKey(sectionKey, topicGroup, item.name));
+    }
+  }
+
+  for (const [topicGroup, { items }] of Object.entries(section.conditionalTopics ?? {})) {
+    for (const item of items) {
+      keys.push(buildTopicKey(sectionKey, topicGroup, item.name));
+    }
+  }
+
+  return keys;
+}

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/index.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/index.ts
@@ -17,6 +17,7 @@ export {
   setDatasetKey,
   setGlobalTopicSwitch,
   setTopicKey,
+  syncSectionEnabledFromLeaves,
   syncSharpDatasets,
 } from './dataset-selection-provider-utils';
 export {

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/index.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/index.ts
@@ -8,7 +8,6 @@ export {
   applyAliveDeceasedDefaults,
   buildDatasetKey,
   buildTopicKey,
-  clearSectionSelections,
   getCanonicalSelectedKeys,
   isDatasetKeySelected,
   isGlobalTopicSwitchSelected,

--- a/packages/app-builder/src/components/Scenario/Screening/FieldDataset.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/FieldDataset.tsx
@@ -5,6 +5,9 @@ import {
   ListAndTopicDatasetConfiguration,
   makeDatasetsMap,
 } from '@app-builder/components/ListAndTopicConfiguration';
+import { Spinner } from '@app-builder/components/Spinner';
+import { type ScreeningProviders } from '@app-builder/models/screening';
+import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
 import { useSignalEffect } from '@preact/signals-react';
 import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,21 +16,54 @@ function getDatasetsKey(datasets: string[]): string {
   return [...datasets].sort().join(',');
 }
 
-export const FieldDataset = ({
-  value,
-  onChange,
-  readOnly = false,
-}: {
+type FieldDatasetProps = {
   value?: string[];
   onChange?: (value: string[]) => void;
   readOnly?: boolean;
-}) => {
+};
+
+export const FieldDataset = ({ value, onChange, readOnly = false }: FieldDatasetProps) => {
   const { t } = useTranslation();
+  const listConfigQuery = useListConfigQuery('transaction_monitoring');
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-s font-semibold">{t('scenarios:sanction.lists.title')}</span>
+      <div className="bg-surface-card border-grey-border flex flex-col gap-4 rounded-sm border p-4">
+        <Callout variant="outlined">
+          <p className="whitespace-pre-wrap">{t('scenarios:sanction.lists.callout')}</p>
+        </Callout>
+        {listConfigQuery.data ? (
+          <FieldDatasetInner
+            provider={listConfigQuery.data.provider}
+            value={value}
+            onChange={onChange}
+            readOnly={readOnly}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-50">
+            <Spinner className="size-10" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const FieldDatasetInner = ({
+  provider,
+  value,
+  onChange,
+  readOnly,
+}: {
+  provider: ScreeningProviders;
+} & FieldDatasetProps) => {
   const valueKey = useMemo(() => getDatasetsKey(value ?? []), [value]);
 
   const listSharp = ListAndTopicDatasetConfiguration.createSharp({
     datasets: makeDatasetsMap(value ?? []),
     mode: readOnly ? 'view' : 'edit',
+    provider,
   });
 
   const onChangeRef = useRef(onChange);
@@ -63,16 +99,8 @@ export const FieldDataset = ({
   });
 
   return (
-    <div className="flex flex-col gap-2">
-      <span className="text-s font-semibold">{t('scenarios:sanction.lists.title')}</span>
-      <div className="bg-surface-card border-grey-border flex flex-col gap-4 rounded-sm border p-4">
-        <Callout variant="outlined">
-          <p className="whitespace-pre-wrap">{t('scenarios:sanction.lists.callout')}</p>
-        </Callout>
-        <ListAndTopicDatasetConfiguration.Provider value={listSharp}>
-          <DatasetSelectionContent useCase="transaction_monitoring" />
-        </ListAndTopicDatasetConfiguration.Provider>
-      </div>
-    </div>
+    <ListAndTopicDatasetConfiguration.Provider value={listSharp}>
+      <DatasetSelectionContent useCase="transaction_monitoring" />
+    </ListAndTopicDatasetConfiguration.Provider>
   );
 };

--- a/packages/app-builder/src/components/Scenario/Screening/FieldDataset.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/FieldDataset.tsx
@@ -11,6 +11,7 @@ import { useListConfigQuery } from '@app-builder/queries/screening/lists-config'
 import { useSignalEffect } from '@preact/signals-react';
 import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { match } from 'ts-pattern';
 
 function getDatasetsKey(datasets: string[]): string {
   return [...datasets].sort().join(',');
@@ -33,18 +34,20 @@ export const FieldDataset = ({ value, onChange, readOnly = false }: FieldDataset
         <Callout variant="outlined">
           <p className="whitespace-pre-wrap">{t('scenarios:sanction.lists.callout')}</p>
         </Callout>
-        {listConfigQuery.data ? (
-          <FieldDatasetInner
-            provider={listConfigQuery.data.provider}
-            value={value}
-            onChange={onChange}
-            readOnly={readOnly}
-          />
-        ) : (
-          <div className="flex items-center justify-center h-50">
-            <Spinner className="size-10" />
-          </div>
-        )}
+        {match(listConfigQuery)
+          .with({ isPending: true }, () => (
+            <div className="flex items-center justify-center h-50">
+              <Spinner className="size-10" />
+            </div>
+          ))
+          .with({ isError: true }, () => (
+            <div className="flex flex-col gap-v2-md items-center justify-center h-50">
+              <div className="">{t('common:generic_fetch_data_error')}</div>
+            </div>
+          ))
+          .otherwise(({ data }) => (
+            <FieldDatasetInner provider={data.provider} value={value} onChange={onChange} readOnly={readOnly} />
+          ))}
       </div>
     </div>
   );

--- a/packages/app-builder/src/components/Screenings/DatasetTag.tsx
+++ b/packages/app-builder/src/components/Screenings/DatasetTag.tsx
@@ -4,17 +4,22 @@ import { match } from 'ts-pattern';
 import { Tag } from 'ui-design-system';
 
 export const DatasetTag = ({ category }: { category: ScreeningCategory }) => {
+  const { getLaTagLabel } = useDatasetTag();
+  return <Tag color={SCREENING_CATEGORY_COLORS[category]}>{getLaTagLabel(category)}</Tag>;
+};
+
+export function useDatasetTag() {
   const { t } = useTranslation(['scenarios']);
 
-  return (
-    <Tag color={SCREENING_CATEGORY_COLORS[category]}>
-      {match(category)
-        .with('peps', () => t(`scenarios:sanction.lists.peps`))
-        .with('third-parties', () => t(`scenarios:sanction.lists.third_parties`))
-        .with('sanctions', () => t(`scenarios:sanction.lists.sanctions`))
-        .with('adverse-media', () => t(`scenarios:sanction.lists.adverse_media`))
-        .with('global', () => t(`scenarios:sanction.lists.global`))
-        .otherwise(() => t(`scenarios:sanction.lists.other`))}
-    </Tag>
-  );
-};
+  function getLaTagLabel(category: ScreeningCategory) {
+    return match(category)
+      .with('peps', () => t(`scenarios:sanction.lists.peps`))
+      .with('third-parties', () => t(`scenarios:sanction.lists.third_parties`))
+      .with('sanctions', () => t(`scenarios:sanction.lists.sanctions`))
+      .with('adverse-media', () => t(`scenarios:sanction.lists.adverse_media`))
+      .with('global', () => t(`scenarios:sanction.lists.global`))
+      .otherwise(() => t(`scenarios:sanction.lists.other`));
+  }
+
+  return { getLaTagLabel };
+}

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/DatasetsPopover.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/DatasetsPopover.tsx
@@ -64,7 +64,7 @@ export const DatasetsPopover = ({ selectedDatasets, onApply, disabled }: Dataset
   const sectionTags = useMemo(() => {
     const data = listConfigQuery.data;
     if (!data || !hasSelection) return [];
-    return Object.entries(data)
+    return Object.entries(data.filters)
       .filter(([key]) => key !== 'global')
       .flatMap(([key, section]) => {
         if (!section) return [];

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
@@ -67,6 +67,8 @@ export const FreeformSearchForm: FunctionComponent<FreeformSearchFormProps> = ({
     datasets: makeDatasetsMap(selectedDatasets),
     mode: 'edit',
     variant: 'popover',
+    provider: 'lexisnexis',
+    // provider,
   });
 
   useEffect(() => {

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
@@ -6,16 +6,18 @@ import {
   syncSharpDatasets,
 } from '@app-builder/components/ListAndTopicConfiguration';
 import { ScreeningThreshold } from '@app-builder/components/ScreeningThreshold';
+import { Spinner } from '@app-builder/components/Spinner';
 import { SEARCH_ENTITIES } from '@app-builder/constants/screening-entity';
-import { type ScreeningMatchPayload } from '@app-builder/models/screening';
+import { type ScreeningMatchPayload, ScreeningProviders } from '@app-builder/models/screening';
 import { useFreeformSearchMutation } from '@app-builder/queries/screening/freeform-search';
-import { type ListConfigFilters } from '@app-builder/queries/screening/lists-config';
+import { type ListConfigFilters, useListConfigQuery } from '@app-builder/queries/screening/lists-config';
 import { type FreeformSearchInput } from '@app-builder/server-fns/screenings';
 import { useOrganizationDetails } from '@app-builder/services/organization/organization-detail';
 import { useForm, useStore } from '@tanstack/react-form';
 import { createContext, type FunctionComponent, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { match } from 'ts-pattern';
 import { Button, Input } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { screeningsI18n } from '../screenings-i18n';
@@ -53,7 +55,31 @@ export function useFormManuallSearch() {
   return form;
 }
 
-export const FreeformSearchForm: FunctionComponent<FreeformSearchFormProps> = ({ onSearchComplete, listConfig }) => {
+export const FreeformSearchForm: FunctionComponent<FreeformSearchFormProps> = ({ onSearchComplete }) => {
+  const listConfigQuery = useListConfigQuery('manual_search');
+  const { t } = useTranslation('common');
+
+  return match(listConfigQuery)
+    .with({ isPending: true }, () => (
+      <div className="flex items-center justify-center h-50">
+        <Spinner className="size-10" />
+      </div>
+    ))
+    .with({ isError: true }, () => (
+      <div className="flex flex-col gap-v2-md items-center justify-center h-50">
+        <div className="">{t('common:generic_fetch_data_error')}</div>
+      </div>
+    ))
+    .otherwise(({ data }) => (
+      <FreeformSearchFormInner provider={data.provider} listConfig={data.filters} onSearchComplete={onSearchComplete} />
+    ));
+};
+
+const FreeformSearchFormInner: FunctionComponent<{ provider: ScreeningProviders } & FreeformSearchFormProps> = ({
+  provider,
+  onSearchComplete,
+  listConfig,
+}) => {
   const { t } = useTranslation(screeningsI18n);
   const searchMutation = useFreeformSearchMutation();
   const [selectedDatasets, setSelectedDatasets] = useState<string[]>(() => {
@@ -67,8 +93,7 @@ export const FreeformSearchForm: FunctionComponent<FreeformSearchFormProps> = ({
     datasets: makeDatasetsMap(selectedDatasets),
     mode: 'edit',
     variant: 'popover',
-    provider: 'lexisnexis',
-    // provider,
+    provider,
   });
 
   useEffect(() => {

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/LimitPopover.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/LimitPopover.tsx
@@ -47,7 +47,7 @@ export const LimitPopover = ({
   const tagRef = useRef<HTMLDivElement>(null);
 
   const listConfig = listConfigQuery.data;
-  const availableGlobalTopicConfigs = listConfig ? getAvailableGlobalTopicConfigs(listConfig) : [];
+  const availableGlobalTopicConfigs = listConfig ? getAvailableGlobalTopicConfigs(listConfig.filters) : [];
   const includeDeceasedSelected =
     listConfig != null &&
     availableGlobalTopicConfigs.some((config) => isGlobalTopicSwitchSelected(listSharp.value.datasets, config));

--- a/packages/app-builder/src/models/screening.ts
+++ b/packages/app-builder/src/models/screening.ts
@@ -697,6 +697,8 @@ export type ScreeningAvailableFiltersAdapted = ScreeningAvailableFilters & {
   conditional_filters?: { key: string; name: string; topics: { name: string; key?: string; title: string }[] }[];
 };
 
+export type ScreeningProviders = ScreeningAvailableFilters['provider'];
+
 export interface SavedScreeningSearchInputs {
   entityType: SearchableSchema;
   fields: Record<string, string>;

--- a/packages/app-builder/src/queries/screening/lists-config.ts
+++ b/packages/app-builder/src/queries/screening/lists-config.ts
@@ -1,5 +1,10 @@
 import { buildDatasetKey } from '@app-builder/components/ListAndTopicConfiguration';
-import { AvailableFeatures, ScreeningAvailableFiltersAdapted, ScreeningCategory } from '@app-builder/models/screening';
+import {
+  AvailableFeatures,
+  ScreeningAvailableFiltersAdapted,
+  ScreeningCategory,
+  ScreeningProviders,
+} from '@app-builder/models/screening';
 import { getListConfigFn } from '@app-builder/server-fns/screenings';
 import { useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
@@ -26,6 +31,11 @@ type NormalizedSection = {
 export type ListConfigFilters = Partial<Record<ScreeningCategory, NormalizedSection>>;
 type SectionKeys = keyof ListConfigFilters;
 
+export type NormalizedListConfig = {
+  filters: ListConfigFilters;
+  provider: ScreeningProviders;
+};
+
 function groupBySection(
   datasets: { section?: string; name: string; title: string }[],
   name: SectionKeys,
@@ -39,7 +49,7 @@ function groupBySection(
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function normalizeListConfig(config: ScreeningAvailableFiltersAdapted): ListConfigFilters {
+export function normalizeListConfig(config: ScreeningAvailableFiltersAdapted): NormalizedListConfig {
   function normalize(
     section: ScreeningAvailableFiltersSection | undefined,
     name: SectionKeys,
@@ -68,14 +78,17 @@ export function normalizeListConfig(config: ScreeningAvailableFiltersAdapted): L
 
     return adaptedSection;
   }
-  if (!config) return {};
+  if (!config) return { filters: {}, provider: 'opensanctions' };
 
   return {
-    sanctions: normalize(config.sections.sanctions, 'sanctions'),
-    peps: normalize(config.sections.peps, 'peps'),
-    'adverse-media': normalize(config.sections.adverse_media, 'adverse-media'),
-    'third-parties': normalize(config.sections.other, 'third-parties'),
-    global: normalize(config.sections.global, 'global'),
+    filters: {
+      sanctions: normalize(config.sections.sanctions, 'sanctions'),
+      peps: normalize(config.sections.peps, 'peps'),
+      'adverse-media': normalize(config.sections.adverse_media, 'adverse-media'),
+      'third-parties': normalize(config.sections.other, 'third-parties'),
+      global: normalize(config.sections.global, 'global'),
+    },
+    provider: config.provider,
   };
 }
 

--- a/packages/app-builder/src/routes/_app/_builder/screening-search/index.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/screening-search/index.tsx
@@ -84,7 +84,7 @@ function ScreeningSearchIndexPage() {
               {/* <ViewSavedResults /> */}
             </div>
           </div>
-          <FreeformSearchPage onSearchComplete={handleSearchComplete} listConfig={listConfig} />
+          <FreeformSearchPage onSearchComplete={handleSearchComplete} listConfig={listConfig.filters} />
         </Page.ContentV2>
       </Page.Container>
     </Page.Main>


### PR DESCRIPTION
Add a different behavior when selecting or deselecting a section depending of the provider:

OS: affect all the attached datasets to the same value, and when no list is selected, the section is reset  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced continuous monitoring configuration with improved provider data integration.
  * Refined dataset and topic selection with provider-specific synchronization capabilities.

* **Improvements**
  * More robust handling of screening list configurations.
  * Better UI feedback with loading indicators during configuration data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-frontend/pull/1584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->