### PR TITLE
fix MAR-1976 MAR-1981 and MAR-1992

### DIFF
--- a/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotNavigationOptions.tsx
+++ b/packages/app-builder/src/components/CaseManager/PivotsPanel/PivotNavigationOptions.tsx
@@ -45,10 +45,10 @@ export function PivotNavigationOptions({
       {linksToTable.length > 0 ? (
         <div
           className={cn(
-            'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-4 gap-y-2 break-all',
-            options?.layout === '2-columns' && 'grid-cols-[repeat(2,minmax(max-content,1fr)_1fr)]',
-            options?.layout === '3-columns' && 'grid-cols-[repeat(3,minmax(max-content,1fr)_1fr)]',
-            (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[minmax(max-content,1fr)_1fr]',
+            'grid auto-rows-[minmax(2rem,auto)] gap-x-4 gap-y-2 break-all items-center',
+            options?.layout === '2-columns' && 'grid-cols-[repeat(2,max-content_minmax(0,1fr))]',
+            options?.layout === '3-columns' && 'grid-cols-[repeat(3,max-content_minmax(0,1fr))]',
+            (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[max-content_minmax(0,1fr)]',
             className,
           )}
         >
@@ -62,10 +62,10 @@ export function PivotNavigationOptions({
               <Fragment key={linkToTable.childTableName}>
                 {navigationOptions.map((navOption) => (
                   <Fragment key={`${navOption.targetTableName}_${navOption.orderingFieldName}`}>
-                    <div>
+                    <label className="text-grey-secondary">
                       {navOption.targetTableName}
                       {navigationOptions.length > 1 ? ` (${navOption.orderingFieldName})` : null}
-                    </div>
+                    </label>
                     <Button
                       disabled={navOption.status === 'pending'}
                       variant="secondary"

--- a/packages/app-builder/src/components/CaseManagerV2/ClientRelatedAlertCasesCard.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/ClientRelatedAlertCasesCard.tsx
@@ -40,23 +40,21 @@ export function ClientRelatedAlertCasesCard({ caseId, pivotValue }: ClientRelate
             <div className="grid w-full grid-cols-[minmax(8rem,_auto)_1fr_auto] gap-v2-sm">
               {cases.map((caseObj, idx) => {
                 return (
-                  <div className="grid grid-cols-subgrid col-span-full" key={caseObj.id}>
-                    <div className="text-grey-secondary">
+                  <div className="grid grid-cols-subgrid col-span-full items-center" key={caseObj.id}>
+                    <label className="text-grey-secondary">
                       {formatDateTime(caseObj.createdAt, { dateStyle: 'short' })}
-                    </div>
-                    <div className="flex flex-col gap-v2-xs">
+                    </label>
+                    <div className="flex items-center gap-v2-xs">
                       <span>{caseObj.name}</span>
                       <CaseStatusBadgeV2 status={caseObj.status} variant="icon-only" />
                     </div>
-                    <div>
-                      <Link
-                        to="/cases/s/$caseId"
-                        params={{ caseId: fromUUIDtoSUUID(caseObj.id) }}
-                        className={CtaV2ClassName({ variant: 'primary', appearance: 'stroked' })}
-                      >
-                        {t('common:open')}
-                      </Link>
-                    </div>
+                    <Link
+                      to="/cases/s/$caseId"
+                      params={{ caseId: fromUUIDtoSUUID(caseObj.id) }}
+                      className={CtaV2ClassName({ variant: 'primary', appearance: 'stroked' })}
+                    >
+                      {t('common:open')}
+                    </Link>
                   </div>
                 );
               })}

--- a/packages/app-builder/src/components/Cases/CaseAlerts.tsx
+++ b/packages/app-builder/src/components/Cases/CaseAlerts.tsx
@@ -7,11 +7,11 @@ import { useScreeningDetailQuery } from '@app-builder/queries/screening/get-scre
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { parseUnknownData } from '@app-builder/utils/parse';
 import { InfiniteData, UseInfiniteQueryResult } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { map, pipe, take } from 'remeda';
 import { match } from 'ts-pattern';
-import { Button, cn } from 'ui-design-system';
+import { Button, cn, ExpandableGroupTagLine, Tooltip } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { DecisionPanel } from '../CaseManager/DecisionPanel/DecisionPanel';
 import { ReviewStatusTag } from '../Decisions/ReviewStatusTag';
@@ -249,12 +249,8 @@ export const AlertCard = ({
  * Renders trigger object fields responsively — shows as many fields as fit
  * on one line, with a "+N" badge for overflow. Uses ResizeObserver to
  * recalculate when the container width changes.
- *
- * Two layers:
- *  - Measurement layer (invisible, absolute): renders ALL items so we can
- *    measure their positions against the container width.
- *  - Display layer: React-controlled, renders only `visibleCount` items + badge.
  */
+
 const TriggerFieldsRow = ({
   fields,
   triggerObject,
@@ -263,65 +259,10 @@ const TriggerFieldsRow = ({
   triggerObject: Record<string, unknown>;
 }) => {
   const { t } = useTranslation(casesI18n);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const measureRef = useRef<HTMLDivElement>(null);
-  const [visibleCount, setVisibleCount] = useState(fields.length);
-
-  useEffect(() => {
-    const wrapper = wrapperRef.current;
-    const measure = measureRef.current;
-    if (!wrapper || !measure) return;
-
-    const recalculate = () => {
-      const items = measure.querySelectorAll<HTMLElement>('[data-field-item]');
-      if (items.length === 0) return;
-
-      const availableWidth = wrapper.clientWidth;
-      const measureLeft = measure.getBoundingClientRect().left;
-
-      // How many items fit without a badge?
-      let fitCount = 0;
-      for (const item of items) {
-        const itemRight = item.getBoundingClientRect().right - measureLeft;
-        if (itemRight <= availableWidth + 1) {
-          fitCount++;
-        } else {
-          break;
-        }
-      }
-
-      if (fitCount >= items.length) {
-        setVisibleCount(items.length);
-        return;
-      }
-
-      // Not all fit — account for the "+N" badge width (~40px)
-      const badgeWidth = 40;
-      let adjusted = 0;
-      for (const item of items) {
-        const itemRight = item.getBoundingClientRect().right - measureLeft;
-        if (itemRight <= availableWidth - badgeWidth + 1) {
-          adjusted++;
-        } else {
-          break;
-        }
-      }
-
-      setVisibleCount(Math.max(1, adjusted));
-    };
-
-    recalculate();
-    const observer = new ResizeObserver(recalculate);
-    observer.observe(wrapper);
-    return () => observer.disconnect();
-  }, [fields.length]);
-
-  const hiddenCount = fields.length - visibleCount;
-
   const renderField = (field: { id: string; name: string }, index: number) => (
-    <span key={field.id} data-field-item className="inline-flex shrink-0 items-baseline gap-0.5 ps-1">
-      {index > 0 ? <span className="text-grey-placeholder pe-1">&middot;</span> : null}
-      <span className="font-medium">{field.name}:</span>{' '}
+    <span key={field.id} data-field-item className="inline-flex shrink-0 items-baseline gap-v2-xs">
+      {index > 0 ? <span className="text-grey-placeholder">&middot;</span> : null}
+      <span className="font-medium">{field.name}:</span>
       <span className="max-w-[120px] truncate">
         <FormatData data={parseUnknownData(triggerObject[field.name])} />
       </span>
@@ -329,26 +270,21 @@ const TriggerFieldsRow = ({
   );
 
   return (
-    <div ref={wrapperRef} className="relative text-xs">
-      {/* Measurement layer: all items, invisible, same width as wrapper */}
-      <div
-        ref={measureRef}
-        className="pointer-events-none invisible absolute inset-x-0 top-0 flex items-baseline"
-        aria-hidden="true"
-      >
-        <span className="shrink-0">{t('cases:decisions.trigger_objects')}</span>
-        {fields.map(renderField)}
-      </div>
-
-      {/* Display layer: only items that fit + overflow badge */}
-      <div className="flex items-baseline">
+    <div className="relative text-xs">
+      <div className="flex items-baseline gap-v2-sm">
         <span className="text-grey-secondary shrink-0">{t('cases:decisions.trigger_objects')}</span>
-        {fields.slice(0, visibleCount).map(renderField)}
-        {hiddenCount > 0 ? (
-          <span className="border-grey-border ms-1 inline-flex shrink-0 rounded-sm border px-1.5 py-0.5 text-xs font-medium">
-            +{hiddenCount}
-          </span>
-        ) : null}
+        <ExpandableGroupTagLine
+          items={fields.map(renderField)}
+          moreButton={(overflow) => (
+            <Tooltip.Default content={<div className="flex flex-wrap w-min text-xs">{fields.map(renderField)}</div>}>
+              <span className="border-grey-border ms-1 inline-flex shrink-0 rounded-sm border px-1.5 py-0.5 text-xs font-medium">
+                +{overflow}
+              </span>
+            </Tooltip.Default>
+          )}
+          overflowTagWidth={40}
+          classname="gap-v2-xs"
+        />
       </div>
     </div>
   );

--- a/packages/ui-design-system/src/ExpandableGroupTagLine/ExpandableGroupTagLine.tsx
+++ b/packages/ui-design-system/src/ExpandableGroupTagLine/ExpandableGroupTagLine.tsx
@@ -13,6 +13,7 @@ export interface ExpandableGroupTagLineProps {
   lessButton?: (onCollapse: (event: MouseEvent) => void) => ReactNode;
   classname?: string;
   trailing?: ReactNode;
+  overflowTagWidth?: number;
 }
 
 function DefaultMoreButton({ overflow, onExpand }: { overflow: number; onExpand: (event: MouseEvent) => void }) {
@@ -37,6 +38,7 @@ export function ExpandableGroupTagLine({
   lessButton,
   classname,
   trailing,
+  overflowTagWidth = OVERFLOW_TAG_WIDTH_PX,
 }: ExpandableGroupTagLineProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -60,7 +62,7 @@ export function ExpandableGroupTagLine({
         const tw = tagEls[i]!.offsetWidth;
         const gapBefore = i > 0 ? gap : 0;
         const isLast = i === tagEls.length - 1;
-        const needed = used + gapBefore + tw + (isLast ? 0 : gap + OVERFLOW_TAG_WIDTH_PX);
+        const needed = used + gapBefore + tw + (isLast ? 0 : gap + overflowTagWidth);
         if (needed <= availableWidth) {
           used += gapBefore + tw;
           count++;
@@ -90,15 +92,20 @@ export function ExpandableGroupTagLine({
   };
 
   return (
-    <div ref={containerRef} className={cn('relative min-w-0 w-full flex-1', classname)}>
+    <div ref={containerRef} className="relative min-w-0 w-full flex-1">
       <div
         ref={ghostRef}
-        className="pointer-events-none invisible absolute top-0 right-0 left-0 flex items-center gap-v2-sm"
+        className={cn(
+          'pointer-events-none invisible absolute top-0 right-0 left-0 flex items-center gap-v2-sm overflow-x-hidden',
+          classname,
+        )}
         aria-hidden="true"
       >
         {items}
       </div>
-      <div className={cn('flex min-w-0 items-center gap-v2-sm', isExpanded ? 'flex-wrap' : 'overflow-hidden')}>
+      <div
+        className={cn('flex min-w-0 items-center gap-v2-sm', isExpanded ? 'flex-wrap' : 'overflow-hidden', classname)}
+      >
         {visibleItems}
         {overflow > 0 &&
           (moreButton ? (


### PR DESCRIPTION
fix minor problems:

- MAR-1992: overflow x of the page
- MAR-1981: Case status could be on the same line
- MAR-1976: Navigation option part is not align with the rest of the card

refacto `TriggerFieldsRow`in `CaseAlerts.tsx` with existing `ExpandableGroupTagLine` to avoid redundant code