### PR TITLE
fix csp headers ?

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "permissions": {
-    "allow": ["Edit:*", "Write:*", "MultiEdit:*", "NotebookEdit:*", "Bash:*"],
+    "allow": ["Edit", "Write", "MultiEdit", "NotebookEdit", "Bash"],
     "defaultMode": "acceptEdits"
   },
   "hooks": {

--- a/packages/app-builder/src/middlewares/security-headers.ts
+++ b/packages/app-builder/src/middlewares/security-headers.ts
@@ -1,0 +1,30 @@
+import { getContentSecurityPolicy, runWithSecurityHeadersStore } from '@app-builder/utils/security-headers.server';
+import { createMiddleware } from '@tanstack/react-start';
+
+// Generates the per-request CSP nonce and applies security headers to every
+// document response.
+//
+// The nonce is opened into the request-scoped store here (before `next()`) so the
+// router (`router.tsx` → `ssr.nonce`) and the root loader (which builds the CSP)
+// all share the same value. After the render, we read the CSP the loader published
+// into the store and set it on the real document `Response` — TanStack Start does
+// not merge server-fn `setResponseHeaders` into successful document responses.
+// See `utils/security-headers.server.ts` for the full rationale.
+export const securityHeadersMiddleware = createMiddleware().server(({ next }) => {
+  const nonce = crypto.randomUUID().replace(/-/g, '');
+
+  return runWithSecurityHeadersStore(nonce, async () => {
+    const result = await next();
+
+    const csp = getContentSecurityPolicy();
+    if (csp && !result.response.headers.has('content-security-policy')) {
+      result.response.headers.set('Content-Security-Policy', csp);
+    }
+    // Redundant with the CSP `frame-ancestors 'none'`, kept for older clients/scanners.
+    if (!result.response.headers.has('x-frame-options')) {
+      result.response.headers.set('X-Frame-Options', 'DENY');
+    }
+
+    return result;
+  });
+});

--- a/packages/app-builder/src/router.tsx
+++ b/packages/app-builder/src/router.tsx
@@ -1,12 +1,22 @@
 import * as TanstackQuery from '@app-builder/integrations/tanstack-query/root-provider';
+import { getRequestNonce } from '@app-builder/utils/security-headers.server';
 import { createRouter } from '@tanstack/react-router';
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query';
+import { createIsomorphicFn } from '@tanstack/react-start';
 import i18next from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { ReactNode } from 'react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { routeTree } from './routeTree.gen';
 import { ALL_NAMESPACES, Namespace } from './services/i18n/all-namespaces';
+
+// Reads the per-request CSP nonce on the server (from the request-scoped store opened
+// by `securityHeadersMiddleware`) so TanStack Start stamps it onto the hydration
+// scripts rendered by `<Scripts>`. `createIsomorphicFn` strips the server branch — and
+// its `node:async_hooks` import — from the client bundle.
+const getNonce = createIsomorphicFn()
+  .server(() => getRequestNonce())
+  .client(() => undefined);
 
 export function getRouter() {
   const rqContext = TanstackQuery.getContext();
@@ -27,6 +37,7 @@ export function getRouter() {
     routeTree,
     context: { ...rqContext, i18n },
     scrollRestoration: true,
+    ssr: { nonce: getNonce() },
     Wrap: (props: { children: ReactNode }) => {
       return (
         <I18nextProvider i18n={i18n}>

--- a/packages/app-builder/src/routes/__root.tsx
+++ b/packages/app-builder/src/routes/__root.tsx
@@ -127,6 +127,7 @@ function RootShell({ children }: { children: ReactNode }) {
           </I18nProvider>
         </I18nextProvider>
         <script
+          suppressHydrationWarning
           nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `window.ENV = ${JSON.stringify(env)}`,

--- a/packages/app-builder/src/server-fns/root.ts
+++ b/packages/app-builder/src/server-fns/root.ts
@@ -6,9 +6,10 @@ import { getToast } from '@app-builder/services/toast.server';
 import { commitCsrfToken } from '@app-builder/utils/csrf.server';
 import { getClientEnvVars, getServerEnv } from '@app-builder/utils/environment';
 import { getPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookie-read.server';
+import { getRequestNonce, setContentSecurityPolicy } from '@app-builder/utils/security-headers.server';
 import { createContentSecurityPolicy } from '@mcansh/http-helmet';
 import { createServerFn } from '@tanstack/react-start';
-import { getRequest, setResponseHeaders } from '@tanstack/react-start/server';
+import { getRequest } from '@tanstack/react-start/server';
 
 export const getRootLoaderDataFn = createServerFn({ method: 'GET' })
   .middleware([servicesMiddleware])
@@ -35,8 +36,10 @@ export const getRootLoaderDataFn = createServerFn({ method: 'GET' })
     const disableSegment = getServerEnv('DISABLE_SEGMENT') ?? false;
     const segmentScript = !disableSegment && segmentApiKey ? getSegmentScript(segmentApiKey) : undefined;
 
-    // Generate a per-request CSP nonce and set the Content-Security-Policy header.
-    const nonce = crypto.randomUUID().replace(/-/g, '');
+    // Use the per-request nonce opened by `securityHeadersMiddleware`, so this CSP, the
+    // hydration scripts (`router.ssr.nonce`), and the inline scripts below all match.
+    // Fallback keeps the loader resilient if it ever runs outside that middleware scope.
+    const nonce = getRequestNonce() ?? crypto.randomUUID().replace(/-/g, '');
 
     const firebaseUrl = appConfig.auth.firebase.isEmulator
       ? [appConfig.auth.firebase.emulatorUrl]
@@ -74,10 +77,10 @@ export const getRootLoaderDataFn = createServerFn({ method: 'GET' })
       frameSrc: frames.length > 0 ? frames : ["'none'"],
     });
 
-    // Set CSP header.
-    const responseHeaders = new Headers();
-    responseHeaders.set('Content-Security-Policy', csp);
-    setResponseHeaders(responseHeaders);
+    // Publish the CSP to `securityHeadersMiddleware` (see start.ts), which sets it on
+    // the document response. We cannot set it here directly: this server fn runs in its
+    // own H3 event scope, so `setResponseHeaders` never reaches the streamed document.
+    setContentSecurityPolicy(csp);
 
     return { ENV, locale, timezone, theme, csrf: csrfToken, toastMessage, segmentScript, appConfig, nonce };
   });

--- a/packages/app-builder/src/start.ts
+++ b/packages/app-builder/src/start.ts
@@ -1,8 +1,10 @@
 import { createStart } from '@tanstack/react-start';
 import { convertRedirectErrorToExceptionMiddleware } from './middlewares/globals';
+import { securityHeadersMiddleware } from './middlewares/security-headers';
 
 export const startInstance = createStart(() => {
   return {
+    requestMiddleware: [securityHeadersMiddleware],
     functionMiddleware: [convertRedirectErrorToExceptionMiddleware],
   };
 });

--- a/packages/app-builder/src/utils/security-headers.server.ts
+++ b/packages/app-builder/src/utils/security-headers.server.ts
@@ -1,0 +1,36 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// Request-scoped storage for the per-request CSP nonce and the built CSP string.
+//
+// Why an AsyncLocalStorage and not the H3 event / response headers:
+//   - The CSP is built in the root loader (`server-fns/root.ts`) — the only place
+//     with both `appConfig` and the render nonce. But the loader runs as a
+//     `createServerFn`, which TanStack Start executes in its OWN H3 event scope, so
+//     headers it sets via `setResponseHeaders` never reach the streamed document.
+//   - The nonce must also be handed to `router.options.ssr.nonce` (see router.tsx)
+//     so TanStack Start stamps it onto the hydration scripts it injects via
+//     `<Scripts>` — otherwise an enforced CSP blocks them and hydration dies. This
+//     regressed in the Remix → TanStack migration (Remix's `<Scripts nonce>` did it).
+//
+// The request middleware (`middlewares/security-headers.ts`) opens this store around
+// `next()`. Everything rendered for the request — `getRouter()`, the root loader, the
+// response-header pass — runs inside that scope and shares one nonce. It is a separate
+// ALS instance from TanStack's, so the server-fn event scoping does not disturb it.
+const storage = new AsyncLocalStorage<{ nonce: string; csp?: string }>();
+
+export function runWithSecurityHeadersStore<T>(nonce: string, fn: () => T): T {
+  return storage.run({ nonce }, fn);
+}
+
+export function getRequestNonce(): string | undefined {
+  return storage.getStore()?.nonce;
+}
+
+export function setContentSecurityPolicy(csp: string): void {
+  const store = storage.getStore();
+  if (store) store.csp = csp;
+}
+
+export function getContentSecurityPolicy(): string | undefined {
+  return storage.getStore()?.csp;
+}


### PR DESCRIPTION
## Restore CSP & X-Frame-Options on document responses

Our CSP and frame protection were never actually shipping — not in prod, staging, or dev. Two things broke silently during the Remix → TanStack migration:

- **Headers never reached the page.** `root.ts` set them via `setResponseHeaders` inside a `createServerFn` loader, but TanStack runs server fns in their own H3 event scope, so those headers never merge into the (2xx) streamed document.
- **Hydration scripts weren't nonced.** TanStack's `<Scripts>` reads its nonce from `router.options.ssr.nonce` (Remix's `<Scripts nonce>` equivalent), which we never set — so enforcing the CSP would block our own bootstrap scripts.

### What changed
- New `securityHeadersMiddleware` (request middleware in `start.ts`) sets CSP + `X-Frame-Options: DENY` on the real document `Response`.
- One per-request nonce now flows through a request-scoped `AsyncLocalStorage` (`utils/security-headers.server.ts`) shared by the middleware, `router.tsx` (`ssr.nonce`), and the root loader (CSP + inline `window.ENV`).
- `router.tsx` reads the nonce via `createIsomorphicFn` so `node:async_hooks` stays out of the client bundle.

### Verified
Dev + production build: headers present, nonces aligned, hydration clean (0 CSP violations), authenticated pages refuse to be framed.

⚠️ If you add inline `<script>`s, they must carry the nonce (`useNonce()` / `NonceProvider`) or they'll be blocked now that CSP is enforced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request CSP nonce generation with automatic CSP header injection and added X-Frame-Options for stronger protection.
  * Request-scoped storage for CSP nonce and policy to ensure consistent headers across request handling.
  * Router/server wiring to apply nonces to SSR hydration scripts.
  * Inline ENV script now suppresses hydration warnings.

* **Configuration**
  * Permissions updated to explicit permission names instead of wildcard entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->