### PR TITLE
Allow Timestamp fields in the continuous monitoring mapping

### DIFF
--- a/packages/app-builder/src/components/ContinuousScreening/form/steps/ObjectMapping.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/form/steps/ObjectMapping.tsx
@@ -1,5 +1,9 @@
 import { Callout } from '@app-builder/components/Callout';
 import {
+  DatatypeIcon,
+  DatatypeToPrimitiveType,
+} from '@app-builder/components/Data/SemanticTables/Shared/DatatypeOption';
+import {
   FTM_ENTITIES,
   FTM_ENTITIES_PROPERTIES,
   FtmEntityPropertyKey,
@@ -257,7 +261,8 @@ const ObjectMappingFtmContent = ({
 
                 return (
                   <div key={field.id} className="grid grid-cols-subgrid col-span-full items-center">
-                    <div className="flex items-center px-sm h-10">
+                    <div className="flex items-center px-sm h-10 gap-sm">
+                      <DatatypeIcon dataType={DatatypeToPrimitiveType(field.dataType)} />
                       {mappingConfig.objectType}.{field.name}
                     </div>
                     <div className={cn('p-sm', { 'opacity-50': hasSavedMapping })}>

--- a/packages/app-builder/src/components/ContinuousScreening/form/steps/ObjectMapping.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/form/steps/ObjectMapping.tsx
@@ -248,7 +248,7 @@ const ObjectMappingFtmContent = ({
           </div>
           <div className="grid grid-cols-[auto_40px_1fr] gap-sm p-md">
             {table.fields
-              .filter((f) => f.dataType === 'String')
+              .filter((f) => ['String', 'Timestamp'].includes(f.dataType) && f.name != 'updated_at')
               .map((field) => {
                 const ftmProperty = field.ftmProperty ?? mappingConfig.fieldMapping[field.id] ?? null;
                 const hasSavedMapping = field.ftmProperty !== undefined;

--- a/packages/app-builder/src/components/ContinuousScreening/validation/ObjectMappingSection.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/validation/ObjectMappingSection.tsx
@@ -1,9 +1,14 @@
+import {
+  DatatypeIcon,
+  DatatypeToPrimitiveType,
+} from '@app-builder/components/Data/SemanticTables/Shared/DatatypeOption';
 import { CreateMappingConfig } from '@app-builder/models/continuous-screening';
 import { TableModel } from '@app-builder/models/data-model';
 import { useDataModelQuery } from '@app-builder/queries/data/get-data-model';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, Collapsible } from 'ui-design-system';
+import { Icon } from 'ui-icons';
 import { Spinner } from '../../Spinner';
 import { type EditionValidationPanelBaseProps } from '../EditionValidationPanel';
 
@@ -94,8 +99,11 @@ const TableValidation = ({ table, objectMapping }: { table: TableModel; objectMa
       <div className="flex flex-col gap-sm border border-grey-border rounded-md p-md max-h-50 overflow-y-auto">
         {fieldsAdded.map(({ field, ftmProperty }) => {
           return (
-            <span key={field?.id}>
-              {field?.name} &gt; {ftmProperty}
+            <span key={field?.id} className="flex items-center gap-sm">
+              <DatatypeIcon dataType={DatatypeToPrimitiveType(field?.dataType ?? 'String')} />
+              <span>{field?.name}</span>
+              <Icon icon="arrow-forward" className="size-6 text-purple-primary" />
+              <span>{ftmProperty}</span>
             </span>
           );
         })}

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
@@ -409,7 +409,7 @@ function DateBirthdate() {
   return <DateBirthdateComponent value={value} />;
 }
 
-export function DateBirthdateComponent({ value }: { value: string }) {
+export function DateBirthdateComponent({ value, compact = false }: { value: string; compact?: boolean }) {
   const formatDateTime = useFormatDateTime();
   const language = useFormatLanguage();
   const date = new Date(value);
@@ -417,7 +417,9 @@ export function DateBirthdateComponent({ value }: { value: string }) {
   return (
     <span className="inline-flex items-center gap-xs">
       <span className="text-grey-secondary text-xs">{age}</span>
-      <span className={codeClassName('text-sm')}>{formatDateTime(date, { dateStyle: 'short' })}</span>
+      <span className={codeClassName(`text-sm ${compact ? 'py-0' : ''}`)}>
+        {formatDateTime(date, { dateStyle: 'short' })}
+      </span>
     </span>
   );
 }

--- a/packages/app-builder/src/components/Data/SemanticTables/Shared/DatatypeOption.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Shared/DatatypeOption.tsx
@@ -1,5 +1,6 @@
-import { getDataTypeIcon, PrimitiveTypes } from '@app-builder/models/data-model';
+import { DataType, getDataTypeIcon, PrimitiveTypes } from '@app-builder/models/data-model';
 import { useMemo } from 'react';
+import { match } from 'ts-pattern';
 import { Icon } from 'ui-icons';
 
 const dataTypeOptions: { value: PrimitiveTypes; labelKey: string }[] = [
@@ -25,7 +26,7 @@ export function DatatypeIcon({ dataType }: { dataType: PrimitiveTypes }) {
   const labelKey = dataTypeOptions.find((opt) => opt.value === dataType)?.labelKey;
   return (
     <span className=" text-grey-secondary bg-grey-background rounded p-sm grid place-items-center" title={labelKey}>
-      <Icon icon={getDataTypeIcon(dataType) ?? 'minus'} className="size-4" />
+      <Icon icon={getDataTypeIcon(dataType) ?? 'string'} className="size-4" />
     </span>
   );
 }
@@ -39,4 +40,17 @@ export function useDatatypeOptions() {
       })),
     [],
   );
+}
+
+export function DatatypeToPrimitiveType(dataType: DataType): PrimitiveTypes {
+  return match(dataType)
+    .with('Timestamp', 'Timestamp[]', () => 'Timestamp')
+    .with('String', 'String[]', () => 'String')
+    .with('Float', 'Float[]', () => 'Float')
+    .with('Bool', 'Bool[]', () => 'Bool')
+    .with('Coords', 'Coords[]', () => 'Coords')
+    .with('IpAddress', 'IpAddress[]', () => 'IpAddress')
+    .with('Int', 'Int[]', () => 'Int')
+    .with('DerivedData', 'unknown', () => 'String')
+    .exhaustive() as PrimitiveTypes;
 }

--- a/packages/app-builder/src/components/Data/SemanticTables/Shared/DatatypeOption.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Shared/DatatypeOption.tsx
@@ -51,6 +51,5 @@ export function DatatypeToPrimitiveType(dataType: DataType): PrimitiveTypes {
     .with('Coords', 'Coords[]', () => 'Coords')
     .with('IpAddress', 'IpAddress[]', () => 'IpAddress')
     .with('Int', 'Int[]', () => 'Int')
-    .with('DerivedData', 'unknown', () => 'String')
-    .exhaustive() as PrimitiveTypes;
+    .otherwise(() => 'String') as PrimitiveTypes;
 }

--- a/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
@@ -1,11 +1,16 @@
 import { decisionsI18n } from '@app-builder/components';
-import { DataModelField, TableModel } from '@app-builder/models';
-import { DataType, getDataTypeIcon } from '@app-builder/models/data-model';
+import { DataModelField, SemanticTypeField, TableModel } from '@app-builder/models';
+import { DataType } from '@app-builder/models/data-model';
 import { isScreeningError, type Screening } from '@app-builder/models/screening';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Collapsible } from 'ui-design-system';
-import { Icon } from 'ui-icons';
+import {
+  DateBirthdateComponent,
+  DateDatetimeComponent,
+  StringMainComponent,
+} from '../Data/DataVisualisation/DataField';
+import { DatatypeIcon, DatatypeToPrimitiveType } from '../Data/SemanticTables/Shared/DatatypeOption';
 import { MatchCard } from '../Screenings/MatchCard';
 import { ScreeningErrors } from '../Screenings/ScreeningErrors';
 import { ScreeningStatusTag } from '../Screenings/ScreeningStatusTag';
@@ -46,6 +51,20 @@ export function ScreeningDetail({ screening, table }: { screening: Screening; ta
   );
 }
 
+type SearchInputItem = {
+  value: string;
+  type: DataType;
+  semanticType: SemanticTypeField;
+};
+
+function toSearchInputItem(value: string, field?: DataModelField): SearchInputItem {
+  return {
+    value,
+    type: field?.dataType ?? 'String',
+    semanticType: field?.semanticType ?? 'text',
+  };
+}
+
 const SearchInput = ({
   request,
   fields,
@@ -55,7 +74,7 @@ const SearchInput = ({
 }) => {
   const { t } = useTranslation(decisionsI18n);
 
-  const searchInputList = R.pipe(
+  const searchInputList: SearchInputItem[] = R.pipe(
     R.values(request.queries),
     R.flatMap((query) =>
       R.pipe(
@@ -63,30 +82,28 @@ const SearchInput = ({
         R.flatMap(([ftmProperty, values]) => {
           const field = fields?.find((f) => f.ftmProperty === ftmProperty);
 
-          return values.map((value) => ({ value, type: field?.dataType ?? 'String' }));
+          return values.map((value) => toSearchInputItem(value, field));
         }),
       ),
     ),
   );
 
-  const iconForType = (type: DataType) => {
-    switch (type) {
-      case 'Timestamp':
-        return 'calendar-month';
-    }
-
-    return getDataTypeIcon(type);
-  };
-
   return (
     <div className="flex items-center gap-sm">
       <span>{t('screenings:search_input')}</span>
-      {searchInputList.map(({ value, type }, i) => (
+      {searchInputList.map(({ value, type, semanticType }, i) => (
         <div key={i} className="border-grey-border flex items-center gap-sm rounded-sm border p-sm">
-          <span className="bg-grey-background size-6 rounded-xs p-xs">
-            <Icon icon={iconForType(type) ?? 'string'} className="size-4" />
-          </span>
-          {value}
+          <DatatypeIcon dataType={DatatypeToPrimitiveType(type)} />
+
+          {semanticType === 'date_of_birth' ? (
+            <DateBirthdateComponent value={value} compact />
+          ) : semanticType === 'name' ? (
+            <StringMainComponent value={value} />
+          ) : type === 'Timestamp' ? (
+            <DateDatetimeComponent value={value} />
+          ) : (
+            value
+          )}
         </div>
       ))}
     </div>

--- a/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
@@ -1,15 +1,16 @@
 import { decisionsI18n } from '@app-builder/components';
+import { DataModelField, TableModel } from '@app-builder/models';
+import { DataType, getDataTypeIcon } from '@app-builder/models/data-model';
 import { isScreeningError, type Screening } from '@app-builder/models/screening';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
 import { Collapsible } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-
 import { MatchCard } from '../Screenings/MatchCard';
 import { ScreeningErrors } from '../Screenings/ScreeningErrors';
 import { ScreeningStatusTag } from '../Screenings/ScreeningStatusTag';
 
-export function ScreeningDetail({ screening }: { screening: Screening }) {
+export function ScreeningDetail({ screening, table }: { screening: Screening; table?: TableModel }) {
   const hasError = isScreeningError(screening);
 
   return (
@@ -27,8 +28,8 @@ export function ScreeningDetail({ screening }: { screening: Screening }) {
       <Collapsible.Content>
         <div className="flex flex-col gap-md">
           {hasError ? <ScreeningErrors screening={screening} /> : null}
-          {screening.request ? <SearchInput request={screening.request} /> : null}
-          <div className="flex flex-col gap-sm">
+          {screening.request ? <SearchInput request={screening.request} fields={table?.fields} /> : null}
+          <div className="flex flex-col gap-2">
             {screening.matches.map((match) => (
               <MatchCard
                 readonly
@@ -45,23 +46,47 @@ export function ScreeningDetail({ screening }: { screening: Screening }) {
   );
 }
 
-const SearchInput = ({ request }: { request: NonNullable<Screening['request']> }) => {
+const SearchInput = ({
+  request,
+  fields,
+}: {
+  request: NonNullable<Screening['request']>;
+  fields?: DataModelField[];
+}) => {
   const { t } = useTranslation(decisionsI18n);
+
   const searchInputList = R.pipe(
     R.values(request.queries),
-    R.flatMap((query) => R.values(query.properties)),
-    R.flat(),
+    R.flatMap((query) =>
+      R.pipe(
+        R.entries(query.properties),
+        R.flatMap(([ftmProperty, values]) => {
+          const field = fields?.find((f) => f.ftmProperty === ftmProperty);
+
+          return values.map((value) => ({ value, type: field?.dataType ?? 'String' }));
+        }),
+      ),
+    ),
   );
+
+  const iconForType = (type: DataType) => {
+    switch (type) {
+      case 'Timestamp':
+        return 'calendar-month';
+    }
+
+    return getDataTypeIcon(type);
+  };
 
   return (
     <div className="flex items-center gap-sm">
       <span>{t('screenings:search_input')}</span>
-      {searchInputList.map((input, i) => (
+      {searchInputList.map(({ value, type }, i) => (
         <div key={i} className="border-grey-border flex items-center gap-sm rounded-sm border p-sm">
           <span className="bg-grey-background size-6 rounded-xs p-xs">
-            <Icon icon="string" className="size-4" />
+            <Icon icon={iconForType(type) ?? 'string'} className="size-4" />
           </span>
-          {input}
+          {value}
         </div>
       ))}
     </div>

--- a/packages/app-builder/src/routes/_app/_builder/detection/decisions/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/decisions/$decisionId.tsx
@@ -174,7 +174,8 @@ export const Route = createFileRoute('/_app/_builder/detection/decisions/$decisi
 });
 
 function DecisionPage() {
-  const { decision, pivots, pivotObjects, scenarioRules, screening, isIterationArchived } = Route.useLoaderData();
+  const { decision, pivots, pivotObjects, scenarioRules, screening, isIterationArchived, dataModel } =
+    Route.useLoaderData();
 
   const pivotValues = R.pipe(
     decision.pivotValues,
@@ -192,6 +193,7 @@ function DecisionPage() {
     R.filter(R.isNonNullish),
   );
 
+  const table = dataModel.find((table) => table.name == decision.triggerObjectType);
   const existingPivotDefinition = pivots.some((pivot) => pivot.baseTable === decision.triggerObjectType);
 
   return (
@@ -214,7 +216,7 @@ function DecisionPage() {
                   isIterationArchived={isIterationArchived}
                 />
                 {screening.map((s) => (
-                  <ScreeningDetail key={s.id} screening={s} />
+                  <ScreeningDetail key={s.id} screening={s} table={table} />
                 ))}
               </div>
               <div className="flex flex-col gap-md lg:gap-xl shrink-0">

--- a/packages/ui-design-system/.storybook/main.ts
+++ b/packages/ui-design-system/.storybook/main.ts
@@ -1,9 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
-  docs: {
-    autodocs: 'tag',
-  },
   core: {
     disableTelemetry: true,
   },

--- a/packages/ui-design-system/src/Radio/Radio.stories.tsx
+++ b/packages/ui-design-system/src/Radio/Radio.stories.tsx
@@ -12,7 +12,6 @@ const OPTIONS = ['option1', 'option2', 'option3'] as const;
 
 const Story: Meta<Args> = {
   title: 'Radio',
-  component: Radio.Root,
   args: {
     size: 'regular',
     disabledItems: [],

--- a/packages/ui-design-system/src/Select/Select.stories.tsx
+++ b/packages/ui-design-system/src/Select/Select.stories.tsx
@@ -5,7 +5,6 @@ import { SelectV2, type SelectV2Props } from './Select';
 type StoryProps = Pick<SelectV2Props<string>, 'disabled' | 'placeholder'>;
 
 const Story: Meta<StoryProps> = {
-  component: SelectV2,
   title: 'SelectV2',
   args: {
     placeholder: 'Select a value...',

--- a/packages/ui-design-system/src/ThresholdRange/ThresholdRange.tsx
+++ b/packages/ui-design-system/src/ThresholdRange/ThresholdRange.tsx
@@ -28,6 +28,8 @@ export type ThresholdRangeProps = {
 const RAIL_HEIGHT = 4;
 const INACTIVE_DOT_SIZE = 8;
 const ACTIVE_DOT_SIZE = 16;
+const LABEL_GAP = 4;
+const LABEL_TOP_OFFSET = RAIL_HEIGHT / 2 + ACTIVE_DOT_SIZE / 2 + LABEL_GAP;
 
 function getSortedSteps(values: ThresholdRangeStep[]) {
   return [...values].sort((a, b) => a.value - b.value);
@@ -239,116 +241,120 @@ export function ThresholdRange({
           onKeyDown={handleKeyDown}
           onBlur={onBlur}
         >
-          <div className="relative px-md pb-sm">
-            <div
-              ref={railRef}
-              data-testid="threshold-range-rail"
-              className="bg-grey-border relative w-full rounded-full before:absolute before:inset-x-0 before:-top-5 before:-bottom-5 before:content-['']"
-              style={{ height: `${RAIL_HEIGHT}px` }}
-              onClick={(event) => {
-                if (hasDraggedRef.current) {
-                  hasDraggedRef.current = false;
-                  return;
-                }
-                selectNearestStep(event.clientX, event.currentTarget);
-              }}
-              onPointerMove={handleRailPointerMove}
-              onPointerUp={endThumbDrag}
-              onPointerCancel={endThumbDrag}
-            >
-              {segments.map((segment) => {
-                const start = (segment.startValue / normalizedMax) * 100;
-                const end = (segment.endValue / normalizedMax) * 100;
-                const width = end - start;
-                const isCompleted = activeIndex >= segment.completedStepIndex;
-                const background = isCompleted
-                  ? `linear-gradient(90deg, ${segment.fromColor} 0%, ${segment.toColor} 100%)`
-                  : undefined;
+          <div className="px-md pb-sm">
+            <div className="relative w-full">
+              <div
+                ref={railRef}
+                data-testid="threshold-range-rail"
+                className="bg-grey-border relative w-full rounded-full before:absolute before:inset-x-0 before:-top-5 before:-bottom-5 before:content-['']"
+                style={{ height: `${RAIL_HEIGHT}px` }}
+                onClick={(event) => {
+                  if (hasDraggedRef.current) {
+                    hasDraggedRef.current = false;
+                    return;
+                  }
+                  selectNearestStep(event.clientX, event.currentTarget);
+                }}
+                onPointerMove={handleRailPointerMove}
+                onPointerUp={endThumbDrag}
+                onPointerCancel={endThumbDrag}
+              >
+                {segments.map((segment) => {
+                  const start = (segment.startValue / normalizedMax) * 100;
+                  const end = (segment.endValue / normalizedMax) * 100;
+                  const width = end - start;
+                  const isCompleted = activeIndex >= segment.completedStepIndex;
+                  const background = isCompleted
+                    ? `linear-gradient(90deg, ${segment.fromColor} 0%, ${segment.toColor} 100%)`
+                    : undefined;
 
-                return (
-                  <div
-                    key={segment.key}
-                    aria-hidden="true"
-                    className={cn('absolute rounded-full', isCompleted ? '' : 'bg-grey-border')}
-                    style={{
-                      left: `${start}%`,
-                      width: `${width}%`,
-                      height: `${RAIL_HEIGHT}px`,
-                      background,
-                    }}
-                  />
-                );
-              })}
+                  return (
+                    <div
+                      key={segment.key}
+                      aria-hidden="true"
+                      className={cn('absolute rounded-full', isCompleted ? '' : 'bg-grey-border')}
+                      style={{
+                        left: `${start}%`,
+                        width: `${width}%`,
+                        height: `${RAIL_HEIGHT}px`,
+                        background,
+                      }}
+                    />
+                  );
+                })}
 
-              {steps.map((step, index) => {
-                const position = (step.value / normalizedMax) * 100;
-                const isActive = index === activeIndex;
-                const isCompleted = activeIndex >= index;
-                const size = isActive ? ACTIVE_DOT_SIZE : INACTIVE_DOT_SIZE;
-                const backgroundColor = isCompleted ? step.color : 'var(--color-grey-border)';
+                {steps.map((step, index) => {
+                  const position = (step.value / normalizedMax) * 100;
+                  const isActive = index === activeIndex;
+                  const isCompleted = activeIndex >= index;
+                  const size = isActive ? ACTIVE_DOT_SIZE : INACTIVE_DOT_SIZE;
+                  const backgroundColor = isCompleted ? step.color : 'var(--color-grey-border)';
 
-                return (
-                  <button
-                    key={step.value}
-                    type="button"
-                    tabIndex={-1}
-                    aria-label={`${title} ${step.value.toString()}`}
-                    disabled={disabled}
-                    data-testid={isActive ? 'threshold-range-thumb-active' : undefined}
-                    className={cn(
-                      'absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border-0 p-0 touch-none',
-                      disabled
-                        ? 'cursor-not-allowed'
-                        : isActive
-                          ? isDragging
-                            ? 'cursor-grabbing'
-                            : 'cursor-grab'
-                          : 'cursor-pointer',
-                    )}
-                    style={{
-                      left: `${position}%`,
-                      width: `${size}px`,
-                      height: `${size}px`,
-                      backgroundColor,
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (hasDraggedRef.current) {
-                        hasDraggedRef.current = false;
-                        return;
-                      }
-                      selectStepAtIndex(index);
-                    }}
-                    onPointerDown={isActive ? handleActiveThumbPointerDown : undefined}
-                  />
-                );
-              })}
+                  return (
+                    <button
+                      key={step.value}
+                      type="button"
+                      tabIndex={-1}
+                      aria-label={`${title} ${step.value.toString()}`}
+                      disabled={disabled}
+                      data-testid={isActive ? 'threshold-range-thumb-active' : undefined}
+                      className={cn(
+                        'absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border-0 p-0 touch-none',
+                        disabled
+                          ? 'cursor-not-allowed'
+                          : isActive
+                            ? isDragging
+                              ? 'cursor-grabbing'
+                              : 'cursor-grab'
+                            : 'cursor-pointer',
+                      )}
+                      style={{
+                        left: `${position}%`,
+                        width: `${size}px`,
+                        height: `${size}px`,
+                        backgroundColor,
+                      }}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (hasDraggedRef.current) {
+                          hasDraggedRef.current = false;
+                          return;
+                        }
+                        selectStepAtIndex(index);
+                      }}
+                      onPointerDown={isActive ? handleActiveThumbPointerDown : undefined}
+                    />
+                  );
+                })}
+              </div>
+
+              {activeStep ? (
+                <div
+                  className="absolute text-s leading-none font-medium"
+                  style={{
+                    top: `${LABEL_TOP_OFFSET}px`,
+                    left: `${(activeStep.value / normalizedMax) * 100}%`,
+                    transform: 'translateX(-50%)',
+                    color: activeStep.color,
+                  }}
+                >
+                  {activeStep.value.toString()}
+                </div>
+              ) : null}
+
+              {activeStep?.value !== lastStep.value ? (
+                <div
+                  className="text-grey-placeholder absolute text-s leading-none font-medium"
+                  style={{
+                    top: `${LABEL_TOP_OFFSET}px`,
+                    left: `${(lastStep.value / normalizedMax) * 100}%`,
+                    transform: 'translateX(-50%)',
+                  }}
+                >
+                  {lastStep.value.toString()}
+                </div>
+              ) : null}
             </div>
-
-            {activeStep ? (
-              <div
-                className="absolute top-full text-s leading-none font-medium"
-                style={{
-                  left: `${(activeStep.value / normalizedMax) * 100}%`,
-                  transform: 'translateX(-50%)',
-                  color: activeStep.color,
-                }}
-              >
-                {activeStep.value.toString()}
-              </div>
-            ) : null}
-
-            {activeStep?.value !== lastStep.value ? (
-              <div
-                className="text-grey-placeholder absolute top-full text-s leading-none font-medium"
-                style={{
-                  left: `${(lastStep.value / normalizedMax) * 100}%`,
-                  transform: 'translateX(-50%)',
-                }}
-              >
-                {lastStep.value.toString()}
-              </div>
-            ) : null}
           </div>
         </div>
 

--- a/packages/ui-design-system/src/ThresholdRange/ThresholdRange.tsx
+++ b/packages/ui-design-system/src/ThresholdRange/ThresholdRange.tsx
@@ -330,7 +330,7 @@ export function ThresholdRange({
 
               {activeStep ? (
                 <div
-                  className="absolute text-s leading-none font-medium"
+                  className="absolute text-s leading-none font-medium pointer-events-none"
                   style={{
                     top: `${LABEL_TOP_OFFSET}px`,
                     left: `${(activeStep.value / normalizedMax) * 100}%`,
@@ -344,7 +344,7 @@ export function ThresholdRange({
 
               {activeStep?.value !== lastStep.value ? (
                 <div
-                  className="text-grey-placeholder absolute text-s leading-none font-medium"
+                  className="text-grey-placeholder absolute text-s leading-none font-medium pointer-events-none"
                   style={{
                     top: `${LABEL_TOP_OFFSET}px`,
                     left: `${(lastStep.value / normalizedMax) * 100}%`,


### PR DESCRIPTION
Requires https://github.com/checkmarble/marble-backend/pull/1809.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added datatype indicators to field-mapping and validation views to make each field’s type clearer.
  * Screening details now render field values with more context-aware formatting (e.g., dates/names) using table field metadata.
  * Date display components now support a compact layout option.

* **Bug Fixes**
  * Improved field lists to include supported string/timestamp fields while excluding the `updated_at` field.
  * Adjusted range slider label placement for cleaner, more readable presentation.

* **Chores**
  * Updated Storybook configuration for design system components (storybook autodocs/meta cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->