### PR TITLE
Mar 1919 random crash in manual search and small improvements

### DIFF
--- a/packages/app-builder/src/components/ContinuousScreening/form/steps/ScoringConfiguration.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/form/steps/ScoringConfiguration.tsx
@@ -1,4 +1,5 @@
 import { Callout } from '@app-builder/components/Callout';
+import { ScreeningThreshold } from '@app-builder/components/ScreeningThreshold';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useGetInboxesQuery } from '@app-builder/queries/cases/get-inboxes';
 import { useState } from 'react';
@@ -21,29 +22,14 @@ export const ScoringConfiguration = () => {
       <Callout bordered className="bg-surface-card mx-v2-md">
         {t(`continuousScreening:${tKey}.scoringConfiguration.callout`)}
       </Callout>
-      <Field
-        title={t('continuousScreening:creation.scoringConfiguration.matchThreshold.title')}
-        description={t(`continuousScreening:creation.scoringConfiguration.matchThreshold.subtitle`)}
-        callout={t('continuousScreening:creation.scoringConfiguration.matchThreshold.callout')}
-      >
-        <Input
-          type="number"
-          min={0}
-          max={100}
-          step={0.1}
-          value={matchThreshold.value}
-          readOnly={mode === 'view'}
-          onChange={(e) => (matchThreshold.value = e.target.valueAsNumber)}
-          onBlur={(e) => {
-            if (e.target.valueAsNumber < 0) {
-              matchThreshold.value = 0;
-            }
-            if (e.target.valueAsNumber > 100) {
-              matchThreshold.value = 100;
-            }
-          }}
+      <Field title={t('continuousScreening:creation.scoringConfiguration.matchThreshold.title')}>
+        <ScreeningThreshold
+          threshold={matchThreshold.value}
+          onChange={(value) => (matchThreshold.value = value)}
+          title={t(`continuousScreening:creation.scoringConfiguration.matchThreshold.subtitle`)}
+          className="flex-1 w-full"
+          disabled={mode === 'view'}
         />
-        <span>%</span>
       </Field>
       <Field
         title={t('continuousScreening:creation.scoringConfiguration.matchLimit.title')}

--- a/packages/app-builder/src/components/ContinuousScreening/shared/Field.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/shared/Field.tsx
@@ -3,7 +3,7 @@ import { cn } from 'ui-design-system';
 
 type FieldProps = {
   title: string;
-  description: string;
+  description?: string;
   children: React.ReactNode;
   callout?: string;
   titleClassName?: string;
@@ -17,7 +17,7 @@ export const Field = ({ title, description, children, callout, titleClassName, r
         <span className={cn('text-h2 font-semibold', titleClassName)}>{title}</span>
         {required ? <span className="text-red-primary text-s">*</span> : null}
       </div>
-      <div className="text-grey-secondary">{description}</div>
+      {description ? <div className="text-grey-secondary">{description}</div> : null}
       <div className="flex gap-v2-md items-center">{children}</div>
       {callout ? <Callout bordered>{callout}</Callout> : null}
     </div>

--- a/packages/app-builder/src/components/ScreeningThreshold.tsx
+++ b/packages/app-builder/src/components/ScreeningThreshold.tsx
@@ -4,10 +4,11 @@ import { ThresholdRange } from 'ui-design-system';
 type ScreeningThresholdProps = {
   threshold: number | undefined;
   onChange: (value: number) => void;
-  title: string;
+  title?: string;
   disabled?: boolean;
+  className?: string;
 };
-export const ScreeningThreshold = ({ threshold, onChange, title, disabled }: ScreeningThresholdProps) => {
+export const ScreeningThreshold = ({ threshold, onChange, title, disabled, className }: ScreeningThresholdProps) => {
   const { t } = useTranslation(['common', 'scenarios']);
 
   const values = [
@@ -41,6 +42,7 @@ export const ScreeningThreshold = ({ threshold, onChange, title, disabled }: Scr
       initialColor="var(--color-red-hover)"
       disabled={disabled}
       learnMoreUrl="https://docs.checkmarble.com/docs/search-scoring-algorithm"
+      className={className}
     />
   );
 };

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformMatchCard.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformMatchCard.tsx
@@ -2,7 +2,7 @@ import { Spinner } from '@app-builder/components/Spinner';
 import { type ScreeningMatchPayload } from '@app-builder/models/screening';
 import { useGetEnrichedDataQuery } from '@app-builder/queries/screening/get-enriched-data';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
-import { type FunctionComponent, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
@@ -16,7 +16,7 @@ interface FreeformMatchCardProps {
   searchTerm?: string;
 }
 
-export const FreeformMatchCard: FunctionComponent<FreeformMatchCardProps> = ({ entity, defaultOpen, searchTerm }) => {
+export function FreeformMatchCard({ entity, defaultOpen, searchTerm }: FreeformMatchCardProps) {
   const { t } = useTranslation(screeningsI18n);
   const [isOpen, setIsOpen] = useState(defaultOpen ?? false);
 
@@ -72,7 +72,7 @@ export const FreeformMatchCard: FunctionComponent<FreeformMatchCardProps> = ({ e
       </CollapsiblePrimitive.Content>
     </CollapsiblePrimitive.Root>
   );
-};
+}
 
 export default FreeformMatchCard;
 

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformMatchCard.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformMatchCard.tsx
@@ -1,11 +1,9 @@
 import { Spinner } from '@app-builder/components/Spinner';
 import { type ScreeningMatchPayload } from '@app-builder/models/screening';
 import { useGetEnrichedDataQuery } from '@app-builder/queries/screening/get-enriched-data';
-import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Tag } from 'ui-design-system';
-import { Icon } from 'ui-icons';
+import { Collapsible, Tag } from 'ui-design-system';
 import { MatchDetails } from '../MatchDetails';
 import { screeningsI18n } from '../screenings-i18n';
 import { TopicsDisplay } from '../TopicsDisplay';
@@ -23,35 +21,28 @@ export function FreeformMatchCard({ entity, defaultOpen, searchTerm }: FreeformM
   const entitySchema = entity.schema.toLowerCase();
 
   return (
-    <CollapsiblePrimitive.Root defaultOpen={defaultOpen} onOpenChange={setIsOpen}>
-      <div className="bg-surface-page border border-grey-border rounded-md">
-        <CollapsiblePrimitive.Trigger className="focus-visible:text-purple-primary group flex grow items-center gap-2 rounded-sm outline-hidden transition-colors px-4 py-3">
-          <Icon
-            icon="smallarrow-up"
-            aria-hidden
-            className="size-5 rotate-90 transition-transform duration-200 group-data-[state=open]:rotate-180 rtl:-rotate-90 group-data-[state=open]:rtl:-rotate-180"
-          />
-          <div className="text-s flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span className="font-semibold">{entity.caption}</span>
+    <Collapsible.Container defaultOpen={defaultOpen} onOpenChange={setIsOpen}>
+      <Collapsible.Title iconPosition="left">
+        <div className="text-s flex flex-wrap items-center gap-x-2 gap-y-1 flex-1">
+          <span className="font-semibold">{entity.caption}</span>
 
-            <span>
-              {t(`screenings:entity.schema.${entitySchema}`, {
-                defaultValue: entitySchema,
-              })}
-            </span>
-            <Tag color="grey">
-              {t('screenings:match.similarity', {
-                percent: Math.round(entity.score * 100),
-              })}
-            </Tag>
-            <div className="col-span-full flex w-full flex-wrap gap-1">
-              <TopicsDisplay entity={entity} />
-            </div>
+          <span>
+            {t(`screenings:entity.schema.${entitySchema}`, {
+              defaultValue: entitySchema,
+            })}
+          </span>
+          <Tag color="grey">
+            {t('screenings:match.similarity', {
+              percent: Math.round(entity.score * 100),
+            })}
+          </Tag>
+          <div className="col-span-full flex w-full flex-wrap gap-1">
+            <TopicsDisplay entity={entity} />
           </div>
-        </CollapsiblePrimitive.Trigger>
-      </div>
+        </div>
+      </Collapsible.Title>
 
-      <CollapsiblePrimitive.Content className="data-[state=open]:animate-slide-down data-[state=closed]:animate-slide-up overflow-hidden">
+      <Collapsible.Content>
         <div className="text-s flex flex-col gap-6 p-4">
           {entitySchema === 'person' && entity.datasets?.length ? (
             <div className="grid grid-cols-[168px_1fr] gap-2">
@@ -69,8 +60,8 @@ export function FreeformMatchCard({ entity, defaultOpen, searchTerm }: FreeformM
           ) : null}
           <DataContent entityId={entity.id} searchTerm={searchTerm} isOpen={isOpen} />
         </div>
-      </CollapsiblePrimitive.Content>
-    </CollapsiblePrimitive.Root>
+      </Collapsible.Content>
+    </Collapsible.Container>
   );
 }
 

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformMatchCard.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformMatchCard.tsx
@@ -36,9 +36,7 @@ export function FreeformMatchCard({ entity, defaultOpen, searchTerm }: FreeformM
               percent: Math.round(entity.score * 100),
             })}
           </Tag>
-          <div className="col-span-full flex w-full flex-wrap gap-1">
-            <TopicsDisplay entity={entity} />
-          </div>
+          <TopicsDisplay entity={entity} containerClassName="flex w-full flex-wrap gap-1 font-normal" />
         </div>
       </Collapsible.Title>
 

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchResults.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchResults.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { match, P } from 'ts-pattern';
 
 import { Callout } from '../../Callout';
-import { sortPayloadsByTopics } from '../match-sorting';
+import { getSortedPayloadByTopics } from '../match-sorting';
 import { screeningsI18n } from '../screenings-i18n';
 import { FreeformMatchCard } from './FreeformMatchCard';
 import { DEFAULT_LIMIT } from './LimitPopover';
@@ -55,7 +55,7 @@ export const FreeformSearchResults: FunctionComponent<FreeformSearchResultsProps
           )}
         </div>
 
-        {[...data].sort(sortPayloadsByTopics).map((entity) => (
+        {getSortedPayloadByTopics(data).map((entity) => (
           <FreeformMatchCard key={entity.id} entity={entity} defaultOpen={data.length === 1} searchTerm={searchTerm} />
         ))}
       </div>

--- a/packages/app-builder/src/components/Screenings/MatchCard/FamilyDetail.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/FamilyDetail.tsx
@@ -34,7 +34,7 @@ export function FamilyDetail<T extends RelationType>({ familyMembers, relation }
               const entities = member.properties[relation === 'familyPerson' ? 'relative' : 'person'] as PersonEntity[];
 
               return entities?.map(({ id, properties }, idx) => {
-                if (!properties.name?.[0]) return null;
+                if (!properties?.name?.[0]) return null;
                 const rel =
                   member.properties.relationship
                     ?.map((relation) =>

--- a/packages/app-builder/src/components/Screenings/TopicsDisplay.tsx
+++ b/packages/app-builder/src/components/Screenings/TopicsDisplay.tsx
@@ -71,7 +71,7 @@ export function TopicsDisplay({ entity, containerClassName }: TopicsDisplayProps
   if (filteredTopics.length === 0) return null;
 
   return (
-    <div className={containerClassName ?? 'flex flex-wrap gap-1'}>
+    <div className={containerClassName ?? 'flex flex-wrap gap-1 font-normal'}>
       {filteredTopics.map((topic) => (
         <TopicTag key={`${entity.id}-${topic}`} topic={topic} />
       ))}

--- a/packages/app-builder/src/components/Screenings/TopicsDisplay.tsx
+++ b/packages/app-builder/src/components/Screenings/TopicsDisplay.tsx
@@ -1,7 +1,12 @@
-import { type ScreeningMatchPayload } from '@app-builder/models/screening';
+import {
+  getCategoryForTopic,
+  isOpenSanctionTopic,
+  ScreeningCategory,
+  type ScreeningMatchPayload,
+} from '@app-builder/models/screening';
 import { TopicTag } from './TopicTag';
 
-const topicsPart1Order: Record<string, number> = {
+export const topicCategoryPriority: Record<string, number> = {
   sanctions: 0,
   pep: 1,
   adverse_media: 2,
@@ -18,8 +23,8 @@ export function sortTopics(topicA: string, topicB: string): number {
   const aPrefix = aParts[0] ?? '';
   const bPrefix = bParts[0] ?? '';
 
-  const aOrder = topicsPart1Order[aPrefix] ?? 999;
-  const bOrder = topicsPart1Order[bPrefix] ?? 999;
+  const aOrder = topicCategoryPriority[aPrefix] ?? 999;
+  const bOrder = topicCategoryPriority[bPrefix] ?? 999;
 
   if (aOrder !== bOrder) {
     return aOrder - bOrder;
@@ -36,7 +41,25 @@ interface TopicsDisplayProps {
   containerClassName?: string;
 }
 
+export const TOPIC_ORDER: Record<ScreeningCategory, keyof typeof topicCategoryPriority | ''> = {
+  sanctions: 'sanctions',
+  peps: 'pep',
+  'adverse-media': 'adverse_media',
+  'third-parties': '',
+  global: '',
+};
+
 export function getFilteredAndSortedTopics(topics: string[]): string[] {
+  if (topics.every(isOpenSanctionTopic)) {
+    const topicsWithCategory = new Set(
+      topics.map((topic) => `${TOPIC_ORDER[getCategoryForTopic(topic) ?? 'third-parties']}.${topic}`),
+    );
+    const sorted = Array.from(topicsWithCategory).toSorted(sortTopics);
+    return sorted.map((sortedTopic) => {
+      const dot = sortedTopic.indexOf('.');
+      return sortedTopic.slice(dot + 1);
+    });
+  }
   const hasPepPrimary = topics.includes('pep.kind.primary');
   return topics.filter((topic) => !(hasPepPrimary && topic === 'pep.kind.secondary')).sort(sortTopics);
 }
@@ -44,9 +67,7 @@ export function getFilteredAndSortedTopics(topics: string[]): string[] {
 export function TopicsDisplay({ entity, containerClassName }: TopicsDisplayProps) {
   const topics = entity.properties?.['topics'] ?? [];
   if (topics.length === 0) return null;
-
   const filteredTopics = getFilteredAndSortedTopics(topics);
-
   if (filteredTopics.length === 0) return null;
 
   return (

--- a/packages/app-builder/src/components/Screenings/TopicsDisplay.tsx
+++ b/packages/app-builder/src/components/Screenings/TopicsDisplay.tsx
@@ -49,11 +49,13 @@ export const TOPIC_ORDER: Record<ScreeningCategory, keyof typeof topicCategoryPr
   global: '',
 };
 
+export function toOrderedTopic(topic: string): string {
+  return `${TOPIC_ORDER[getCategoryForTopic(topic) ?? 'third-parties']}.${topic}`;
+}
+
 export function getFilteredAndSortedTopics(topics: string[]): string[] {
   if (topics.every(isOpenSanctionTopic)) {
-    const topicsWithCategory = new Set(
-      topics.map((topic) => `${TOPIC_ORDER[getCategoryForTopic(topic) ?? 'third-parties']}.${topic}`),
-    );
+    const topicsWithCategory = new Set(topics.map(toOrderedTopic));
     const sorted = Array.from(topicsWithCategory).toSorted(sortTopics);
     return sorted.map((sortedTopic) => {
       const dot = sortedTopic.indexOf('.');

--- a/packages/app-builder/src/components/Screenings/match-sorting.ts
+++ b/packages/app-builder/src/components/Screenings/match-sorting.ts
@@ -1,10 +1,5 @@
-import {
-  getCategoryForTopic,
-  isOpenSanctionTopic,
-  type ScreeningMatch,
-  type ScreeningMatchPayload,
-} from '@app-builder/models/screening';
-import { TOPIC_ORDER, topicCategoryPriority } from './TopicsDisplay';
+import { isOpenSanctionTopic, type ScreeningMatch, type ScreeningMatchPayload } from '@app-builder/models/screening';
+import { toOrderedTopic, topicCategoryPriority } from './TopicsDisplay';
 
 function getDisplayedTopics(topics: string[]): string[] {
   const hasPepPrimary = topics.includes('pep.kind.primary');
@@ -58,8 +53,10 @@ function withEnrichedOpenSanctionTopics(payload: ScreeningMatchPayload): Screeni
     ...payload,
     properties: {
       ...payload.properties,
-      topics: topics.map((topic) => `${TOPIC_ORDER[getCategoryForTopic(topic) ?? 'third-parties']}.${topic}`),
+      topics: topics.map(toOrderedTopic),
     },
+    // Cast required: ScreeningMatchPayload['properties'] intersects entity arrays
+    // with Record<string, string[]>, an internally contradictory type.
   } as unknown as ScreeningMatchPayload;
 }
 

--- a/packages/app-builder/src/components/Screenings/match-sorting.ts
+++ b/packages/app-builder/src/components/Screenings/match-sorting.ts
@@ -1,10 +1,10 @@
-import { type ScreeningMatch, type ScreeningMatchPayload } from '@app-builder/models/screening';
-
-const topicCategoryPriority: Record<string, number> = {
-  sanctions: 0,
-  pep: 1,
-  adverse_media: 2,
-};
+import {
+  getCategoryForTopic,
+  isOpenSanctionTopic,
+  type ScreeningMatch,
+  type ScreeningMatchPayload,
+} from '@app-builder/models/screening';
+import { TOPIC_ORDER, topicCategoryPriority } from './TopicsDisplay';
 
 function getDisplayedTopics(topics: string[]): string[] {
   const hasPepPrimary = topics.includes('pep.kind.primary');
@@ -48,4 +48,30 @@ export function sortScreeningMatchesByTopics(a: ScreeningMatch, b: ScreeningMatc
   }
 
   return b.payload.score - a.payload.score;
+}
+
+function withEnrichedOpenSanctionTopics(payload: ScreeningMatchPayload): ScreeningMatchPayload {
+  const topics = payload.properties?.['topics'];
+  if (!topics) return payload;
+
+  return {
+    ...payload,
+    properties: {
+      ...payload.properties,
+      topics: topics.map((topic) => `${TOPIC_ORDER[getCategoryForTopic(topic) ?? 'third-parties']}.${topic}`),
+    },
+  } as unknown as ScreeningMatchPayload;
+}
+
+export function getSortedPayloadByTopics(payloads: ScreeningMatchPayload[]): ScreeningMatchPayload[] {
+  const allTopics = new Set(payloads.flatMap((payload) => payload.properties?.['topics'] ?? []));
+  const isOpenSanctions = Array.from(allTopics).every(isOpenSanctionTopic);
+
+  if (!isOpenSanctions) {
+    return payloads.toSorted(sortPayloadsByTopics);
+  }
+
+  return payloads.toSorted((a, b) =>
+    sortPayloadsByTopics(withEnrichedOpenSanctionTopics(a), withEnrichedOpenSanctionTopics(b)),
+  );
 }


### PR DESCRIPTION
# Diverse fix and improvements

- fix the random crash in the display of enriched data (from manual search) with a guard if some values are undefined
- sort the tags and use the Collapsible component from ui design in the match cards (same oredering functions than LN view)

<img width="1640" height="675" alt="Screenshot 2026-06-02 at 15 30 41" src="https://github.com/user-attachments/assets/a44b6f8d-1e49-473a-b603-4fe1a11d9eba" />

- use ScreeningThreshold component in continuous screening configuration

<img width="972" height="416" alt="Screenshot 2026-06-02 at 15 29 42" src="https://github.com/user-attachments/assets/165cc4ac-a9bc-4cd9-b674-f13054639041" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of missing or empty person names in family detail views.

* **Improvements**
  * Replaced numeric threshold input with a consistent threshold control; respects read-only view mode.
  * Topic ordering and result sorting refined to better group open-sanction topics.
  * Result cards’ collapsible headers and default-open behavior improved for clearer navigation.
  * Field descriptions are now hidden when not provided.

* **Refactor**
  * Consolidated related components for cleaner structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->