### PR TITLE
fix display of data fields in case manager

### DIFF
--- a/packages/app-builder/src/components/CaseManagerV2/ClientsPage.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/ClientsPage.tsx
@@ -87,7 +87,11 @@ export function CaseManagerClientsPage({
         </div>
         <Card className="flex flex-col gap-sm text-small">
           <div>
-            <DataFields object={pivotObject.pivotObjectData as DataModelObject} table={pivotObject.pivotObjectName} />
+            <DataFields
+              object={pivotObject.pivotObjectData as DataModelObject}
+              table={pivotObject.pivotObjectName}
+              options={{ layout: '2-columns' }}
+            />
             {currentTable ? (
               <DataModelExplorerProvider>
                 <PivotNavigationOptions

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
@@ -118,7 +118,7 @@ export function DataField({ field, value, linkedTo, metaData, currency }: DataFi
   return (
     <DataFieldProvider value={contextValue}>
       <div className="col-span-2 grid grid-cols-subgrid items-start">
-        <label htmlFor={field?.id} className="text-grey-secondary">
+        <label htmlFor={field?.id} className="text-grey-secondary truncate" title={field?.name}>
           {field?.name}
         </label>
         <div id={field?.id}>

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
@@ -35,9 +35,12 @@ export type DataFieldsProps = (
   };
 };
 
+const MAX_VISIBLE_FIELDS = 20;
+
 export function DataFields({ table, object, preset, customFields, className, options }: DataFieldsProps) {
   const dataModel = useDataModel();
   const [showHidden, setShowHidden] = useState(false);
+  const [showAllFields, setShowAllFields] = useState(false);
   const tableModel = dataModel.find((tbl) => tbl.name === table);
   const { t } = useTranslation(['data']);
 
@@ -99,47 +102,62 @@ export function DataFields({ table, object, preset, customFields, className, opt
     return metadataByField;
   }, [object.data]);
 
+  const visibleFields = useMemo(() => {
+    if (!Array.isArray(fields)) return [];
+    return fields.filter((field): field is DataModelField => Boolean(field && (!field.hidden || showHidden)));
+  }, [fields, showHidden]);
+
+  const hasMoreFields = visibleFields.length > MAX_VISIBLE_FIELDS;
+  const displayedFields = showAllFields || !hasMoreFields ? visibleFields : visibleFields.slice(0, MAX_VISIBLE_FIELDS);
+
   return (
     <DataVisualisationProvider value={contextValue}>
       {options?.showHeader ? <DataFieldsHeader object={object} /> : null}
-      <div
-        className={cn(
-          'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-4 gap-y-2 break-all',
-          options?.layout === '2-columns' && 'grid-cols-[repeat(2,max-content_minmax(0,1fr))]',
-          options?.layout === '3-columns' && 'grid-cols-[repeat(3,max-content_minmax(0,1fr))]',
-          (options?.layout === '1-column' || !options?.layout) && 'grid-cols-[max-content_minmax(0,1fr)]',
-          className,
-        )}
-      >
-        {Array.isArray(fields)
-          ? fields.map((field) => {
-              const linkedTo = field ? links?.[field.name] : undefined;
-              const metaDataValue =
-                field && hasMetadataContent(metaData?.[field?.name]) ? metaData?.[field?.name] : undefined;
-              const fieldCurrency = resolveFieldCurrency(field, tableModel?.fields, object.data);
-              const isHidden = field?.hidden && !showHidden;
-              if (isHidden) return null;
-              return field ? (
-                <DataField
-                  key={field?.id}
-                  field={field}
-                  value={formatValue(object.data?.[field.name])}
-                  linkedTo={linkedTo}
-                  metaData={metaDataValue}
-                  currency={fieldCurrency}
-                />
-              ) : null;
-            })
-          : null}
-        {fields.some((field) => field?.hidden) && options?.withOptionalHidden ? (
-          <div className="flex justify-start col-span-full">
-            <Button variant="secondary" size="small" onClick={() => setShowHidden(!showHidden)}>
-              {showHidden
-                ? t('data:hide_hidden_fields')
-                : t('data:show_hidden_fields', { count: fields.filter((field) => field?.hidden).length })}
-            </Button>
-          </div>
-        ) : null}
+      <div className="@container">
+        <div
+          className={cn(
+            'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-md gap-y-sm break-all',
+            'grid-cols-[minmax(0,20ch)_minmax(0,1fr)]',
+            options?.layout === '2-columns' && '@[700px]:grid-cols-[repeat(2,minmax(0,20ch)_minmax(0,1fr))]',
+            options?.layout === '3-columns' && '@[700px]:grid-cols-[repeat(3,minmax(0,20ch)_minmax(0,1fr))]',
+            className,
+          )}
+        >
+          {displayedFields.map((field) => {
+            const linkedTo = links?.[field.name];
+            const metaDataValue = hasMetadataContent(metaData?.[field.name]) ? metaData?.[field.name] : undefined;
+            const fieldCurrency = resolveFieldCurrency(field, tableModel?.fields, object.data);
+
+            return (
+              <DataField
+                key={field.id}
+                field={field}
+                value={formatValue(object.data?.[field.name])}
+                linkedTo={linkedTo}
+                metaData={metaDataValue}
+                currency={fieldCurrency}
+              />
+            );
+          })}
+          {hasMoreFields ? (
+            <div className="col-span-full flex justify-start">
+              <Button variant="secondary" size="small" onClick={() => setShowAllFields(!showAllFields)}>
+                {showAllFields
+                  ? t('data:fields_show_less')
+                  : t('data:fields_show_more', { count: visibleFields.length - MAX_VISIBLE_FIELDS })}
+              </Button>
+            </div>
+          ) : null}
+          {fields.some((field) => field?.hidden) && options?.withOptionalHidden ? (
+            <div className="col-span-full flex justify-start">
+              <Button variant="secondary" size="small" onClick={() => setShowHidden(!showHidden)}>
+                {showHidden
+                  ? t('data:hide_hidden_fields')
+                  : t('data:show_hidden_fields', { count: fields.filter((field) => field?.hidden).length })}
+              </Button>
+            </div>
+          ) : null}
+        </div>
       </div>
     </DataVisualisationProvider>
   );

--- a/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
@@ -1,10 +1,9 @@
 import { DataModelObjectValue, type TableModel } from '@app-builder/models';
 import { parseUnknownData } from '@app-builder/utils/parse';
-import clsx from 'clsx';
 import { Fragment, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
-import { Collapsible } from 'ui-design-system';
+import { Card, Collapsible, cn } from 'ui-design-system';
 import { DataFields } from '../Data/DataVisualisation/DataFields';
 import { FormatData } from '../FormatData';
 import { decisionsI18n } from './decisions-i18n';
@@ -56,12 +55,7 @@ export function CaseDetailTriggerObject({
   );
 
   return (
-    <div
-      className={clsx(
-        'text-s text-grey-primary border-grey-border grid grid-cols-[max-content_1fr] gap-md gap-x-4 break-all rounded-lg border bg-surface-card p-md',
-        className,
-      )}
-    >
+    <Card className={className}>
       {dataModelTable?.name ? (
         <DataFields
           // use the fancy display if possible
@@ -70,27 +64,29 @@ export function CaseDetailTriggerObject({
           options={{ hideLinks: true, withOptionalHidden: true }}
         />
       ) : (
-        parsedTriggerObject.map(([property, data]) => {
-          const fieldType = dataModelTable?.fields?.find((f) => f.name === property)?.dataType;
-          return (
-            <Fragment key={property}>
-              <span className="font-semibold">{property}</span>
-              <div className="inline-flex items-center gap-sm">
-                {links[property] && data.value ? (
-                  <button
-                    className="text-purple-primary group flex items-center gap-xs text-left"
-                    onClick={() => onLinkClicked(links[property] as string, data.value as string)}
-                  >
+        <div className={cn('grid grid-cols-[max-content_1fr] gap-md ', className)}>
+          {parsedTriggerObject.map(([property, data]) => {
+            const fieldType = dataModelTable?.fields?.find((f) => f.name === property)?.dataType;
+            return (
+              <Fragment key={property}>
+                <span className="font-semibold">{property}</span>
+                <div className="inline-flex items-center gap-sm">
+                  {links[property] && data.value ? (
+                    <button
+                      className="text-purple-primary group flex items-center gap-xs text-left"
+                      onClick={() => onLinkClicked(links[property] as string, data.value as string)}
+                    >
+                      <FormatData type={fieldType} data={data} mapHeight={200} />
+                    </button>
+                  ) : (
                     <FormatData type={fieldType} data={data} mapHeight={200} />
-                  </button>
-                ) : (
-                  <FormatData type={fieldType} data={data} mapHeight={200} />
-                )}
-              </div>
-            </Fragment>
-          );
-        })
+                  )}
+                </div>
+              </Fragment>
+            );
+          })}
+        </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/TriggerObjectDetail.tsx
@@ -55,13 +55,14 @@ export function CaseDetailTriggerObject({
   );
 
   return (
-    <Card className={className}>
+    <Card>
       {dataModelTable?.name ? (
         <DataFields
           // use the fancy display if possible
           table={dataModelTable.name}
           object={{ data: triggerObject }}
           options={{ hideLinks: true, withOptionalHidden: true }}
+          className={className}
         />
       ) : (
         <div className={cn('grid grid-cols-[max-content_1fr] gap-md ', className)}>

--- a/packages/app-builder/src/locales/ar/data.json
+++ b/packages/app-builder/src/locales/ar/data.json
@@ -134,6 +134,8 @@
   "field_name": "الاسم",
   "field_required": "إلزامي",
   "field_type": "النوع",
+  "fields_show_less": "عرض أقل",
+  "fields_show_more": "عرض المزيد (+{{count}})",
   "foreign_key": "مفتاح خارجي",
   "hide_hidden_fields": "إخفاء الحقول المخفية",
   "import_org.button": "استيراد البيانات",

--- a/packages/app-builder/src/locales/en/data.json
+++ b/packages/app-builder/src/locales/en/data.json
@@ -134,6 +134,8 @@
   "field_name": "Name",
   "field_required": "Required",
   "field_type": "Type",
+  "fields_show_less": "Show less",
+  "fields_show_more": "Show more (+{{count}})",
   "foreign_key": "Foreign Key",
   "hide_hidden_fields": "Hide the hidden fields",
   "import_org.button": "Import data",

--- a/packages/app-builder/src/locales/fr/data.json
+++ b/packages/app-builder/src/locales/fr/data.json
@@ -134,6 +134,8 @@
   "field_name": "Nom",
   "field_required": "Requis",
   "field_type": "Type",
+  "fields_show_less": "Voir moins",
+  "fields_show_more": "Voir plus (+{{count}})",
   "foreign_key": "Clé étrangère",
   "hide_hidden_fields": "Masquer les champs cachés",
   "import_org.button": "Importer les données",

--- a/packages/app-builder/src/routes/_app/_builder/cases/_detail.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/cases/_detail.tsx
@@ -39,6 +39,8 @@ export const Route = createFileRoute('/_app/_builder/cases/_detail')({
       ({ isLast, data }: BreadCrumbProps<Awaited<ReturnType<typeof caseDetailLayoutLoader>>>) => {
         const caseDetail = data.caseDetail;
 
+        console.log(caseDetail);
+
         return (
           <BreadCrumbLink to="/cases/$caseId" params={{ caseId: fromUUIDtoSUUID(caseDetail.id) }} isLast={isLast}>
             <span className="line-clamp-2 text-start">{caseDetail.name}</span>

--- a/packages/app-builder/src/routes/_app/_builder/cases/_detail.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/cases/_detail.tsx
@@ -39,8 +39,6 @@ export const Route = createFileRoute('/_app/_builder/cases/_detail')({
       ({ isLast, data }: BreadCrumbProps<Awaited<ReturnType<typeof caseDetailLayoutLoader>>>) => {
         const caseDetail = data.caseDetail;
 
-        console.log(caseDetail);
-
         return (
           <BreadCrumbLink to="/cases/$caseId" params={{ caseId: fromUUIDtoSUUID(caseDetail.id) }} isLast={isLast}>
             <span className="line-clamp-2 text-start">{caseDetail.name}</span>

--- a/packages/tests/e2e/inboxes.spec.ts
+++ b/packages/tests/e2e/inboxes.spec.ts
@@ -86,9 +86,9 @@ test('Delete an inbox', async ({ page }) => {
   const deleteDialog = page.getByRole('dialog');
   await deleteDialog.waitFor();
   await deleteDialog.getByRole('button', { name: 'Delete' }).click();
-  await waitForHydration(page);
-
-  await page.goto('/settings/inboxes');
+  // Deleting redirects back to the list once the server-side delete commits.
+  // Wait for that redirect instead of racing it with a manual goto.
+  await page.waitForURL(/\/settings\/inboxes$/);
   await waitForHydration(page);
   await expect(page.locator('body')).not.toContainText(inboxName);
 });


### PR DESCRIPTION
- truncate long labels (add title to reveal complete name)
- see more button if there is more than 20 fields
- fix grid in grid in trigger object details (and use card component)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "show more/less" toggle for data field lists exceeding 20 fields.
  * Field name labels now display tooltips on hover for better usability.

* **Improvements**
  * Enhanced data field layout handling with optimized grid styling.
  * Improved UI consistency with updated card component styling.

* **Localization**
  * Added translations for new field display controls in English, French, and Arabic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->