### PR TITLE
Display of datasets and topics improvement

### DIFF
--- a/packages/app-builder/src/components/ContinuousScreening/ConfigurationsPage.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/ConfigurationsPage.tsx
@@ -3,29 +3,34 @@ import {
   ContinuousScreeningConfig,
   PrevalidationCreateContinuousScreeningConfig,
 } from '@app-builder/models/continuous-screening';
-import { useContinuousScreeningConfigurationsQuery } from '@app-builder/queries/continuous-screening/configurations';
+import { ScreeningAvailableFiltersAdapted } from '@app-builder/models/screening';
+import { ContinuousScreeningConfiguration } from '@app-builder/queries/continuous-screening/configurations';
 import QueryString from 'qs';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { match } from 'ts-pattern';
+import { match, P } from 'ts-pattern';
 import { Button, ExpandableGroupTagLine, Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { CopyToClipboardButton } from '../CopyToClipboardButton';
 import GridTable from '../GridTable';
 import { makeDatasetsMap } from '../ListAndTopicConfiguration/dataset-selection-provider-utils';
-import { useDatasetTitle } from '../ListAndTopicConfiguration/dataset-utils';
+import { findDatasetOrTopicByKey, useDatasetTitle } from '../ListAndTopicConfiguration/dataset-utils';
 import { Page } from '../Page';
 import { PanelRoot } from '../Panel/Panel';
-import { Spinner } from '../Spinner';
 import { ConfigurationPanel } from './ConfigurationPanel';
 import { CreationModal } from './CreationModal';
 import { PartialCreateContinuousScreeningConfig } from './context/CreationStepper';
 import { EditionValidationPanel } from './EditionValidationPanel';
 
-export const ConfigurationsPage = ({ canEdit }: { canEdit: boolean }) => {
+type ConfigurationsPageProps = {
+  canEdit: boolean;
+  configurations: ContinuousScreeningConfiguration[];
+  datasets: ScreeningAvailableFiltersAdapted;
+};
+
+export const ConfigurationsPage = ({ canEdit, configurations, datasets }: ConfigurationsPageProps) => {
   const { t } = useTranslation(['common', 'continuousScreening', 'navigation']);
-  const { formatDatasetTitle } = useDatasetTitle();
-  const configurationsQuery = useContinuousScreeningConfigurationsQuery();
+  const { formatItemName } = useDatasetTitle();
   const [creationModalOpen, setCreationModalOpen] = useState(false);
   const navigate = useAgnosticNavigation();
 
@@ -76,39 +81,21 @@ export const ConfigurationsPage = ({ canEdit }: { canEdit: boolean }) => {
               </Button>
             ) : null}
           </div>
-          {match(configurationsQuery)
-            .with({ isPending: true }, () => (
-              <div className="flex flex-col gap-v2-sm items-center justify-center py-10 border border-grey-border rounded-lg bg-surface-card">
-                <Spinner className="size-10 text-purple-primary" />
-                <span>{t('continuousScreening:configurations.list.loading')}</span>
-              </div>
-            ))
-            .with({ isError: true }, () => (
-              <div className="flex flex-col gap-v2-sm items-center justify-center py-10 border border-grey-border rounded-lg bg-surface-card">
-                <div className="">{t('common:generic_fetch_data_error')}</div>
-                <Button variant="secondary" onClick={() => configurationsQuery.refetch()}>
-                  {t('common:retry')}
-                </Button>
-              </div>
-            ))
-            .with({ isSuccess: true }, ({ data: configurations }) => {
-              if (!configurations) return null;
-              if (configurations.length === 0) {
-                return (
-                  <div className="flex flex-col gap-v2-sm items-center justify-center py-10 border border-grey-border rounded-lg bg-surface-card">
-                    <Icon icon="scan-eye" className="size-10 text-purple-primary" />
-                    <span>{t('continuousScreening:configurations.list.empty')}</span>
-                    {canEdit ? (
-                      <Button variant="primary" onClick={() => setCreationModalOpen(true)}>
-                        <Icon icon="plus" className="size-4" />
-                        {t('continuousScreening:configurations.add_configuration')}
-                      </Button>
-                    ) : null}
-                  </div>
-                );
-              }
-
-              return (
+          {match(configurations)
+            .with(P.nullish, () => null)
+            .with(P.array(), (configurations) =>
+              configurations.length === 0 ? (
+                <div className="flex flex-col gap-v2-sm items-center justify-center py-10 border border-grey-border rounded-lg bg-surface-card">
+                  <Icon icon="scan-eye" className="size-10 text-purple-primary" />
+                  <span>{t('continuousScreening:configurations.list.empty')}</span>
+                  {canEdit ? (
+                    <Button variant="primary" onClick={() => setCreationModalOpen(true)}>
+                      <Icon icon="plus" className="size-4" />
+                      {t('continuousScreening:configurations.add_configuration')}
+                    </Button>
+                  ) : null}
+                </div>
+              ) : (
                 <GridTable.Table className="grid-cols-[minmax(0,_33.33%)_repeat(3,_1fr)]">
                   <GridTable.Row className="font-semibold border-b border-grey-border">
                     <GridTable.Cell>{t('continuousScreening:configurations.list.column.name')}</GridTable.Cell>
@@ -131,11 +118,17 @@ export const ConfigurationsPage = ({ canEdit }: { canEdit: boolean }) => {
                       <GridTable.Cell className="min-w-0">
                         <div className="flex min-w-0 w-full max-w-[20vw] overflow-hidden">
                           <ExpandableGroupTagLine
-                            items={item.datasets.map((d) => (
-                              <Tag key={d} color="grey">
-                                {formatDatasetTitle(d)}
-                              </Tag>
-                            ))}
+                            items={item.datasets.map((d) => {
+                              const resolvedItem = findDatasetOrTopicByKey(datasets, d);
+                              const itemName = resolvedItem ? formatItemName(resolvedItem) : d;
+                              return (
+                                <Tag key={d} color="grey">
+                                  <span className="max-w-[15ch] truncate" title={itemName}>
+                                    {itemName}
+                                  </span>
+                                </Tag>
+                              );
+                            })}
                           />
                         </div>
                       </GridTable.Cell>
@@ -154,9 +147,10 @@ export const ConfigurationsPage = ({ canEdit }: { canEdit: boolean }) => {
                     </GridTable.Row>
                   ))}
                 </GridTable.Table>
-              );
-            })
+              ),
+            )
             .exhaustive()}
+
           <CreationModal open={creationModalOpen} onOpenChange={setCreationModalOpen} onSubmit={handleCreationSubmit} />
           {editingConfig && draft ? (
             <PanelRoot open onOpenChange={handlePanelOpenChange}>
@@ -171,6 +165,7 @@ export const ConfigurationsPage = ({ canEdit }: { canEdit: boolean }) => {
                 <EditionValidationPanel
                   baseConfig={editingConfig}
                   updatedConfig={updatedConfig}
+                  datasets={datasets}
                   onCancel={() => setUpdatedConfig(null)}
                 />
               ) : null}

--- a/packages/app-builder/src/components/ContinuousScreening/EditionValidationPanel.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/EditionValidationPanel.tsx
@@ -4,6 +4,7 @@ import {
   ContinuousScreeningConfig,
   PrevalidationCreateContinuousScreeningConfig,
 } from '@app-builder/models/continuous-screening';
+import { ScreeningAvailableFiltersAdapted } from '@app-builder/models/screening';
 import { useUpdateContinuousScreeningConfigurationMutation } from '@app-builder/queries/continuous-screening/update-configuration';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
@@ -23,9 +24,15 @@ export type EditionValidationPanelBaseProps = {
 
 export type EditionValidationPanelProps = EditionValidationPanelBaseProps & {
   onCancel: (draft: PrevalidationCreateContinuousScreeningConfig) => void;
+  datasets: ScreeningAvailableFiltersAdapted;
 };
 
-export const EditionValidationPanel = ({ baseConfig, updatedConfig, onCancel }: EditionValidationPanelProps) => {
+export const EditionValidationPanel = ({
+  baseConfig,
+  updatedConfig,
+  onCancel,
+  datasets,
+}: EditionValidationPanelProps) => {
   const panelSharp = PanelSharpFactory.useSharp();
   const { t } = useTranslation(['continuousScreening', 'common']);
   const updateConfigurationMutation = useUpdateContinuousScreeningConfigurationMutation(baseConfig.stableId);
@@ -60,7 +67,7 @@ export const EditionValidationPanel = ({ baseConfig, updatedConfig, onCancel }: 
           {t('continuousScreening:edition.validation.validation_callout')}
         </Callout>
         <GeneralInfoSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
-        <DatasetSelectionSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
+        <DatasetSelectionSection updatedConfig={updatedConfig} baseConfig={baseConfig} datasets={datasets} />
         <ScoringConfigurationSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
         <ObjectMappingSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
       </div>

--- a/packages/app-builder/src/components/ContinuousScreening/validation/DatasetSelectionSection.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/validation/DatasetSelectionSection.tsx
@@ -32,7 +32,7 @@ function DatasetChangeList({
     const category = getSectionFromKey(key);
     return (
       <div key={key} className="flex items-center justify-between gap-v2-sm">
-        <span className="truncate">{formatItemName(item)}</span>
+        <span className="truncate min-w-0">{formatItemName(item)}</span>
         {category ? <DatasetTag category={category} /> : null}
       </div>
     );

--- a/packages/app-builder/src/components/ContinuousScreening/validation/DatasetSelectionSection.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/validation/DatasetSelectionSection.tsx
@@ -1,18 +1,56 @@
-import { useDatasetTitle } from '@app-builder/components/ListAndTopicConfiguration/dataset-utils';
-import { ScreeningCategory } from '@app-builder/models/screening';
-import { useScreeningDatasetsQuery } from '@app-builder/queries/screening/datasets';
+import {
+  findDatasetOrTopicByKey,
+  useDatasetTitle,
+} from '@app-builder/components/ListAndTopicConfiguration/dataset-utils';
+import type { ScreeningAvailableFiltersAdapted, ScreeningCategory } from '@app-builder/models/screening';
+import { SCREENING_CATEGORY_TO_DTO_SECTION } from '@app-builder/models/screening-config';
 import { useTranslation } from 'react-i18next';
-import * as R from 'remeda';
-import { match } from 'ts-pattern';
-import { Button, Collapsible } from 'ui-design-system';
+import { Collapsible } from 'ui-design-system';
 import { DatasetTag } from '../../Screenings/DatasetTag';
-import { Spinner } from '../../Spinner';
 import { EditionValidationPanelBaseProps } from '../EditionValidationPanel';
 
-export const DatasetSelectionSection = ({ updatedConfig, baseConfig }: EditionValidationPanelBaseProps) => {
+function getSectionFromKey(key: string): ScreeningCategory | undefined {
+  const section = key.split(':')[0];
+  if (!section || !(section in SCREENING_CATEGORY_TO_DTO_SECTION)) return undefined;
+  return section as ScreeningCategory;
+}
+
+function DatasetChangeList({
+  keys,
+  catalog,
+  emptyLabel,
+}: {
+  keys: string[];
+  catalog: ScreeningAvailableFiltersAdapted;
+  emptyLabel: string;
+}) {
+  const { formatItemName } = useDatasetTitle();
+  const rows = keys.flatMap((key) => {
+    const item = findDatasetOrTopicByKey(catalog, key);
+    if (!item) return [];
+
+    const category = getSectionFromKey(key);
+    return (
+      <div key={key} className="flex items-center justify-between gap-v2-sm">
+        <span className="truncate">{formatItemName(item)}</span>
+        {category ? <DatasetTag category={category} /> : null}
+      </div>
+    );
+  });
+
+  if (rows.length === 0) {
+    return <span className="text-grey-secondary text-center">{emptyLabel}</span>;
+  }
+
+  return rows;
+}
+
+type DatasetSelectionSectionProps = EditionValidationPanelBaseProps & {
+  datasets: ScreeningAvailableFiltersAdapted;
+};
+
+export const DatasetSelectionSection = ({ updatedConfig, baseConfig, datasets }: DatasetSelectionSectionProps) => {
   const { t } = useTranslation(['common', 'continuousScreening']);
-  const { formatDatasetTitle } = useDatasetTitle();
-  const datasetsQuery = useScreeningDatasetsQuery();
   const addedDatasets = Object.keys(updatedConfig.datasets).filter(
     (k) => !!updatedConfig.datasets[k] && !baseConfig.datasets.includes(k),
   );
@@ -22,72 +60,28 @@ export const DatasetSelectionSection = ({ updatedConfig, baseConfig }: EditionVa
     <Collapsible.Container>
       <Collapsible.Title>{t('continuousScreening:edition.validation.datasetSelection.title')}</Collapsible.Title>
       <Collapsible.Content>
-        {match(datasetsQuery)
-          .with({ isPending: true }, () => (
-            <div className="flex items-center justify-center h-50">
-              <Spinner className="size-10" />
+        <div className="grid grid-cols-2 gap-v2-md">
+          <div className="flex flex-col gap-v2-sm">
+            <span>{t('continuousScreening:edition.validation.datasetSelection.added.title')}</span>
+            <div className="flex flex-col gap-v2-sm border border-grey-border rounded-v2-md p-v2-md max-h-50 overflow-y-auto">
+              <DatasetChangeList
+                keys={addedDatasets}
+                catalog={datasets}
+                emptyLabel={t('continuousScreening:edition.validation.datasetSelection.no_added')}
+              />
             </div>
-          ))
-          .with({ isError: true }, () => (
-            <div className="flex flex-col gap-v2-md items-center justify-center h-50">
-              <div className="">{t('common:generic_fetch_data_error')}</div>
-              <Button variant="secondary" onClick={() => datasetsQuery.refetch()}>
-                {t('common:retry')}
-              </Button>
+          </div>
+          <div className="flex flex-col gap-v2-sm">
+            <span>{t('continuousScreening:edition.validation.datasetSelection.removed.title')}</span>
+            <div className="flex flex-col gap-v2-sm border border-grey-border rounded-v2-md p-v2-md max-h-50 overflow-y-auto">
+              <DatasetChangeList
+                keys={removedDatasets}
+                catalog={datasets}
+                emptyLabel={t('continuousScreening:edition.validation.datasetSelection.no_removed')}
+              />
             </div>
-          ))
-          .with({ isSuccess: true }, ({ data: { datasets } }) => {
-            if (!datasets?.sections) return null;
-            const datasetsArray = R.pipe(
-              datasets.sections,
-              R.flatMap(R.prop('datasets')),
-              R.map((d) => ({ name: d.name, tag: d.tag, title: d.title })),
-            );
-
-            return (
-              <div className="grid grid-cols-2 gap-v2-md">
-                <div className="flex flex-col gap-v2-sm">
-                  <span>{t('continuousScreening:edition.validation.datasetSelection.added.title')}</span>
-                  <div className="flex flex-col gap-v2-sm border border-grey-border rounded-v2-md p-v2-md max-h-50 overflow-y-auto">
-                    {addedDatasets.map((k) => {
-                      const dataset = datasetsArray.find((d) => d.name === k);
-                      return (
-                        <div key={k} className="flex items-center justify-between gap-v2-sm">
-                          <span>{formatDatasetTitle(dataset?.title ?? k)}</span>
-                          {dataset ? <DatasetTag category={dataset.tag as ScreeningCategory} /> : null}
-                        </div>
-                      );
-                    })}
-                    {addedDatasets.length === 0 && (
-                      <span className="text-grey-secondary text-center">
-                        {t('continuousScreening:edition.validation.datasetSelection.no_added')}
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex flex-col gap-v2-sm">
-                  <span>{t('continuousScreening:edition.validation.datasetSelection.removed.title')}</span>
-                  <div className="flex flex-col gap-v2-sm border border-grey-border rounded-v2-md p-v2-md max-h-50 overflow-y-auto">
-                    {removedDatasets.map((k) => {
-                      const dataset = datasetsArray.find((d) => d.name === k);
-                      return (
-                        <div key={k} className="flex items-center justify-between gap-v2-sm">
-                          <span>{formatDatasetTitle(dataset?.title ?? k)}</span>
-                          {dataset ? <DatasetTag category={dataset.tag as ScreeningCategory} /> : null}
-                        </div>
-                      );
-                    })}
-                    {removedDatasets.length === 0 && (
-                      <span className="text-grey-secondary text-center">
-                        {t('continuousScreening:edition.validation.datasetSelection.no_removed')}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            );
-          })
-          .exhaustive()}
+          </div>
+        </div>
       </Collapsible.Content>
     </Collapsible.Container>
   );

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-utils.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-utils.ts
@@ -1,20 +1,15 @@
-import type { ScreeningCategory } from '@app-builder/models/screening';
+import type { ScreeningAvailableFiltersAdapted, ScreeningCategory } from '@app-builder/models/screening';
+import { SCREENING_CATEGORY_TO_DTO_SECTION } from '@app-builder/models/screening-config';
 import type { ListConfigFilters } from '@app-builder/queries/screening/lists-config';
+import type { ScreeningAvailableFiltersSection } from 'marble-api';
 import { capitalize } from 'radash';
 import { useTranslation } from 'react-i18next';
 
-export type TopicItem = NonNullable<SectionData['topics']>[keyof NonNullable<SectionData['topics']>][number];
+export type DatasetTopicSearchResult = { name: string; title: string };
 
-// All fields derived from listConfig.global.topics + conventions:
-// - keys[0]: always persisted when the global topic switch is active
-// - keys[1] / value: persisted when the switch is ON
-// - label: `screenings:freeform_search.global.${groupKey}`
-export type GlobalTopicConfig = {
-  groupKey: string;
-  keys: string[];
-  value: string;
-  label: string;
-};
+type SectionData = NonNullable<ListConfigFilters[keyof ListConfigFilters]>;
+
+export type TopicItem = NonNullable<SectionData['topics']>[keyof NonNullable<SectionData['topics']>][number];
 
 type SpecialTopicConfig = TopicItem & {
   section: ScreeningCategory;
@@ -40,7 +35,85 @@ const SPECIAL_TOPICS: SpecialTopicConfig[] = [
   },
 ];
 
-type SectionData = NonNullable<ListConfigFilters[keyof ListConfigFilters]>;
+function findInSection(
+  section: ScreeningAvailableFiltersSection,
+  kind: 'dataset' | 'topic',
+  itemName: string,
+): DatasetTopicSearchResult | undefined {
+  if (kind === 'dataset') {
+    for (const dataset of section.datasets ?? []) {
+      if (dataset.name === itemName) {
+        return { name: dataset.name, title: dataset.title ?? dataset.name };
+      }
+    }
+    return undefined;
+  }
+
+  for (const topicGroup of Object.values(section.topics ?? {})) {
+    for (const topic of topicGroup ?? []) {
+      if (topic.name === itemName) {
+        return { name: topic.name, title: topic.title ?? topic.name };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Finds the dataset or topic referenced by a composite leaf key in the provided
+ * catalog and returns its `{ name, title }` (compatible with `formatItemName`).
+ *
+ * The key matches the format produced by `getSectionLeafKeys`:
+ * - dataset: `${section}:dataset:${name}` (e.g. `sanctions:dataset:us-plc`)
+ * - topic:   `${section}:topic:${group}:${name}` (e.g. `peps:topic:category:filter.pep.category.state_owned_enterprise`)
+ *
+ * Returns `undefined` when the key is malformed or the item is not in the catalog.
+ */
+export function findDatasetOrTopicByKey(
+  filters: ScreeningAvailableFiltersAdapted | null | undefined,
+  key: string,
+): DatasetTopicSearchResult | undefined {
+  const normalizedKey = key?.trim() ?? '';
+  if (normalizedKey === '' || !filters) return undefined;
+
+  const [sectionKey, kind, ...rest] = normalizedKey.split(':');
+  if (kind !== 'dataset' && kind !== 'topic') return undefined;
+
+  const itemName = kind === 'dataset' ? rest.join(':') : rest.slice(1).join(':');
+  if (itemName === '') return undefined;
+
+  const dtoSection = SCREENING_CATEGORY_TO_DTO_SECTION[sectionKey as ScreeningCategory];
+  const targetSection = filters.sections?.[dtoSection];
+
+  if (targetSection) {
+    const match = findInSection(targetSection, kind, itemName);
+    if (match) return match;
+  }
+
+  if (kind === 'topic') {
+    for (const conditionalFilter of filters.conditional_filters ?? []) {
+      for (const topic of conditionalFilter.topics ?? []) {
+        if (topic.name === itemName) {
+          return { name: topic.name, title: topic.title ?? topic.name };
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+// All fields derived from listConfig.global.topics + conventions:
+// - keys[0]: always persisted when the global topic switch is active
+// - keys[1] / value: persisted when the switch is ON
+// - label: `screenings:freeform_search.global.${groupKey}`
+export type GlobalTopicConfig = {
+  groupKey: string;
+  keys: string[];
+  value: string;
+  label: string;
+};
 
 function getSpecialTopicConfig(sectionKey: ScreeningCategory, groupKey: string) {
   const normalized = groupKey.toLowerCase();
@@ -163,6 +236,10 @@ export function useDatasetTitle() {
 
   function formatItemName(item: { name: string; title?: string }): string {
     const label = item.title ?? item.name;
+    if (label.startsWith('continuousScreening:')) {
+      return t(label.slice('continuousScreening:'.length));
+    }
+
     const translation = hasTranslation(label);
     if (translation) return t(translation);
 

--- a/packages/app-builder/src/locales/ar/continuous-screening.json
+++ b/packages/app-builder/src/locales/ar/continuous-screening.json
@@ -1,6 +1,6 @@
 {
   "configurations.add_configuration": "إنشاء فحص مستمر",
-  "configurations.list.column.datasets": "القوائم",
+  "configurations.list.column.datasets": "القوائم والمواضيع",
   "configurations.list.column.name": "اسم الإعداد",
   "configurations.list.column.object_types": "أنواع الكيانات",
   "configurations.list.column.status": "الحالة",

--- a/packages/app-builder/src/locales/en/continuous-screening.json
+++ b/packages/app-builder/src/locales/en/continuous-screening.json
@@ -1,6 +1,6 @@
 {
   "configurations.add_configuration": "Add a configuration",
-  "configurations.list.column.datasets": "Datasets",
+  "configurations.list.column.datasets": "Datasets and topics",
   "configurations.list.column.name": "Name of configuration",
   "configurations.list.column.object_types": "Object types",
   "configurations.list.column.status": "Status",

--- a/packages/app-builder/src/locales/fr/continuous-screening.json
+++ b/packages/app-builder/src/locales/fr/continuous-screening.json
@@ -1,6 +1,6 @@
 {
   "configurations.add_configuration": "Créer un monitoring permanent",
-  "configurations.list.column.datasets": "Listes",
+  "configurations.list.column.datasets": "Listes et sujets",
   "configurations.list.column.name": "Nom de la configuration",
   "configurations.list.column.object_types": "Types d’entités",
   "configurations.list.column.status": "Statut",

--- a/packages/app-builder/src/models/screening-config.ts
+++ b/packages/app-builder/src/models/screening-config.ts
@@ -83,7 +83,7 @@ export function adaptScreeningConfigDto(config: ScreeningConfig): ScreeningConfi
   return configDto;
 }
 
-const ConvertSectionNameToDto: Record<ScreeningCategory, keyof ScreeningConfigBodyFiltersDto> = {
+export const SCREENING_CATEGORY_TO_DTO_SECTION: Record<ScreeningCategory, keyof ScreeningConfigBodyFiltersDto> = {
   sanctions: 'sanctions',
   peps: 'peps',
   'third-parties': 'other',
@@ -110,7 +110,7 @@ export function createScreeningFilters(selection: string[]): ScreeningConfigBody
   for (const item of selection) {
     const chunks = item.split(':');
     const sectionChuk = chunks[0] as ScreeningCategory;
-    const section = ConvertSectionNameToDto[sectionChuk];
+    const section = SCREENING_CATEGORY_TO_DTO_SECTION[sectionChuk];
     if (!filters[section]) continue;
     if (chunks.length === 1) filters[section].enabled = true;
     if (chunks.length < 3) continue;

--- a/packages/app-builder/src/queries/continuous-screening/configuration.ts
+++ b/packages/app-builder/src/queries/continuous-screening/configuration.ts
@@ -1,4 +1,3 @@
-import { ContinuousScreeningConfig } from '@app-builder/models/continuous-screening';
 import { getContinuousScreeningConfigurationFn } from '@app-builder/server-fns/continuous-screening';
 import { useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
@@ -10,7 +9,7 @@ export const useContinuousScreeningConfigurationQuery = (stableId: string) => {
     queryKey: ['continuous-screening', 'configuration', stableId],
     queryFn: async () => {
       const result = await getContinuousScreeningConfiguration({ data: { stableId } });
-      return result.config as ContinuousScreeningConfig;
+      return result.config;
     },
   });
 };

--- a/packages/app-builder/src/queries/continuous-screening/configurations.ts
+++ b/packages/app-builder/src/queries/continuous-screening/configurations.ts
@@ -4,7 +4,7 @@ import { listContinuousScreeningConfigurationsFn } from '@app-builder/server-fns
 import { useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
 
-type ContinuousScreeningConfiguration = ContinuousScreeningConfig & {
+export type ContinuousScreeningConfiguration = ContinuousScreeningConfig & {
   inbox: Inbox | undefined;
 };
 

--- a/packages/app-builder/src/queries/screening/lists-config.ts
+++ b/packages/app-builder/src/queries/screening/lists-config.ts
@@ -56,7 +56,14 @@ export function normalizeListConfig(config: ScreeningAvailableFiltersAdapted): N
   ): NormalizedSection | undefined {
     if (!section) return undefined;
     const adaptedSection: NormalizedSection = {
-      ...section,
+      topics: section.topics
+        ? Object.fromEntries(
+            Object.entries(section.topics).map(([key, value]) => [
+              key,
+              value.map((t) => ({ name: t.name, title: t.title })).sort((a, b) => a.title.localeCompare(b.title)),
+            ]),
+          )
+        : undefined,
       datasets: Array.isArray(section?.datasets) ? groupBySection(section.datasets, name) : undefined,
     };
 

--- a/packages/app-builder/src/routes/_app/_builder/continuous-screening/configurations.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/continuous-screening/configurations.tsx
@@ -1,6 +1,8 @@
 import { BreadCrumbLink, type BreadCrumbProps } from '@app-builder/components/Breadcrumbs';
 import { ConfigurationsPage } from '@app-builder/components/ContinuousScreening/ConfigurationsPage';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
+import { listContinuousScreeningConfigurationsFn } from '@app-builder/server-fns/continuous-screening';
+import { getListConfigFn } from '@app-builder/server-fns/screenings';
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { useTranslation } from 'react-i18next';
@@ -9,9 +11,15 @@ const configurationsLoader = createServerFn()
   .middleware([authMiddleware])
   .handler(async function continuousScreeningConfigurationsLoader({ context }) {
     const { user } = context.authInfo;
+    const [listContinuousScreeningConfigurations, datasets] = await Promise.all([
+      listContinuousScreeningConfigurationsFn(),
+      getListConfigFn({ data: { feature: 'continuous_monitoring' } }),
+    ]);
 
     return {
       canEdit: ['ADMIN', 'PUBLISHER'].includes(user.role),
+      configurations: listContinuousScreeningConfigurations.configurations,
+      datasets,
     };
   });
 
@@ -34,7 +42,7 @@ export const Route = createFileRoute('/_app/_builder/continuous-screening/config
 });
 
 function ContinuousScreeningConfigurations() {
-  const { canEdit } = Route.useLoaderData();
+  const { canEdit, configurations, datasets } = Route.useLoaderData();
 
-  return <ConfigurationsPage canEdit={canEdit} />;
+  return <ConfigurationsPage canEdit={canEdit} configurations={configurations} datasets={datasets} />;
 }


### PR DESCRIPTION
- `ConfigurationsPage` consumes configurations and datasets from server side
- display all dataset and topics keys using translation or title when available
<img width="838" height="52" alt="Screenshot 2026-06-01 at 11 20 07" src="https://github.com/user-attachments/assets/a801b2f8-4cd4-4418-b359-038c37d401de" />
<img width="1015" height="181" alt="Screenshot 2026-06-01 at 11 20 21" src="https://github.com/user-attachments/assets/f1259caa-f914-4f48-af44-51c8afe0624f" />
<img width="964" height="372" alt="Screenshot 2026-06-01 at 11 21 26" src="https://github.com/user-attachments/assets/5444c768-87f1-4edd-847f-76316f31eb06" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Datasets and topics now display with properly formatted titles and categorization tags instead of raw identifiers
  * Configuration list column headers updated to "Datasets and topics" across all supported languages (English, French, Arabic)
  * Improved visual organization of dataset changes in the validation panel with grid-based layout
  * Better resolution of dataset and topic information from available catalogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->