### PR TITLE
feat: add a refresh button on the ingestion csv page

### DIFF
--- a/packages/app-builder/src/components/Data/SemanticTables/UploadData/UploadTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/UploadData/UploadTableDrawer.tsx
@@ -1,11 +1,13 @@
 import { ExternalLink } from '@app-builder/components/ExternalLink';
+import { LoadingIcon } from '@app-builder/components/Spinner';
 import { type TableModel } from '@app-builder/models';
 import { useUploadTableQuery } from '@app-builder/queries/data/upload-table';
 import { ingestingDataByCsvDocHref } from '@app-builder/services/documentation-href';
 import { useQueryClient } from '@tanstack/react-query';
 import { type UploadLog } from 'marble-api';
+import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
-import { Tag, Typo } from 'ui-design-system';
+import { Button, Tag, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { generateCsvTemplateLink, PastUploads, UploadForm } from './UploadIngestionComponents';
 
@@ -26,6 +28,12 @@ export function UploadTableDrawer({
 
   const handleUploadSuccess = (_uploadLog: UploadLog) => {
     queryClient.invalidateQueries({ queryKey: ['ingestion', 'upload-logs', tableName] });
+  };
+
+  const handleRefresh = () => {
+    uploadLogsQuery.refetch().then((result) => {
+      if (result.isError) toast.error(t('common:errors.unknown'));
+    });
   };
 
   if (!open) return null;
@@ -78,7 +86,18 @@ export function UploadTableDrawer({
 
               {uploadLogs.length > 0 ? (
                 <div className="flex flex-col gap-v2-sm">
-                  <Typo variant="subtitle2">{t('upload:past_uploads')}</Typo>
+                  <div className="flex items-center justify-between">
+                    <Typo variant="subtitle2">{t('upload:past_uploads')}</Typo>
+                    <Button
+                      variant="secondary"
+                      size="small"
+                      onClick={handleRefresh}
+                      disabled={uploadLogsQuery.isFetching}
+                      aria-label={t('upload:refresh')}
+                    >
+                      <LoadingIcon icon="restart-alt" loading={uploadLogsQuery.isFetching} className="size-4" />
+                    </Button>
+                  </div>
                   <PastUploads uploadLogs={uploadLogs} />
                 </div>
               ) : null}

--- a/packages/app-builder/src/components/Spinner.tsx
+++ b/packages/app-builder/src/components/Spinner.tsx
@@ -10,7 +10,7 @@ interface SpinnerProps {
 export function Spinner({ className }: SpinnerProps) {
   const { t } = useTranslation(['common']);
   return (
-    <span role="status">
+    <span role="status" className="inline-flex items-center justify-center">
       <span
         aria-hidden
         className={clsx(

--- a/packages/app-builder/src/locales/ar/upload.json
+++ b/packages/app-builder/src/locales/ar/upload.json
@@ -9,6 +9,7 @@
   "num_rows_ingested": "عدد السجلات التي تم استيرادها",
   "past_uploads": "عمليات الرفع السابقة",
   "pick_file_cta": "اختر ملفًا",
+  "refresh": "تحديث",
   "results": "النتائج",
   "started_at": "بدأ في",
   "status_failure": "فشل",

--- a/packages/app-builder/src/locales/en/upload.json
+++ b/packages/app-builder/src/locales/en/upload.json
@@ -9,6 +9,7 @@
   "num_rows_ingested": "Number of records ingested",
   "past_uploads": "Past uploads",
   "pick_file_cta": "Pick a file",
+  "refresh": "Refresh",
   "results": "Results",
   "started_at": "Started at",
   "status_failure": "Failed",

--- a/packages/app-builder/src/locales/fr/upload.json
+++ b/packages/app-builder/src/locales/fr/upload.json
@@ -9,6 +9,7 @@
   "num_rows_ingested": "Nombre d'enregistrements importés",
   "past_uploads": "Imports précédents",
   "pick_file_cta": "Sélectionner un fichier",
+  "refresh": "Rafraîchir",
   "results": "Résultats",
   "started_at": "Commencé le",
   "status_failure": "Échec",

--- a/packages/app-builder/src/routes/_app/_builder/upload/$objectType.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/upload/$objectType.tsx
@@ -1,13 +1,16 @@
 import { Page, Paper } from '@app-builder/components';
 import { ExternalLink } from '@app-builder/components/ExternalLink';
+import { LoadingIcon } from '@app-builder/components/Spinner';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
 import { type TableModel } from '@app-builder/models';
+import { useUploadTableQuery } from '@app-builder/queries/data/upload-table';
 import { useUploadIngestionData } from '@app-builder/queries/upload-ingestion-data';
 import { ingestingDataByCsvDocHref } from '@app-builder/services/documentation-href';
 import { isIngestDataAvailable } from '@app-builder/services/feature-access';
 import { formatNumber, useFormatDateTime, useFormatLanguage } from '@app-builder/utils/format';
 import { REQUEST_TIMEOUT } from '@app-builder/utils/http/http-status-codes';
-import { ClientOnly, createFileRoute, redirect, useRouter } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
+import { ClientOnly, createFileRoute, redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import clsx from 'clsx';
@@ -15,6 +18,7 @@ import { type Namespace, type ParseKeys } from 'i18next';
 import { type UploadLog } from 'marble-api';
 import { useCallback, useMemo, useState } from 'react';
 import { useDropzone } from 'react-dropzone-esm';
+import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Button, Modal, Table, useVirtualTable } from 'ui-design-system';
@@ -63,7 +67,7 @@ type ModalContent = {
   error?: string;
 };
 
-const UploadForm = ({ objectType }: { objectType: string }) => {
+const UploadForm = ({ objectType, onSuccess }: { objectType: string; onSuccess?: () => void }) => {
   const { t } = useTranslation(['common', 'upload']);
   const [loading, setLoading] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -71,7 +75,6 @@ const UploadForm = ({ objectType }: { objectType: string }) => {
     message: '',
     success: true,
   });
-  const router = useRouter();
   const uploadIngestionData = useUploadIngestionData(objectType);
 
   const computeModalMessage = useCallback(
@@ -136,7 +139,7 @@ const UploadForm = ({ objectType }: { objectType: string }) => {
         success: true,
         linesProcessed: uploadLog.lines_processed,
       });
-      void router.invalidate();
+      onSuccess?.();
     } catch (error) {
       setIsModalOpen(true);
       computeModalMessage({
@@ -258,7 +261,15 @@ const ResultModal = ({
 
 const columnHelper = createColumnHelper<UploadLog>();
 
-const PastUploads = ({ uploadLogs }: { uploadLogs: UploadLog[] }) => {
+const PastUploads = ({
+  uploadLogs,
+  onRefresh,
+  isFetching,
+}: {
+  uploadLogs: UploadLog[];
+  onRefresh: () => void;
+  isFetching: boolean;
+}) => {
   const { t } = useTranslation(['upload']);
   const language = useFormatLanguage();
   const formatDateTime = useFormatDateTime();
@@ -325,7 +336,18 @@ const PastUploads = ({ uploadLogs }: { uploadLogs: UploadLog[] }) => {
 
   return (
     <Paper.Container className="bg-surface-card mb-10 w-full">
-      <Paper.Title>{t('upload:past_uploads')}</Paper.Title>
+      <div className="flex items-center justify-between">
+        <Paper.Title>{t('upload:past_uploads')}</Paper.Title>
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={onRefresh}
+          disabled={isFetching}
+          aria-label={t('upload:refresh')}
+        >
+          <LoadingIcon icon="restart-alt" loading={isFetching} className="size-4" />
+        </Button>
+      </div>
       <Table.Container {...getContainerProps()} className="max-h-96">
         <Table.Header headerGroups={table.getHeaderGroups()} />
         <Table.Body {...getBodyProps()}>
@@ -363,7 +385,19 @@ const getStatusTKey = (status: string): ParseKeys<['upload']> => {
 
 function Upload() {
   const { t } = useTranslation(['common', 'upload']);
-  const { objectType, table, uploadLogs } = Route.useLoaderData();
+  const { objectType, table, uploadLogs: initialUploadLogs } = Route.useLoaderData();
+  const queryClient = useQueryClient();
+  const { data: uploadLogs = initialUploadLogs, refetch, isFetching } = useUploadTableQuery(objectType, true);
+
+  const handleUploadSuccess = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['ingestion', 'upload-logs', objectType] });
+  }, [queryClient, objectType]);
+
+  const handleRefresh = useCallback(() => {
+    void refetch().then((result) => {
+      if (result.isError) toast.error(t('common:errors.unknown'));
+    });
+  }, [refetch, t]);
 
   return (
     <Page.Main>
@@ -403,9 +437,11 @@ function Upload() {
             </ClientOnly>
           </div>
           <ClientOnly fallback={<Loading />}>
-            <UploadForm objectType={objectType} />
+            <UploadForm objectType={objectType} onSuccess={handleUploadSuccess} />
           </ClientOnly>
-          {uploadLogs.length > 0 ? <PastUploads uploadLogs={uploadLogs} /> : null}
+          {uploadLogs.length > 0 ? (
+            <PastUploads uploadLogs={uploadLogs} onRefresh={handleRefresh} isFetching={isFetching} />
+          ) : null}
         </Page.Content>
       </Page.Container>
     </Page.Main>


### PR DESCRIPTION
I’m tired of refreshing the entire page to check if the ingestion is complete. 
However, refreshing the page quite the panel. 
So, 
I decided to code the refresh button with an animation to provide feedback to the user that the button has been clicked and the query is processing.
I also displayed an error message in case the query failed. 
During the animation, the button is disabled to prevent multiple clicks. 
The button animates for at least one second to create a pleasant animation and complete a full loop of the spinner. 
Additionally, the button has a reverse animation to follow the spinner’s direction.

<img width="1728" height="1026" alt="Capture d’écran 2026-06-16 à 14 58 10" src="https://github.com/user-attachments/assets/7437479b-a5d4-4935-8904-06e16aaeefa8" />
<img width="1535" height="1059" alt="Capture d’écran 2026-06-16 à 16 18 16" src="https://github.com/user-attachments/assets/8552cdde-7aa9-44d3-8996-23dbc2f8afcc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh/restart button to the “Past uploads” section to quickly update the displayed upload logs.
  * Upload logs refresh automatically after a successful CSV ingestion.
* **User Experience**
  * Refresh actions show a spinning indicator while updating and provide an error toast if the refresh fails.
  * Loading animation duration is smoothed to prevent brief flicker.
* **Internationalization**
  * Added “Refresh” translation strings to the upload UI (English, French, and Arabic).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->