### PR TITLE
force unique dataset selection

### DIFF
--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -99,7 +99,14 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
               </div>
             )*/}
             {sections.map(([key, section]) =>
-              section ? <Section key={key} sectionKey={key as ScreeningCategory} section={section} /> : null,
+              section ? (
+                <Section
+                  key={key}
+                  sectionKey={key as ScreeningCategory}
+                  section={section}
+                  sectionCount={sections.length}
+                />
+              ) : null,
             )}
           </div>
         );
@@ -123,6 +130,7 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
                       section={section}
                       isActive={activeSectionKey === key}
                       onSelect={() => setActiveSectionKey(key as ScreeningCategory)}
+                      sectionCount={sections.length}
                     />
                   ) : null,
                 )}
@@ -196,9 +204,10 @@ type SectionProps = {
   section: SectionData;
   isActive?: boolean;
   onSelect?: () => void;
+  sectionCount: number;
 };
 
-const Section = ({ sectionKey, section, isActive, onSelect }: SectionProps) => {
+const Section = ({ sectionKey, section, isActive, onSelect, sectionCount }: SectionProps) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
   const variant = ListAndTopicDatasetConfiguration.select((state) => state.variant);
@@ -211,6 +220,7 @@ const Section = ({ sectionKey, section, isActive, onSelect }: SectionProps) => {
   const selectedCount = ListAndTopicDatasetConfiguration.select(
     (state) => datasetNames.filter((n) => state.datasets[buildDatasetKey(sectionKey, n)]).length,
   );
+  const isUniqueListForLN = provider === 'lexisnexis' && sectionCount === 1;
 
   return match(variant)
     .with('default', () => (
@@ -222,8 +232,8 @@ const Section = ({ sectionKey, section, isActive, onSelect }: SectionProps) => {
                 <Checkbox
                   stopPropagation
                   size="small"
-                  checked={isEnabled}
-                  disabled={mode === 'view'}
+                  checked={isEnabled || isUniqueListForLN}
+                  disabled={mode === 'view' || isUniqueListForLN}
                   onCheckedChange={() => {
                     listConfig.update((state) => {
                       const nextValue = !state.datasets[sectionKey];

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -24,11 +24,14 @@ import { Icon } from 'ui-icons';
 import { ListAndTopicDatasetConfiguration } from './context/ListAndTopicDatasetConfiguration';
 import {
   applyAliveDeceasedDefaults,
+  applyUniqueLexisNexisSectionDefault,
   buildDatasetKey,
   buildTopicKey,
   isDatasetKeySelected,
+  isSectionEnabled,
   // isGlobalTopicSwitchSelected,
   isTopicKeySelected,
+  isUniqueLexisNexisList,
   selectAllInSection,
   setDatasetKey,
   // setGlobalTopicSwitch,
@@ -75,7 +78,8 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
     const data = listConfigQuery.data;
     if (!data) return;
     listConfig.update((state) => {
-      applyAliveDeceasedDefaults(state.datasets, listConfig.value.datasets, useCase);
+      applyAliveDeceasedDefaults(state.datasets, data.filters, useCase);
+      applyUniqueLexisNexisSectionDefault(state.datasets, data.filters, state.provider);
     });
   }, [listConfigQuery.data, useCase, listConfig]);
 
@@ -148,6 +152,7 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
                 <SectionPanel
                   sectionKey={activeSectionKey}
                   section={activeSection}
+                  sectionCount={sections.length}
                   onApply={onApply}
                   onCancel={() => {
                     setActiveSectionKey(null);
@@ -216,11 +221,13 @@ const Section = ({ sectionKey, section, isActive, onSelect, sectionCount }: Sect
   const { t } = useTranslation(['common', 'continuousScreening', 'scenarios', 'screenings']);
 
   const datasetNames = getDatasetNames(section);
-  const isEnabled = ListAndTopicDatasetConfiguration.select((state) => !!state.datasets[sectionKey]);
+  const isEnabled = ListAndTopicDatasetConfiguration.select((state) =>
+    isSectionEnabled(state.datasets, sectionKey, state.provider, sectionCount),
+  );
   const selectedCount = ListAndTopicDatasetConfiguration.select(
     (state) => datasetNames.filter((n) => state.datasets[buildDatasetKey(sectionKey, n)]).length,
   );
-  const isUniqueListForLN = provider === 'lexisnexis' && sectionCount === 1;
+  const isUniqueListForLN = isUniqueLexisNexisList(provider, sectionCount);
 
   return match(variant)
     .with('default', () => (
@@ -232,7 +239,7 @@ const Section = ({ sectionKey, section, isActive, onSelect, sectionCount }: Sect
                 <Checkbox
                   stopPropagation
                   size="small"
-                  checked={isEnabled || isUniqueListForLN}
+                  checked={isEnabled}
                   disabled={mode === 'view' || isUniqueListForLN}
                   onCheckedChange={() => {
                     listConfig.update((state) => {
@@ -289,15 +296,19 @@ const Section = ({ sectionKey, section, isActive, onSelect, sectionCount }: Sect
 type SectionPanelProps = {
   sectionKey: ScreeningCategory;
   section: SectionData;
+  sectionCount: number;
   onApply?: () => void;
   onCancel?: () => void;
 };
 
-const SectionPanel = ({ sectionKey, section, onApply, onCancel }: SectionPanelProps) => {
+const SectionPanel = ({ sectionKey, section, sectionCount, onApply, onCancel }: SectionPanelProps) => {
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
   const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
-  const isEnabled = ListAndTopicDatasetConfiguration.select((state) => !!state.datasets[sectionKey]);
+  const isEnabled = ListAndTopicDatasetConfiguration.select((state) =>
+    isSectionEnabled(state.datasets, sectionKey, state.provider, sectionCount),
+  );
+  const isUniqueListForLN = isUniqueLexisNexisList(provider, sectionCount);
   const { t } = useTranslation(['common', 'continuousScreening', 'scenarios', 'screenings']);
   const { getLaTagLabel } = useDatasetTag();
 
@@ -308,7 +319,7 @@ const SectionPanel = ({ sectionKey, section, onApply, onCancel }: SectionPanelPr
           <Switch
             id={`section-switch-${sectionKey}`}
             checked={isEnabled}
-            disabled={mode === 'view'}
+            disabled={mode === 'view' || isUniqueListForLN}
             onCheckedChange={(checked) => {
               listConfig.update((state) => {
                 state.datasets[sectionKey] = checked;

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
@@ -1,4 +1,4 @@
-import type { AvailableFeatures, ScreeningCategory } from '@app-builder/models/screening';
+import type { AvailableFeatures, ScreeningCategory, ScreeningProviders } from '@app-builder/models/screening';
 import type { ListConfigFilters } from '@app-builder/queries/screening/lists-config';
 import { type GlobalTopicConfig } from './dataset-utils';
 
@@ -138,6 +138,39 @@ export function setGlobalTopicSwitch(
 
   datasets[buildTopicKey('global', config.groupKey, defaultKey)] = true;
   datasets[buildTopicKey('global', config.groupKey, switchKey)] = checked;
+}
+
+function getAvailableSectionKeys(filters: ListConfigFilters): ScreeningCategory[] {
+  return Object.entries(filters)
+    .filter(([key, section]) => key !== 'global' && (section?.datasets?.length || section?.topics))
+    .map(([key]) => key as ScreeningCategory);
+}
+
+/** LexisNexis configs expose a single list section that cannot be turned off. */
+export function isUniqueLexisNexisList(provider: ScreeningProviders, availableSectionCount: number): boolean {
+  return provider === 'lexisnexis' && availableSectionCount === 1;
+}
+
+export function isSectionEnabled(
+  datasets: Record<string, boolean>,
+  sectionKey: ScreeningCategory,
+  provider: ScreeningProviders,
+  availableSectionCount: number,
+): boolean {
+  return !!datasets[sectionKey] || isUniqueLexisNexisList(provider, availableSectionCount);
+}
+
+/** Persists the mandatory LexisNexis section flag so UI state and wire payload stay aligned. */
+export function applyUniqueLexisNexisSectionDefault(
+  datasets: Record<string, boolean>,
+  filters: ListConfigFilters,
+  provider: ScreeningProviders,
+): void {
+  if (provider !== 'lexisnexis') return;
+  const sectionKeys = getAvailableSectionKeys(filters);
+  const sectionKey = sectionKeys[0];
+  if (sectionKeys.length !== 1 || !sectionKey) return;
+  datasets[sectionKey] = true;
 }
 
 /** Strips falsy entries from the datasets map before persistence. */

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/rules.$ruleId.tsx
@@ -146,6 +146,10 @@ function RuleDetail() {
     onSuccess: async () => {
       await router.invalidate();
       toast.success(t('common:success.save'));
+      router.navigate({
+        to: '/detection/scenarios/$scenarioId/i/$iterationId/rules',
+        params: { scenarioId: fromUUIDtoSUUID(scenarioId), iterationId: fromUUIDtoSUUID(iterationId) },
+      });
     },
     onError: () => {
       toast.error(t('common:errors.unknown'));

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/rules.$ruleId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/rules.$ruleId.tsx
@@ -146,10 +146,11 @@ function RuleDetail() {
     onSuccess: async () => {
       await router.invalidate();
       toast.success(t('common:success.save'));
-      router.navigate({
-        to: '/detection/scenarios/$scenarioId/i/$iterationId/rules',
-        params: { scenarioId: fromUUIDtoSUUID(scenarioId), iterationId: fromUUIDtoSUUID(iterationId) },
-      });
+      // TODO: wait for second thought, we might not need to navigate back to the rules list
+      // router.navigate({
+      //   to: '/detection/scenarios/$scenarioId/i/$iterationId/rules',
+      //   params: { scenarioId: fromUUIDtoSUUID(scenarioId), iterationId: fromUUIDtoSUUID(iterationId) },
+      // });
     },
     onError: () => {
       toast.error(t('common:errors.unknown'));

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
@@ -251,10 +251,11 @@ function ScreeningDetail() {
             setHasBeenSaved(true);
             toast.success(t('common:success.save'));
             revalidate();
-            router.navigate({
-              to: '/detection/scenarios/$scenarioId/i/$iterationId/rules',
-              params: { scenarioId: fromUUIDtoSUUID(scenario.id), iterationId: fromUUIDtoSUUID(iterationId) },
-            });
+            // TODO: wait for second thought, we might not need to navigate back to the rules list
+            // router.navigate({
+            //   to: '/detection/scenarios/$scenarioId/i/$iterationId/rules',
+            //   params: { scenarioId: fromUUIDtoSUUID(scenario.id), iterationId: fromUUIDtoSUUID(iterationId) },
+            // });
           })
           .catch(() => {
             toast.error(t('common:errors.unknown'));

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
@@ -251,6 +251,10 @@ function ScreeningDetail() {
             setHasBeenSaved(true);
             toast.success(t('common:success.save'));
             revalidate();
+            router.navigate({
+              to: '/detection/scenarios/$scenarioId/i/$iterationId/rules',
+              params: { scenarioId: fromUUIDtoSUUID(scenario.id), iterationId: fromUUIDtoSUUID(iterationId) },
+            });
           })
           .catch(() => {
             toast.error(t('common:errors.unknown'));


### PR DESCRIPTION
for LN provider in screening rules settings
navigate back to rules after saving

<img width="839" height="271" alt="Screenshot 2026-06-02 at 11 41 55" src="https://github.com/user-attachments/assets/d31e07e9-89f9-4809-989c-bdaf8349de58" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic navigation after saving rule or screening edits; success toasts remain and the page stays as-is.
  * Dataset selection controls now respect view mode and LexisNexis single-section constraints, disabling activation toggles when required.
* **Chores**
  * Dataset defaults hydration updated to enforce the required LexisNexis single-section default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->