### PR TITLE
fix: old case manager page columns broken

### DIFF
--- a/packages/app-builder/src/routes/_app/_builder/cases/_detail/s.$caseId/old.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/cases/_detail/s.$caseId/old.tsx
@@ -172,7 +172,7 @@ function CaseManagerIndexPage() {
           </a>
         </div>
       </Page.Header>
-      <Page.Container className="text-default relative h-full flex-row p-0 lg:p-0">
+      <div className="relative text-default h-full flex flex-row p-0 lg:p-0 z-0">
         <CaseDetails
           key={details.id}
           caseDetail={details}
@@ -213,7 +213,7 @@ function CaseManagerIndexPage() {
               .exhaustive()}
           </CaseManagerDrawer>
         </DataModelExplorerProvider>
-      </Page.Container>
+      </div>
     </Page.Main>
   );
 }


### PR DESCRIPTION
Case manager 2 columns layout was broken and drawer was displayed under the main content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the case details page layout by replacing the previous container wrapper with a plain wrapper element using equivalent Tailwind styling, ensuring the surrounding panels render with the expected structure and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->