### PR TITLE
feat: redesign sidebar MAR-1997

### DIFF
--- a/packages/app-builder/src/components/Layout/LeftSidebar.tsx
+++ b/packages/app-builder/src/components/Layout/LeftSidebar.tsx
@@ -1,69 +1,11 @@
-import { useTheme } from '@app-builder/contexts/ThemeContext';
-import { setPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookies-write';
-import clsx from 'clsx';
 import type * as React from 'react';
-import { createSharpFactory } from 'sharpstate';
-import { Icon } from 'ui-icons';
-
-import { SidebarButton } from '../Navigation';
-
-export const LeftSidebarSharpFactory = createSharpFactory({
-  name: 'LeftSidebar',
-  initializer: (expanded: boolean = true) => ({ expanded }),
-}).withActions({
-  toggleExpanded(api) {
-    api.value.expanded = !api.value.expanded;
-  },
-  setExpanded(api, value: boolean) {
-    api.value.expanded = value;
-  },
-});
 
 export function LeftSidebar({ children }: { children: React.ReactNode }) {
-  const isExpanded = LeftSidebarSharpFactory.select((s) => s.expanded);
-
   return (
-    <div
-      aria-expanded={isExpanded}
-      className="bg-surface-sidebar group/nav border-e-grey-border z-20 flex max-h-screen w-14 shrink-0 flex-col border-e transition-all aria-expanded:w-[235px] dark:border-e-grey-border"
-    >
-      {children}
+    <div className="group/sidebar relative w-14 max-h-screen z-20">
+      <div className="group/nav h-full w-14 bg-surface-sidebar border-e border-e-grey-border flex flex-col group-hover/sidebar:absolute group-hover/sidebar:top-0 group-hover/sidebar:left-0 group-hover/sidebar:w-58.5 transition-all delay-300 group-hover/sidebar:delay-0 motion-reduce:delay-0 motion-reduce:duration-0 group-hover/sidebar:shadow-sticky-left">
+        {children}
+      </div>
     </div>
-  );
-}
-
-export function ToggleSidebar() {
-  const leftSidebarSharp = LeftSidebarSharpFactory.useSharp();
-  const isExpanded = leftSidebarSharp.select((s) => s.expanded);
-
-  const toggleExpanded = async () => {
-    leftSidebarSharp.actions.toggleExpanded();
-    setPreferencesCookie('menuExpd', leftSidebarSharp.value.expanded);
-  };
-
-  return (
-    <SidebarButton
-      onClick={toggleExpanded}
-      labelTKey={isExpanded ? 'navigation:collapse' : 'navigation:expand'}
-      Icon={({ className, ...props }) => (
-        <Icon
-          className={clsx('rtl:rotate-180', className)}
-          icon={isExpanded ? 'left-panel-close' : 'left-panel-open'}
-          {...props}
-        />
-      )}
-    />
-  );
-}
-
-export function ToggleTheme() {
-  const { theme, toggleTheme } = useTheme();
-
-  return (
-    <SidebarButton
-      onClick={toggleTheme}
-      labelTKey={theme === 'dark' ? 'navigation:light_mode' : 'navigation:dark_mode'}
-      Icon={(props) => <Icon icon={theme === 'dark' ? 'light_mode' : 'dark_mode'} {...props} />}
-    />
   );
 }

--- a/packages/app-builder/src/components/Navigation.tsx
+++ b/packages/app-builder/src/components/Navigation.tsx
@@ -40,7 +40,7 @@ export function SidebarLink({ Icon, labelTKey, to, children, className }: Sideba
       to={to}
     >
       <Icon className="size-6 shrink-0" />
-      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
+      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
         {t(labelTKey)}
       </span>
       {children}
@@ -62,7 +62,7 @@ export const SidebarButton = React.forwardRef<HTMLButtonElement, SidebarButtonPr
   return (
     <button ref={ref} className={sidebarLink({ className })} {...props}>
       <Icon className="size-6 shrink-0" />
-      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
+      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
         {t(labelTKey)}
       </span>
     </button>

--- a/packages/app-builder/src/components/Nudge.tsx
+++ b/packages/app-builder/src/components/Nudge.tsx
@@ -12,51 +12,31 @@ type NudgeProps = {
   iconClass?: string;
   link?: string;
   kind?: Exclude<FeatureAccessLevelDto, 'allowed'>;
-  collapsed?: boolean;
 };
 
-const triggerClassName = cva('flex items-center justify-center text-white ', {
+const triggerClassName = cva('flex items-center justify-center text-white rounded-sm size-6', {
   variants: {
     kind: {
       test: 'bg-purple-primary',
       restricted: 'bg-purple-disabled',
       missing_configuration: 'bg-yellow-primary',
     },
-    collapsed: {
-      true: 'absolute top-v2-sm right-v2-sm translate-x-[50%] -translate-y-[50%] rounded-full',
-      false: 'rounded-sm size-6',
-    },
-  },
-  defaultVariants: {
-    collapsed: false,
   },
 });
 
-const iconClassName = cva('', {
-  variants: {
-    collapsed: {
-      true: 'size-2.5',
-      false: 'size-3',
-    },
-  },
-  defaultVariants: {
-    collapsed: false,
-  },
-});
-
-export const Nudge = ({ content, link, className, kind = 'restricted', iconClass, collapsed = false }: NudgeProps) => {
+export const Nudge = ({ content, link, className, kind = 'restricted', iconClass }: NudgeProps) => {
   const { t } = useTranslation(['common']);
   return (
     <HoverCard>
       <HoverCardTrigger tabIndex={-1} asChild>
-        <span className={triggerClassName({ kind, collapsed, className })}>
+        <span className={triggerClassName({ kind, className })}>
           <Icon
             icon={match<typeof kind, IconName>(kind)
               .with('restricted', () => 'lock')
               .with('test', () => 'unlock-right')
               .with('missing_configuration', () => 'warning')
               .exhaustive()}
-            className={iconClassName({ collapsed, className: iconClass })}
+            className={cn('size-3', iconClass)}
             aria-hidden
           />
         </span>

--- a/packages/app-builder/src/components/UserInfo.tsx
+++ b/packages/app-builder/src/components/UserInfo.tsx
@@ -16,8 +16,8 @@ export function UserInfo({ isAutoAssignmentAvailable = false }: UserInfoProps) {
           <CustomLogo
             logo="logo"
             alt="Logo"
-            className="size-6 shrink-0 transition-all group-aria-expanded/nav:size-12 text-grey-primary"
-            customLogoClassName="size-6 shrink-0 object-contain transition-all group-aria-expanded/nav:h-12 group-aria-expanded/nav:w-auto"
+            className="size-6 shrink-0 transition-all group-hover/sidebar:size-12 delay-300 group-hover/sidebar:delay-0 text-grey-primary"
+            customLogoClassName="size-6 shrink-0 object-contain transition-all group-hover/sidebar:h-12 delay-300 group-hover/sidebar:delay-0 group-hover/sidebar:w-auto"
           />
           {isAutoAssignmentAvailable && unavailabilityQuery.isSuccess && unavailabilityQuery.data.until !== null ? (
             <div className="absolute top-1 left-1 flex h-3 w-3">
@@ -28,7 +28,7 @@ export function UserInfo({ isAutoAssignmentAvailable = false }: UserInfoProps) {
           <CustomLogo
             logo="marble"
             alt="Logo"
-            className="h-6 w-full opacity-0 transition-opacity group-aria-expanded/nav:opacity-100 dark:invert"
+            className="h-6 w-full opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0 dark:invert"
             hideWhenCustom
           />
         </div>

--- a/packages/app-builder/src/routes/_app/_builder.tsx
+++ b/packages/app-builder/src/routes/_app/_builder.tsx
@@ -1,5 +1,5 @@
 import { navigationI18n, SidebarLink } from '@app-builder/components';
-import { LeftSidebar, LeftSidebarSharpFactory, ToggleSidebar } from '@app-builder/components/Layout/LeftSidebar';
+import { LeftSidebar } from '@app-builder/components/Layout/LeftSidebar';
 import { Nudge } from '@app-builder/components/Nudge';
 import { DatasetFreshnessBanner } from '@app-builder/components/Screenings/DatasetFresshnessBanner';
 import { UnavailableBanner } from '@app-builder/components/Settings/UnavailableBanner';
@@ -20,19 +20,18 @@ import { OrganizationUsersContextProvider } from '@app-builder/services/organiza
 import { useSegmentIdentification } from '@app-builder/services/segment';
 import { useSentryIdentification, useSentryReplay } from '@app-builder/services/sentry';
 import { getSettingsAccess } from '@app-builder/services/settings-access';
-import { getPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookie-read.server';
 import { ClientOnly, createFileRoute, Outlet } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
-import { getRequest } from '@tanstack/react-start/server';
 import { type Namespace } from 'i18next';
+import { type ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match, P } from 'ts-pattern';
+import { cn } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 const appBuilderLayoutLoader = createServerFn()
   .middleware([authMiddleware])
   .handler(async function appBuilderLayout({ context }) {
-    const request = getRequest();
     const { user, inbox, organization, entitlements } = context.authInfo;
     const [organizationDetail, orgUsers, orgTags, orgObjectTags, inboxes] = await Promise.all([
       organization.getCurrentOrganization(),
@@ -64,7 +63,6 @@ const appBuilderLayoutLoader = createServerFn()
         userScoring: isAnalyst(user) ? ('restricted' as const) : entitlements.userScoring,
       },
       authProvider: context.appConfig.auth.provider,
-      isMenuExpanded: getPreferencesCookie(request, 'menuExpd'),
       sentryReplayEnabled: organizationDetail.sentryReplayEnabled,
     };
   });
@@ -81,23 +79,25 @@ const TokenRefresher = () => {
   return null;
 };
 
+const SIDEBAR_NUDGE_CLASS = cn(
+  'absolute top-v2-sm right-v2-sm translate-x-[50%] -translate-y-[50%] rounded-full size-2.5',
+  'group-hover/sidebar:static group-hover/sidebar:translate-x-0 group-hover/sidebar:translate-y-0',
+  'group-hover/sidebar:rounded-sm group-hover/sidebar:size-6',
+  'transition-all delay-300 group-hover/sidebar:delay-0 motion-reduce:delay-0 motion-reduce:duration-0',
+);
+const SIDEBAR_NUDGE_ICON_CLASS = 'size-2.5 group-hover/sidebar:size-3';
+
+function SidebarNudge(props: Omit<ComponentProps<typeof Nudge>, 'className' | 'iconClass'>) {
+  return <Nudge {...props} className={SIDEBAR_NUDGE_CLASS} iconClass={SIDEBAR_NUDGE_ICON_CLASS} />;
+}
+
 function Builder() {
-  const {
-    user,
-    orgUsers,
-    organization,
-    orgTags,
-    orgObjectTags,
-    featuresAccess,
-    isMenuExpanded,
-    authProvider,
-    sentryReplayEnabled,
-  } = Route.useLoaderData();
+  const { user, orgUsers, organization, orgTags, orgObjectTags, featuresAccess, authProvider, sentryReplayEnabled } =
+    Route.useLoaderData();
   useSegmentIdentification(user);
   useSentryIdentification(user);
   useSentryReplay(sentryReplayEnabled);
   const { t } = useTranslation(i18n);
-  const leftSidebarSharp = LeftSidebarSharpFactory.createSharp(isMenuExpanded);
 
   return (
     <>
@@ -112,154 +112,139 @@ function Builder() {
               <div className="flex h-screen flex-1 flex-col">
                 <DatasetFreshnessBanner />
                 <div className="flex flex-1 flex-row overflow-hidden">
-                  <LeftSidebarSharpFactory.Provider value={leftSidebarSharp}>
-                    <LeftSidebar>
-                      <div className="h-24 px-2 pt-3">
-                        <UserInfo isAutoAssignmentAvailable={featuresAccess.isAutoAssignmentAvailable} />
-                      </div>
-                      <nav className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-2">
-                        <ul className="flex flex-col gap-2">
-                          {/* Detection - flat link (tabs are inside the page) */}
-                          {!isAnalyst(user) && (
-                            <li>
-                              <SidebarLink
-                                labelTKey="navigation:detection"
-                                to="/detection"
-                                Icon={(props) => <Icon icon="scenarios" {...props} />}
-                              />
-                            </li>
-                          )}
-                          {/* User Scoring */}
-                          {!isAnalyst(user) && (
-                            <li>
-                              {match(featuresAccess.userScoring)
-                                .with(P.union('allowed', 'test'), () => {
-                                  return (
-                                    <SidebarLink
-                                      labelTKey="navigation:user_scoring"
-                                      to="/user-scoring"
-                                      Icon={(props) => <Icon icon="123" {...props} />}
-                                    />
-                                  );
-                                })
-                                .otherwise((value) => {
-                                  return (
-                                    <div className="text-grey-disabled relative flex gap-2 p-2">
-                                      <Icon icon="123" className="size-6 shrink-0" />
-                                      <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
-                                        {t('navigation:user_scoring')}
-                                      </span>
-                                      <Nudge
-                                        collapsed={!leftSidebarSharp.value.expanded}
-                                        kind={value}
-                                        className="size-6"
-                                        content={t('navigation:user_scoring.nudge')}
-                                      />
-                                    </div>
-                                  );
-                                })}
-                            </li>
-                          )}
-                          {/* Monitoring (Continuous Screening) */}
-                          {!isAnalyst(user) && (
-                            <li>
-                              {match(featuresAccess.continuousScreening)
-                                .with(P.union('allowed', 'test'), () => {
-                                  return (
-                                    <SidebarLink
-                                      labelTKey="navigation:continuous_screening"
-                                      to="/continuous-screening"
-                                      Icon={(props) => <Icon icon="scan-eye" {...props} />}
-                                    />
-                                  );
-                                })
-                                .otherwise((value) => {
-                                  return (
-                                    <div className="text-grey-disabled relative flex gap-2 p-2">
-                                      <Icon icon="scan-eye" className="size-6 shrink-0" />
-                                      <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-aria-expanded/nav:opacity-100">
-                                        {t('navigation:continuous_screening')}
-                                      </span>
-                                      <Nudge
-                                        collapsed={!leftSidebarSharp.value.expanded}
-                                        kind={value}
-                                        className="size-6"
-                                        content={t('navigation:continuous_screening.nudge')}
-                                      />
-                                    </div>
-                                  );
-                                })}
-                            </li>
-                          )}
-                          {/* Investigations (Cases) */}
+                  <LeftSidebar>
+                    <div className="h-24 px-2 pt-3">
+                      <UserInfo isAutoAssignmentAvailable={featuresAccess.isAutoAssignmentAvailable} />
+                    </div>
+                    <nav className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-2">
+                      <ul className="flex flex-col gap-2">
+                        {/* Detection - flat link (tabs are inside the page) */}
+                        {!isAnalyst(user) && (
                           <li>
                             <SidebarLink
-                              labelTKey="navigation:case_manager"
-                              to="/cases"
-                              Icon={(props) => <Icon icon="case-manager" {...props} />}
+                              labelTKey="navigation:detection"
+                              to="/detection"
+                              Icon={(props) => <Icon icon="scenarios" {...props} />}
                             />
                           </li>
-                          {/* Global Search (Screening Search) */}
-                          {featuresAccess.isScreeningSearchAvailable ? (
-                            <li>
-                              <SidebarLink
-                                labelTKey="navigation:screening_search"
-                                to="/screening-search"
-                                Icon={(props) => <Icon icon="search" {...props} />}
-                              />
-                            </li>
-                          ) : null}
-                          {/* Client detail */}
+                        )}
+                        {/* User Scoring */}
+                        {!isAnalyst(user) && (
+                          <li>
+                            {match(featuresAccess.userScoring)
+                              .with(P.union('allowed', 'test'), () => {
+                                return (
+                                  <SidebarLink
+                                    labelTKey="navigation:user_scoring"
+                                    to="/user-scoring"
+                                    Icon={(props) => <Icon icon="123" {...props} />}
+                                  />
+                                );
+                              })
+                              .otherwise((value) => {
+                                return (
+                                  <div className="text-grey-disabled relative flex gap-2 p-2">
+                                    <Icon icon="123" className="size-6 shrink-0" />
+                                    <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
+                                      {t('navigation:user_scoring')}
+                                    </span>
+                                    <SidebarNudge kind={value} content={t('navigation:user_scoring.nudge')} />
+                                  </div>
+                                );
+                              })}
+                          </li>
+                        )}
+                        {/* Monitoring (Continuous Screening) */}
+                        {!isAnalyst(user) && (
+                          <li>
+                            {match(featuresAccess.continuousScreening)
+                              .with(P.union('allowed', 'test'), () => {
+                                return (
+                                  <SidebarLink
+                                    labelTKey="navigation:continuous_screening"
+                                    to="/continuous-screening"
+                                    Icon={(props) => <Icon icon="scan-eye" {...props} />}
+                                  />
+                                );
+                              })
+                              .otherwise((value) => {
+                                return (
+                                  <div className="text-grey-disabled relative flex gap-2 p-2">
+                                    <Icon icon="scan-eye" className="size-6 shrink-0" />
+                                    <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
+                                      {t('navigation:continuous_screening')}
+                                    </span>
+                                    <SidebarNudge kind={value} content={t('navigation:continuous_screening.nudge')} />
+                                  </div>
+                                );
+                              })}
+                          </li>
+                        )}
+                        {/* Investigations (Cases) */}
+                        <li>
+                          <SidebarLink
+                            labelTKey="navigation:case_manager"
+                            to="/cases"
+                            Icon={(props) => <Icon icon="case-manager" {...props} />}
+                          />
+                        </li>
+                        {/* Global Search (Screening Search) */}
+                        {featuresAccess.isScreeningSearchAvailable ? (
                           <li>
                             <SidebarLink
-                              labelTKey="navigation:client_detail"
-                              to="/client-detail"
-                              Icon={(props) => <Icon icon="users" {...props} />}
+                              labelTKey="navigation:screening_search"
+                              to="/screening-search"
+                              Icon={(props) => <Icon icon="search" {...props} />}
                             />
                           </li>
-                        </ul>
-                      </nav>
-                      {/* Secondary Navigation - Bottom */}
-                      <nav className="p-2 pb-4">
-                        <ul className="flex flex-col gap-2">
-                          {/* Your Data */}
-                          {!isAnalyst(user) && (
-                            <li>
-                              <SidebarLink
-                                labelTKey="navigation:data"
-                                to="/data"
-                                Icon={(props) => <Icon icon="harddrive" {...props} />}
-                              />
-                            </li>
-                          )}
-                          {/* Settings */}
-                          {featuresAccess.settings.isAvailable ? (
-                            <li>
-                              <SidebarLink
-                                labelTKey="navigation:settings"
-                                to={featuresAccess.settings.to}
-                                Icon={(props) => <Icon icon="settings" {...props} />}
-                              />
-                            </li>
-                          ) : null}
-                          {/* My Account */}
+                        ) : null}
+                        {/* Client detail */}
+                        <li>
+                          <SidebarLink
+                            labelTKey="navigation:client_detail"
+                            to="/client-detail"
+                            Icon={(props) => <Icon icon="users" {...props} />}
+                          />
+                        </li>
+                      </ul>
+                    </nav>
+                    {/* Secondary Navigation - Bottom */}
+                    <nav className="p-2 pb-4">
+                      <ul className="flex flex-col gap-2">
+                        {/* Your Data */}
+                        {!isAnalyst(user) && (
                           <li>
                             <SidebarLink
-                              labelTKey="navigation:my_account"
-                              to="/account"
-                              Icon={(props) => <Icon icon="user" {...props} />}
+                              labelTKey="navigation:data"
+                              to="/data"
+                              Icon={(props) => <Icon icon="harddrive" {...props} />}
                             />
                           </li>
-                        </ul>
-                      </nav>
-                      <div className="p-2 pb-4">
-                        <ToggleSidebar />
-                      </div>
-                    </LeftSidebar>
+                        )}
+                        {/* Settings */}
+                        {featuresAccess.settings.isAvailable ? (
+                          <li>
+                            <SidebarLink
+                              labelTKey="navigation:settings"
+                              to={featuresAccess.settings.to}
+                              Icon={(props) => <Icon icon="settings" {...props} />}
+                            />
+                          </li>
+                        ) : null}
+                        {/* My Account */}
+                        <li>
+                          <SidebarLink
+                            labelTKey="navigation:my_account"
+                            to="/account"
+                            Icon={(props) => <Icon icon="user" {...props} />}
+                          />
+                        </li>
+                      </ul>
+                    </nav>
+                  </LeftSidebar>
 
-                    <Outlet />
-                    {featuresAccess.isAutoAssignmentAvailable ? <UnavailableBanner /> : null}
-                  </LeftSidebarSharpFactory.Provider>
+                  <Outlet />
+                  {featuresAccess.isAutoAssignmentAvailable ? <UnavailableBanner /> : null}
                 </div>
               </div>
             </OrganizationObjectTagsContextProvider>

--- a/packages/app-builder/src/routes/_app/_builder/cases/_detail/s.$caseId/old.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/cases/_detail/s.$caseId/old.tsx
@@ -6,7 +6,6 @@ import { SnoozePanel } from '@app-builder/components/CaseManager/SnoozePanel/Sno
 import { CaseDetails } from '@app-builder/components/Cases/CaseDetails';
 import { CaseReviewsModal } from '@app-builder/components/Cases/CaseReviewsModal';
 import { DataModelExplorerProvider } from '@app-builder/components/DataModelExplorer/Provider';
-import { LeftSidebarSharpFactory } from '@app-builder/components/Layout/LeftSidebar';
 import { MY_INBOX_ID } from '@app-builder/constants/inboxes';
 import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
@@ -15,14 +14,11 @@ import { isNotFoundHttpError } from '@app-builder/models';
 import { type CaseReview } from '@app-builder/models/cases';
 import { type DataModelObject } from '@app-builder/models/data-model';
 import { getNextUnassignedCaseFn } from '@app-builder/server-fns/cases';
-import { getPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookie-read.server';
-import { setPreferencesCookie } from '@app-builder/utils/preferences-cookies/preferences-cookies-write';
 import { fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import * as Sentry from '@sentry/react';
 import { ClientOnly, createFileRoute, useRouter } from '@tanstack/react-router';
 import { createServerFn, useServerFn } from '@tanstack/react-start';
-import { getRequest } from '@tanstack/react-start/server';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { match } from 'ts-pattern';
@@ -34,7 +30,6 @@ const scenarioCaseDetailLoader = createServerFn()
   .middleware([authMiddleware, caseDetailMiddleware])
   .inputValidator((input: { params?: Record<string, string> } | undefined) => input)
   .handler(async function scenarioCaseDetailLoader({ context }) {
-    const request = getRequest();
     const { cases: caseRepository, dataModelRepository, aiAssistSettings, user, entitlements } = context.authInfo;
     const { detail: caseDetail, inbox: caseInbox } = context.case;
     const caseId = caseDetail.id;
@@ -85,7 +80,6 @@ const scenarioCaseDetailLoader = createServerFn()
       inboxes: context.inboxes,
       pivots,
       entitlements,
-      isMenuExpanded: getPreferencesCookie(request, 'menuExpd'),
       mostRecentReview: review,
       isKycEnrichmentEnabled: settings.kycEnrichmentSetting.enabled,
     };
@@ -126,7 +120,6 @@ function CaseManagerIndexPage() {
     currentUser,
     currentInbox,
     entitlements,
-    isMenuExpanded,
     mostRecentReview,
     isKycEnrichmentEnabled,
     reports,
@@ -140,15 +133,7 @@ function CaseManagerIndexPage() {
     to: '/ressources/cases/next-unassigned/$caseId',
     params: { caseId: fromUUIDtoSUUID(details.id) },
   }).href;
-  const leftSidebarSharp = LeftSidebarSharpFactory.useSharp();
   const [drawerContentMode, setDrawerContentMode] = useState<'pivot' | 'snooze'>('pivot');
-
-  useEffect(() => {
-    if (isMenuExpanded) {
-      leftSidebarSharp.actions.setExpanded(false);
-      setPreferencesCookie('menuExpd', false);
-    }
-  }, [isMenuExpanded, leftSidebarSharp]);
 
   return (
     <Page.Main>

--- a/packages/app-builder/src/utils/preferences-cookies/config.ts
+++ b/packages/app-builder/src/utils/preferences-cookies/config.ts
@@ -21,13 +21,11 @@ const themeSchema = z.enum(['light', 'dark']);
 export type Theme = z.infer<typeof themeSchema>;
 
 export type PreferencesCookie = {
-  menuExpd: boolean;
   favInbox?: string;
   timezone?: string;
   theme?: Theme;
 };
 export const PreferencesCookieSchema = z.object({
-  menuExpd: z.preprocess((val) => val === 1, z.boolean()),
   favInbox: z.string().optional(),
   timezone: timezoneSchema.optional(),
   theme: themeSchema.optional(),


### PR DESCRIPTION
Redesign sidebar to expand on hover. Expended version doesn't impact the layout anymore.

Specs:
- Open delay: 0ms
- Close delay: 300ms (lets you move outside and come back without the sidebar shrinking)

Removed the the sidebar context which was handling sidebar expansion persistance and control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Left sidebar redesigned to a compact rail that expands on hover for quicker access.
  * Persistent sidebar expansion preference removed; sidebar no longer remembers expanded/collapsed state.
  * Sidebar toggle control removed from the UI.

* **UI Behavior**
  * Navigation item labels and user logo now reveal via hover with smooth delay/transition.
  * Contextual nudges updated to reveal based on hover-driven styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->