### PR TITLE
Scenario Deployment Modal with Preparation

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/Shared/FieldsForm.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Shared/FieldsForm.tsx
@@ -84,7 +84,7 @@ export function FieldsForm({
           <p className="text-s text-grey-secondary">{description ?? t('data:upload_data.fields_description')}</p>
         </div>
         {isCreateDataModelFieldAvailable && (
-          <Button variant="primary" appearance="stroked" onClick={handleAddField}>
+          <Button variant="primary" appearance="stroked" onClick={handleAddField} className="shrink-0">
             <Icon icon="plus" className="size-4" />
             {t('data:upload_data.field_add')}
           </Button>

--- a/packages/app-builder/src/components/Scenario/Iteration/Actions/DeactivateScenarioVersion.tsx
+++ b/packages/app-builder/src/components/Scenario/Iteration/Actions/DeactivateScenarioVersion.tsx
@@ -1,19 +1,14 @@
-import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
-import {
-  deactivateIterationPayloadSchema,
-  useDeactivateIterationMutation,
-} from '@app-builder/queries/scenarios/deactivate-iteration';
-import { useForm } from '@tanstack/react-form';
-import * as React from 'react';
+import { useDeactivateIterationMutation } from '@app-builder/queries/scenarios/deactivate-iteration';
+import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button, Checkbox, Modal } from 'ui-design-system';
+import { Button, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 export function DeactivateScenarioVersion({ scenarioId, iterationId }: { scenarioId: string; iterationId: string }) {
   const { t } = useTranslation(['scenarios']);
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>
@@ -35,81 +30,28 @@ function DeactivateScenarioVersionContent({ scenarioId, iterationId }: { scenari
   const deactivateIterationMutation = useDeactivateIterationMutation(scenarioId, iterationId);
   const revalidate = useLoaderRevalidator();
 
-  const form = useForm({
-    defaultValues: {
-      stopOperating: false,
-      changeIsImmediate: false,
-    },
-    onSubmit: ({ value, formApi }) => {
-      if (formApi.state.isValid) {
-        const payload = deactivateIterationPayloadSchema.safeParse(value);
-        if (payload.success) {
-          deactivateIterationMutation
-            .mutateAsync(payload.data)
-            .then(() => {
-              revalidate();
-            })
-            .catch(() => {
-              toast.error(t('common:errors.unknown'));
-            });
-        }
-      }
-    },
-    validators: {
-      onSubmitAsync: deactivateIterationPayloadSchema,
-    },
-  });
+  function handleDeactivate() {
+    deactivateIterationMutation
+      .mutateAsync({ stopOperating: true, changeIsImmediate: true })
+      .then(() => {
+        toast.success(t('scenarios:deployment_modal.deactivate.success'));
+        revalidate();
+      })
+      .catch(() => {
+        toast.error(t('common:errors.unknown'));
+      });
+  }
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        form.handleSubmit();
-      }}
-    >
+    <>
       <Modal.Title>{t('scenarios:deployment_modal.deactivate.title')}</Modal.Title>
       <div className="flex flex-col gap-6 p-6">
         <div className="text-s flex flex-col gap-4 font-medium">
           <p className="font-semibold">{t('scenarios:deployment_modal.deactivate.confirm')}</p>
-          <form.Field
-            name="stopOperating"
-            validators={{
-              onBlur: deactivateIterationPayloadSchema.shape.stopOperating,
-              onChange: deactivateIterationPayloadSchema.shape.stopOperating,
-            }}
-          >
-            {(field) => (
-              <div className="group flex flex-row items-center gap-2">
-                <Checkbox
-                  name={field.name}
-                  defaultChecked={field.state.value}
-                  onCheckedChange={(state) => state !== 'indeterminate' && field.handleChange(state)}
-                />
-                <FormLabel name={field.name}>{t('scenarios:deployment_modal.deactivate.stop_operating')}</FormLabel>
-              </div>
-            )}
-          </form.Field>
-          <form.Field
-            name="changeIsImmediate"
-            validators={{
-              onBlur: deactivateIterationPayloadSchema.shape.changeIsImmediate,
-              onChange: deactivateIterationPayloadSchema.shape.changeIsImmediate,
-            }}
-          >
-            {(field) => (
-              <div className="group flex flex-row items-center gap-2">
-                <Checkbox
-                  name={field.name}
-                  defaultChecked={field.state.value}
-                  onCheckedChange={(state) => state !== 'indeterminate' && field.handleChange(state)}
-                />
-                <FormLabel name={field.name}>
-                  {t('scenarios:deployment_modal.deactivate.change_is_immediate')}
-                </FormLabel>
-              </div>
-            )}
-          </form.Field>
+          <ul className="flex list-disc flex-col gap-4 ps-5">
+            <li>{t('scenarios:deployment_modal.deactivate.stop_operating')}</li>
+            <li>{t('scenarios:deployment_modal.deactivate.change_is_immediate')}</li>
+          </ul>
           <p className="text-grey-disabled text-xs font-medium">{t('scenarios:deployment_modal.deactivate.helper')}</p>
         </div>
       </div>
@@ -119,11 +61,11 @@ function DeactivateScenarioVersionContent({ scenarioId, iterationId }: { scenari
             {t('common:cancel')}
           </Button>
         </Modal.Close>
-        <Button className="flex-1" variant="destructive" type="submit">
+        <Button className="flex-1" variant="destructive" onClick={handleDeactivate}>
           <Icon icon="stop" className="size-5" />
           {t('scenarios:deployment_modal.deactivate.button')}
         </Button>
       </Modal.Footer>
-    </form>
+    </>
   );
 }

--- a/packages/app-builder/src/components/Scenario/Iteration/Actions/ScenarioDeploymentModal.tsx
+++ b/packages/app-builder/src/components/Scenario/Iteration/Actions/ScenarioDeploymentModal.tsx
@@ -1,11 +1,13 @@
+import { Callout } from '@app-builder/components/Callout';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { ScenarioIterationRuleMetadata } from '@app-builder/models/scenario/iteration-rule';
 import { useActivateIterationMutation } from '@app-builder/queries/scenarios/activate-iteration';
 import { useCommitIterationMutation } from '@app-builder/queries/scenarios/commit-iteration';
 import { usePrepareIterationMutation } from '@app-builder/queries/scenarios/prepare-iteration';
+import { usePublicationPreparationStatusQuery } from '@app-builder/queries/scenarios/publication-preparation-status';
 import { useRuleSnoozesQuery } from '@app-builder/queries/scenarios/rule-snoozes';
-import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Modal, StepProgressBar, Tooltip } from 'ui-design-system';
 import { Icon, type IconName } from 'ui-icons';
@@ -28,13 +30,38 @@ type ScenarioDeploymentModalProps = {
 };
 
 type Bullet = { text: string; tooltip?: string };
+type DeploymentStepDefinition = { key: DeploymentStep; label: string; isCurrent: boolean };
 
-// The current step is always derived from the live loader state, never an
-// internal cursor: reopening mid-flow resumes at the actual current step.
-function getCurrentStep(iteration: DeploymentIteration): DeploymentStep {
-  if (iteration.type === 'draft') return 'commit';
-  if (iteration.status === 'required') return 'prepare';
-  return 'activate';
+const PREPARATION_POLL_INTERVAL_MS = 2_000;
+const PREPARATION_WAIT_CALLOUT_DELAY_MS = 1_000;
+
+function* generateDeploymentSteps(
+  iteration: DeploymentIteration,
+  includePreparationStep: boolean,
+  t: ReturnType<typeof useTranslation>['t'],
+): Generator<DeploymentStepDefinition> {
+  yield {
+    key: 'draft',
+    label: t('scenarios:deployment_modal.steps.draft'),
+    isCurrent: false,
+  };
+  yield {
+    key: 'commit',
+    label: t('scenarios:deployment_modal.steps.commit'),
+    isCurrent: iteration.type === 'draft',
+  };
+  if (includePreparationStep) {
+    yield {
+      key: 'prepare',
+      label: t('scenarios:deployment_modal.steps.prepare'),
+      isCurrent: iteration.type !== 'draft' && iteration.status === 'required',
+    };
+  }
+  yield {
+    key: 'activate',
+    label: t('scenarios:deployment_modal.steps.activate'),
+    isCurrent: iteration.type !== 'draft' && iteration.status === 'ready_to_activate',
+  };
 }
 
 export function ScenarioDeploymentModal({
@@ -44,8 +71,11 @@ export function ScenarioDeploymentModal({
   rulesMetadata,
 }: ScenarioDeploymentModalProps) {
   const { t } = useTranslation(['common', 'scenarios']);
-  const [open, setOpen] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isPreparationPollingStarted, setIsPreparationPollingStarted] = useState(false);
+  const [shouldPersistPreparationStep, setShouldPersistPreparationStep] = useState(false);
+  const [showPreparationWaitCallout, setShowPreparationWaitCallout] = useState(false);
   const revalidate = useLoaderRevalidator();
 
   const commitMutation = useCommitIterationMutation(scenario.id, iteration.id);
@@ -53,25 +83,61 @@ export function ScenarioDeploymentModal({
   const activateMutation = useActivateIterationMutation(scenario.id, iteration.id);
   const ruleSnoozesQuery = useRuleSnoozesQuery(scenario.id, iteration.id);
 
-  const currentStep = getCurrentStep(iteration);
+  const publicationPreparationStatusQuery = usePublicationPreparationStatusQuery(scenario.id, iteration.id, {
+    enabled: isPreparationPollingStarted && iteration.status !== 'ready_to_activate',
+    refetchInterval: (query) => {
+      if (!isPreparationPollingStarted) return false;
+      if (query.state.data?.status === 'ready_to_activate') return false;
+      return PREPARATION_POLL_INTERVAL_MS;
+    },
+  });
+
+  const effectiveIteration: DeploymentIteration = {
+    ...iteration,
+    status: publicationPreparationStatusQuery.data?.status ?? iteration.status,
+  };
+  const steps = Array.from(
+    generateDeploymentSteps(effectiveIteration, iteration.status === 'required' || shouldPersistPreparationStep, t),
+  );
+  const currentStep = steps.find((step) => step.isCurrent)?.key ?? 'activate';
+  const hasActivationBecomeAvailable = effectiveIteration.status === 'ready_to_activate';
+  const isWaitingForActivation = isPreparationPollingStarted && !hasActivationBecomeAvailable;
 
   // Reset the error whenever the flow advances to a new step.
-  React.useEffect(() => {
+  useEffect(() => {
     setErrorMessage(null);
   }, [currentStep]);
 
+  useEffect(() => {
+    setIsPreparationPollingStarted(false);
+    setShouldPersistPreparationStep(false);
+    setShowPreparationWaitCallout(false);
+  }, [iteration.id]);
+
+  useEffect(() => {
+    if (!isPreparationPollingStarted || !hasActivationBecomeAvailable) return;
+
+    setIsPreparationPollingStarted(false);
+    revalidate();
+  }, [hasActivationBecomeAvailable, isPreparationPollingStarted, revalidate]);
+
+  useEffect(() => {
+    if (!isWaitingForActivation) {
+      setShowPreparationWaitCallout(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setShowPreparationWaitCallout(true);
+    }, PREPARATION_WAIT_CALLOUT_DELAY_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [isWaitingForActivation]);
+
   const activeMutation =
     currentStep === 'commit' ? commitMutation : currentStep === 'prepare' ? prepareMutation : activateMutation;
-  const isPending = activeMutation.isPending || (currentStep === 'activate' && ruleSnoozesQuery.isPending);
-
-  const steps: { key: DeploymentStep; label: string }[] = [
-    { key: 'draft', label: t('scenarios:deployment_modal.steps.draft') },
-    { key: 'commit', label: t('scenarios:deployment_modal.steps.commit') },
-    ...(iteration.status === 'required'
-      ? [{ key: 'prepare' as const, label: t('scenarios:deployment_modal.steps.prepare') }]
-      : []),
-    { key: 'activate', label: t('scenarios:deployment_modal.steps.activate') },
-  ];
+  const isPending =
+    activeMutation.isPending || isWaitingForActivation || (currentStep === 'activate' && ruleSnoozesQuery.isPending);
 
   const action: { label: string; icon: IconName } =
     currentStep === 'commit'
@@ -156,6 +222,9 @@ export function ScenarioDeploymentModal({
           );
           return;
         }
+        setShouldPersistPreparationStep(true);
+        setIsPreparationPollingStarted(true);
+        return;
       } else {
         const res = await activateMutation.mutateAsync({ willBeLive: true, changeIsImmediate: true });
         if (res?.error) {
@@ -228,6 +297,11 @@ export function ScenarioDeploymentModal({
                 <div className="min-h-6 w-full">
                   <RuleSnoozeDetail scenarioId={scenario.id} iterationId={iteration.id} rulesMetadata={rulesMetadata} />
                 </div>
+              ) : null}
+              {showPreparationWaitCallout ? (
+                <Callout color="purple" icon="tip">
+                  {t('scenarios:deployment_modal.prepare.waiting_for_activation')}
+                </Callout>
               ) : null}
               {errorMessage ? <p className="text-s text-red-primary font-medium">{errorMessage}</p> : null}
             </div>

--- a/packages/app-builder/src/locales/ar/scenarios.json
+++ b/packages/app-builder/src/locales/ar/scenarios.json
@@ -114,6 +114,7 @@
   "deployment_modal.prepare.preparation_service_occupied": "خدمة التهيئة غير متوفرة حاليًا. يرجى المحاولة مرة أخرى لاحقًا.",
   "deployment_modal.prepare.title": "تهيئة النسخة",
   "deployment_modal.prepare.validation_error": "لا يمكن تفعيل النسخة بسبب أخطاء التحقق. قم بإنشاء مسودة من هذه النسخة وقم بإصلاح الأخطاء.",
+  "deployment_modal.prepare.waiting_for_activation": "قد تستغرق التهيئة بعض الوقت. سنواصل التحقق حتى يصبح التفعيل متاحًا.",
   "deployment_modal.steps.activate": "تفعيل",
   "deployment_modal.steps.commit": "اعتماد",
   "deployment_modal.steps.draft": "مسودة",

--- a/packages/app-builder/src/locales/ar/scenarios.json
+++ b/packages/app-builder/src/locales/ar/scenarios.json
@@ -105,6 +105,7 @@
   "deployment_modal.deactivate.confirm": "بإلغاء التفعيل، أفهم ما يلي:",
   "deployment_modal.deactivate.helper": "يمكنك التراجع إلى نسخة سابقة مباشرة من صفحة النسخ.",
   "deployment_modal.deactivate.stop_operating": "سيتوقف السيناريو عن العمل ولن يتخذ أي قرارات بعد الآن.",
+  "deployment_modal.deactivate.success": "تم إلغاء تفعيل النسخة بنجاح",
   "deployment_modal.deactivate.title": "إلغاء تفعيل النسخة",
   "deployment_modal.prepare.activate_to_go_in_prod": "يتطلب الإنتاج تفعيل النسخة المُحضَّرة",
   "deployment_modal.prepare.activate_to_go_in_prod.tooltip": "بعد إكمال التهيئة، قم بتفعيل النسخة لجعلها سارية المفعول.",

--- a/packages/app-builder/src/locales/en/scenarios.json
+++ b/packages/app-builder/src/locales/en/scenarios.json
@@ -114,6 +114,7 @@
   "deployment_modal.prepare.preparation_service_occupied": "The preparation service is currently occupied. Please try again later.",
   "deployment_modal.prepare.title": "Prepare version",
   "deployment_modal.prepare.validation_error": "The version cannot be activated due to validation errors. Create a draft from this version and fix the errors.",
+  "deployment_modal.prepare.waiting_for_activation": "Preparation can take some time. We will keep checking until activation is available.",
   "deployment_modal.steps.activate": "Activate",
   "deployment_modal.steps.commit": "Commit",
   "deployment_modal.steps.draft": "Draft",

--- a/packages/app-builder/src/locales/en/scenarios.json
+++ b/packages/app-builder/src/locales/en/scenarios.json
@@ -105,6 +105,7 @@
   "deployment_modal.deactivate.confirm": "By deactivating, I understand :",
   "deployment_modal.deactivate.helper": "You can roll back to a previous version directly from the version page",
   "deployment_modal.deactivate.stop_operating": "The scenario will stop operating and no longer make any decision.",
+  "deployment_modal.deactivate.success": "The version has been successfully deactivated",
   "deployment_modal.deactivate.title": "Deactivate version",
   "deployment_modal.prepare.activate_to_go_in_prod": "Activating the prepared version is required for production",
   "deployment_modal.prepare.activate_to_go_in_prod.tooltip": "After completing the preparation, activate the version to make it live",

--- a/packages/app-builder/src/locales/fr/scenarios.json
+++ b/packages/app-builder/src/locales/fr/scenarios.json
@@ -114,6 +114,7 @@
   "deployment_modal.prepare.preparation_service_occupied": "Le service de préparation est actuellement occupé. Veuillez réessayer plus tard.",
   "deployment_modal.prepare.title": "Préparer la version",
   "deployment_modal.prepare.validation_error": "La version ne peut pas être activée en raison d'erreurs de validation. Créez un brouillon à partir de cette version et corrigez les erreurs.",
+  "deployment_modal.prepare.waiting_for_activation": "La préparation peut prendre un certain temps. Nous continuerons à vérifier jusqu'à ce que l'activation soit disponible.",
   "deployment_modal.steps.activate": "Activation",
   "deployment_modal.steps.commit": "Version",
   "deployment_modal.steps.draft": "Brouillon",

--- a/packages/app-builder/src/locales/fr/scenarios.json
+++ b/packages/app-builder/src/locales/fr/scenarios.json
@@ -105,6 +105,7 @@
   "deployment_modal.deactivate.confirm": "Veuillez confirmer ce qui suit :",
   "deployment_modal.deactivate.helper": "Vous pouvez revenir à une version précédente directement depuis la page des versions",
   "deployment_modal.deactivate.stop_operating": "Le scénario cessera de fonctionner et ne prendra plus aucune décision",
+  "deployment_modal.deactivate.success": "La version a été désactivée avec succès",
   "deployment_modal.deactivate.title": "Désactiver la version",
   "deployment_modal.prepare.activate_to_go_in_prod": "La nouvelle version ne sera pas active tant que vous ne l'aurez pas activée",
   "deployment_modal.prepare.activate_to_go_in_prod.tooltip": "Après avoir terminé la préparation, activez la version pour la mettre en production.",

--- a/packages/app-builder/src/queries/scenarios/publication-preparation-status.ts
+++ b/packages/app-builder/src/queries/scenarios/publication-preparation-status.ts
@@ -1,0 +1,26 @@
+import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
+import { getPublicationPreparationStatusFn } from '@app-builder/server-fns/scenarios';
+import { type Query, useQuery } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+
+type PublicationPreparationStatusQuery = Query<ScenarioPublicationStatus, Error, ScenarioPublicationStatus, string[]>;
+
+type UsePublicationPreparationStatusQueryOptions = {
+  enabled?: boolean;
+  refetchInterval?: number | false | ((query: PublicationPreparationStatusQuery) => number | false | undefined);
+};
+
+export function usePublicationPreparationStatusQuery(
+  scenarioId: string,
+  iterationId: string,
+  options?: UsePublicationPreparationStatusQueryOptions,
+) {
+  const getPublicationPreparationStatus = useServerFn(getPublicationPreparationStatusFn);
+
+  return useQuery({
+    queryKey: ['scenarios', 'iterations', 'publicationPreparationStatus', scenarioId, iterationId],
+    queryFn: async () => getPublicationPreparationStatus({ data: { scenarioId, iterationId } }),
+    enabled: options?.enabled ?? true,
+    refetchInterval: options?.refetchInterval,
+  });
+}

--- a/packages/app-builder/src/server-fns/scenarios.ts
+++ b/packages/app-builder/src/server-fns/scenarios.ts
@@ -507,6 +507,13 @@ export const prepareIterationFn = createServerFn({ method: 'POST' })
     }
   });
 
+export const getPublicationPreparationStatusFn = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ scenarioId: z.string(), iterationId: z.string() }))
+  .handler(async ({ context, data }) => {
+    return context.authInfo.scenario.getPublicationPreparationStatus({ iterationId: data.iterationId });
+  });
+
 export const getRuleSnoozeFn = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
   .inputValidator(z.object({ iterationId: z.string() }))


### PR DESCRIPTION
Enhance Scenario Deployment Modal with Preparation Status and UI Improvements

- Added a new callout to inform users about the waiting period for activation in the Scenario Deployment Modal.
- Introduced a polling mechanism to check the publication preparation status, improving user experience during deployment.
- Refactored state management in the Scenario Deployment Modal for better clarity and functionality.
- Added a new server function to retrieve publication preparation status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time polling during scenario deployment preparation and activation with improved status tracking.
  * New confirmation messaging when scenarios are successfully deactivated.
  * Added informational callout to clarify that preparation may take time while waiting for activation.

* **Bug Fixes**
  * Simplified deactivation workflow to use direct action instead of form-based selection.

* **Style**
  * Minor UI layout adjustment to form components for better spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->