### PR TITLE
Revert "Pascal/mar 1922 save manual search history and results backend"

### DIFF
--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
@@ -28,10 +28,7 @@ import { EntitySearchFormProvider } from './entity-search-form-context';
 import { DEFAULT_LIMIT, LimitPopover } from './LimitPopover';
 
 interface FreeformSearchFormProps {
-  onSearchComplete: (
-    result: { id: string; matches: ScreeningMatchPayload[] },
-    searchInputs: FreeformSearchInput,
-  ) => void;
+  onSearchComplete: (results: ScreeningMatchPayload[], searchInputs: FreeformSearchInput) => void;
   listConfig: ListConfigFilters;
 }
 

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchPage.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchPage.tsx
@@ -8,7 +8,6 @@ import { FreeformSearchForm } from './FreeformSearchForm';
 import { FreeformSearchResults } from './FreeformSearchResults';
 
 export interface FreeformSearchState {
-  searchId: string;
   results: ScreeningMatchPayload[];
   inputs: {
     entityType: SearchableSchema;
@@ -30,14 +29,13 @@ export const FreeformSearchPage: FunctionComponent<FreeformSearchPageProps> = ({
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
 
   const handleSearchComplete = useCallback(
-    (result: { id: string; matches: ScreeningMatchPayload[] }, inputs: FreeformSearchInput) => {
-      setResults(result.matches);
+    (data: ScreeningMatchPayload[], inputs: FreeformSearchInput) => {
+      setResults(data);
       setCurrentLimit(inputs.limit);
       // Extract the 'name' field value as the search term for highlighting
       setSearchTerm(inputs.fields.name as string | undefined);
       onSearchComplete?.({
-        searchId: result.id,
-        results: result.matches,
+        results: data,
         inputs: {
           entityType: inputs.entityType,
           fields: inputs.fields as Record<string, string>,

--- a/packages/app-builder/src/queries/screening/freeform-search.ts
+++ b/packages/app-builder/src/queries/screening/freeform-search.ts
@@ -15,9 +15,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
 
-type FreeformSearchResponse =
-  | { success: true; data: { id: string; matches: ScreeningMatchPayload[] } }
-  | { success: false; error: unknown };
+type FreeformSearchResponse = { success: true; data: ScreeningMatchPayload[] } | { success: false; error: unknown };
 
 export const useFreeformSearchMutation = () => {
   const freeformSearch = useServerFn(freeformSearchFn);

--- a/packages/app-builder/src/repositories/ScreeningRepository.ts
+++ b/packages/app-builder/src/repositories/ScreeningRepository.ts
@@ -54,7 +54,7 @@ export interface ScreeningRepository {
     datasets?: string[];
     threshold?: number;
     limit?: number;
-  }): Promise<{ id: string; matches: ScreeningMatchPayload[] }>;
+  }): Promise<ScreeningMatchPayload[]>;
   getAiSuggestions(args: { screeningId: string }): Promise<ScreeningAiSuggestion[]>;
   enrichedData(args: { entityId: string }): Promise<ScreeningMatchPayload>;
   getAvailableFilters(args: { feature: AvailableFeatures }): Promise<ScreeningAvailableFiltersAdapted>;
@@ -164,11 +164,8 @@ export function makeGetScreeningRepository() {
         filters: createScreeningFilters(datasets ?? []),
         threshold,
       };
-      const { id, matches } = await marbleCoreApiClient.freeformSearch(dto, { limit });
-      return {
-        id,
-        matches: R.map(matches, (match) => adaptScreeningMatchPayload(match.payload)),
-      };
+      const results = await marbleCoreApiClient.freeformSearch(dto, { limit });
+      return R.map(results, (result) => adaptScreeningMatchPayload(result.payload));
     },
     getAiSuggestions: async ({ screeningId }) => {
       return R.map(await marbleCoreApiClient.getScreeningAiSuggestions(screeningId), adaptScreeningAiSuggestion);

--- a/packages/app-builder/src/server-fns/screenings.ts
+++ b/packages/app-builder/src/server-fns/screenings.ts
@@ -207,8 +207,8 @@ export const freeformSearchFn = createServerFn({ method: 'POST' })
   .inputValidator(freeformSearchSchema)
   .handler(async ({ context, data }) => {
     try {
-      const result = await context.authInfo.screening.freeformSearch(data);
-      return { success: true as const, data: result };
+      const results = await context.authInfo.screening.freeformSearch(data);
+      return { success: true as const, data: results as ScreeningMatchPayload[] };
     } catch {
       return { success: false as const, error: 'Freeform search failed' };
     }

--- a/packages/marble-api/openapis/marblecore-api/screenings.yml
+++ b/packages/marble-api/openapis/marblecore-api/screenings.yml
@@ -354,69 +354,13 @@
             $ref: '#/components/schemas/ScreeningFreeformDto'
     responses:
       '200':
-        description: The freeform search id and its matches
+        description: The list of matches
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ScreeningFreeformSearchResultDto'
-  get:
-    tags:
-      - Screening
-    summary: List past freeform searches
-    operationId: listFreeformSearches
-    parameters:
-      - $ref: 'components.yml#/parameters/limit'
-      - $ref: 'components.yml#/parameters/offset_id'
-      - $ref: 'components.yml#/parameters/order'
-      - name: sorting
-        description: the field used to sort the items
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-            - created_at
-      - name: user_id
-        description: filter searches by user ID
-        in: query
-        required: false
-        schema:
-          type: string
-          format: uuid
-      - name: api_key_id
-        description: filter searches by API key ID
-        in: query
-        required: false
-        schema:
-          type: string
-          format: uuid
-      - name: is_saved
-        description: show only searches that have been manually saved
-        in: query
-        required: false
-        schema:
-          type: boolean
-    responses:
-      '200':
-        description: The list of past freeform searches
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - data
-                - has_next_page
-              properties:
-                data:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/ScreeningFreeformSearchDto'
-                has_next_page:
-                  type: boolean
-      '401':
-        $ref: 'components.yml#/responses/401'
-      '403':
-        $ref: 'components.yml#/responses/403'
+              type: array
+              items:
+                $ref: '#/components/schemas/ScreeningMatchDto'
 
 components:
   schemas:
@@ -978,6 +922,9 @@ components:
       required:
         - query
       properties:
+        screening_id:
+          type: string
+          format: uuid
         query:
           $ref: '#/components/schemas/RefineQueryDto'
         datasets:
@@ -988,76 +935,6 @@ components:
           type: integer
           minimum: 0
           maximum: 100
-    ScreeningFreeformSearchResultDto:
-      type: object
-      required:
-        - id
-        - matches
-      properties:
-        id:
-          type: string
-          format: uuid
-        matches:
-          type: array
-          items:
-            $ref: '#/components/schemas/ScreeningMatchDto'
-    ScreeningFreeformSearchDto:
-      type: object
-      required:
-        - id
-        - created_at
-        - search_input
-        - search_config
-      properties:
-        id:
-          type: string
-          format: uuid
-        user_id:
-          type: string
-          format: uuid
-        api_key_id:
-          type: string
-          format: uuid
-        created_at:
-          type: string
-          format: date-time
-        search_input:
-          $ref: '#/components/schemas/ScreeningFreeformSearchInputDto'
-        search_config:
-          $ref: '#/components/schemas/ScreeningFreeformSearchConfigDto'
-    ScreeningFreeformSearchInputDto:
-      type: object
-      required:
-        - type
-        - query
-      properties:
-        type:
-          type: string
-          enum: ['Thing', 'Person', 'Organization', 'Vehicle']
-        query:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-    ScreeningFreeformSearchConfigDto:
-      type: object
-      required:
-        - provider
-        - filters
-        - limit
-      properties:
-        provider:
-          type: string
-        filters:
-          $ref: '#/components/schemas/ScreeningConfigBodyFiltersDto'
-        threshold:
-          type: integer
-          nullable: true
-          minimum: 0
-          maximum: 100
-        limit:
-          type: integer
     RefineQueryDto:
       type: object
       description: One of Thing, Person, Organization, or Vehicle must be provided

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -4118,6 +4118,7 @@ export function refineScreening(screeningRefineDto?: ScreeningRefineDto, opts?: 
  * Freeform search for sanctions matches
  */
 export function freeformSearch(body?: {
+    screening_id?: string;
     /** One of Thing, Person, Organization, or Vehicle must be provided */
     query: {
         Thing?: {
@@ -4148,10 +4149,7 @@ export function freeformSearch(body?: {
 } = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
-        data: {
-            id: string;
-            matches: ScreeningMatchDto[];
-        };
+        data: ScreeningMatchDto[];
     }>(`/screenings/freeform-search${QS.query(QS.explode({
         limit
     }))}`, oazapfts.json({
@@ -4159,59 +4157,6 @@ export function freeformSearch(body?: {
         method: "POST",
         body
     })));
-}
-/**
- * List past freeform searches
- */
-export function listFreeformSearches({ limit, offsetId, order, sorting, userId, apiKeyId, isSaved }: {
-    limit?: number;
-    offsetId?: string;
-    order?: "ASC" | "DESC";
-    sorting?: "created_at";
-    userId?: string;
-    apiKeyId?: string;
-    isSaved?: boolean;
-} = {}, opts?: Oazapfts.RequestOpts) {
-    return oazapfts.ok(oazapfts.fetchJson<{
-        status: 200;
-        data: {
-            data: {
-                id: string;
-                user_id?: string;
-                api_key_id?: string;
-                created_at: string;
-                search_input: {
-                    "type": "Thing" | "Person" | "Organization" | "Vehicle";
-                    query: {
-                        [key: string]: string[];
-                    };
-                };
-                search_config: {
-                    provider: string;
-                    filters: ScreeningConfigBodyFiltersDto;
-                    threshold?: number | null;
-                    limit: number;
-                };
-            }[];
-            has_next_page: boolean;
-        };
-    } | {
-        status: 401;
-        data: string;
-    } | {
-        status: 403;
-        data: string;
-    }>(`/screenings/freeform-search${QS.query(QS.explode({
-        limit,
-        offset_id: offsetId,
-        order,
-        sorting,
-        user_id: userId,
-        api_key_id: apiKeyId,
-        is_saved: isSaved
-    }))}`, {
-        ...opts
-    }));
 }
 /**
  * Retrieve the freshness of sanction datasets


### PR DESCRIPTION
Reverts checkmarble/marble-frontend#1607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined freeform search result handling by simplifying the API response structure and improving data flow consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->