### PR TITLE
feat: redesign panel structure components MAR-1999

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "marble-front",

--- a/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
+++ b/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
@@ -12,6 +12,7 @@ import {
   RulesExecutionsContainer,
 } from '@app-builder/components/Decisions/RulesExecutions/RulesExecutions';
 import { CaseDetailTriggerObject } from '@app-builder/components/Decisions/TriggerObjectDetail';
+import { Panel } from '@app-builder/components/Panel';
 import { ScoreModifier } from '@app-builder/components/Scenario/Rules/ScoreModifier';
 import { Spinner } from '@app-builder/components/Spinner';
 import { DataModel } from '@app-builder/models';
@@ -22,7 +23,6 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, Switch } from 'ui-design-system';
-import { Icon } from 'ui-icons';
 
 type DecisionPanelProps = {
   decision: DetailedCaseDecision;
@@ -59,21 +59,15 @@ export function DecisionPanel({ decision, dataModel, onClose, onScreeningSelect 
   }, [detailDecisionQuery.data, showHitOnly]);
 
   return (
-    <div className="flex flex-col gap-lg p-lg">
+    <Panel.Content>
       {/* Header */}
-      <div className="flex items-center gap-md">
-        <Button variant="secondary" mode="icon" size="small" onClick={() => onClose()}>
-          <Icon icon="cross" className="size-5" />
-        </Button>
+      <Panel.Header>
         <div className="flex flex-1 flex-col gap-xs">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-sm">
               <AlertOutcomeIcon outcome={decision.outcome} reviewStatus={decision.reviewStatus} showLabel={false} />
-              <span className="text-l text-grey-primary font-semibold">{decision.scenario.name}</span>
-              <ScoreModifier
-                score={decision.score}
-                className="border-grey-placeholder text-grey-placeholder border bg-transparent"
-              />
+              <span className="text-grey-primary font-semibold">{decision.scenario.name}</span>
+              <ScoreModifier score={decision.score} />
             </div>
             {isPendingReview ? (
               <ReviewDecisionModal decisionId={decision.id} screening={screenings[0]}>
@@ -89,114 +83,116 @@ export function DecisionPanel({ decision, dataModel, onClose, onScreeningSelect 
             </span>
           </CopyToClipboardButton>
         </div>
-      </div>
+      </Panel.Header>
 
-      {/* Screenings Rules */}
-      {screenings.length > 0 ? (
-        <div className="flex flex-col gap-sm">
-          <span className="text-m text-grey-primary font-medium">{t('cases:decisions.screenings_rules')}</span>
+      <div className="flex flex-col gap-md">
+        {/* Screenings Rules */}
+        {screenings.length > 0 ? (
           <div className="flex flex-col gap-sm">
-            {screenings.map((screening) => (
-              <div key={screening.id} className="flex items-center gap-sm">
-                <span className="text-grey-placeholder text-xs font-medium">&bull;</span>
-                <span className="text-grey-placeholder text-xs font-medium">{screening.name}</span>
-                <div
-                  role="button"
-                  tabIndex={0}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onScreeningSelect(screening.id);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
+            <span className="text-m text-grey-primary font-medium">{t('cases:decisions.screenings_rules')}</span>
+            <div className="flex flex-col gap-sm">
+              {screenings.map((screening) => (
+                <div key={screening.id} className="flex items-center gap-sm">
+                  <span className="text-grey-placeholder text-xs font-medium">&bull;</span>
+                  <span className="text-grey-placeholder text-xs font-medium">{screening.name}</span>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
                       e.stopPropagation();
                       onScreeningSelect(screening.id);
-                    }
-                  }}
-                >
-                  <ScreeningStatusBadge
-                    status={screening.status}
-                    decisionId={decision.id}
-                    screeningId={screening.id}
-                    nbHits={screening.count}
-                  />
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.stopPropagation();
+                        onScreeningSelect(screening.id);
+                      }
+                    }}
+                  >
+                    <ScreeningStatusBadge
+                      status={screening.status}
+                      decisionId={decision.id}
+                      screeningId={screening.id}
+                      nbHits={screening.count}
+                    />
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      {/* Rules */}
-      {match(detailDecisionQuery)
-        .with({ isPending: true }, () => (
-          <div className="flex items-center justify-center p-md">
-            <Spinner className="size-8" />
-          </div>
-        ))
-        .with({ isError: true }, () => (
-          <div className="text-grey-secondary p-md text-center text-xs">{t('common:global_error')}</div>
-        ))
-        .otherwise(() => {
-          const allRules = detailDecisionQuery.data?.decision.rules ?? [];
-          if (allRules.length === 0) return null;
-
-          return (
-            <div className="flex flex-col gap-sm">
-              <div className="flex items-center justify-between">
-                <span className="text-m text-grey-primary font-medium">{t('cases:decisions.rules')}</span>
-                <div className="flex items-center gap-sm">
-                  <label htmlFor="showHitOnly" className="text-grey-primary cursor-pointer select-none text-xs">
-                    {t('cases:case_detail.rules_execution.show_hit_only')}
-                  </label>
-                  <Switch id="showHitOnly" checked={showHitOnly} onCheckedChange={setShowHitOnly} />
-                </div>
-              </div>
-              {filteredRuleExecutions.length > 0 ? (
-                <RulesExecutionsContainer className="h-fit">
-                  {filteredRuleExecutions.map((ruleExecution) => (
-                    <RuleExecutionCollapsible key={ruleExecution.ruleId}>
-                      <RuleExecutionTitle ruleExecution={ruleExecution} />
-                      <RuleExecutionContent>
-                        <RuleExecutionDescription description={ruleExecution.description} />
-                        {scenarioIterationRules.data ? (
-                          <RuleExecutionDetail
-                            scenarioId={detailDecisionQuery.data?.decision.scenario.id ?? ''}
-                            ruleExecution={ruleExecution}
-                            rules={scenarioIterationRules.data.rules}
-                            isIterationArchived={scenarioIterationRules.data.archived}
-                          />
-                        ) : null}
-                      </RuleExecutionContent>
-                    </RuleExecutionCollapsible>
-                  ))}
-                </RulesExecutionsContainer>
-              ) : null}
+              ))}
             </div>
-          );
-        })}
+          </div>
+        ) : null}
 
-      {/* Trigger Object */}
-      {detailDecisionQuery.data ? (
-        <div className="flex flex-col gap-sm">
-          <span className="text-m text-grey-primary font-medium">{t('cases:case_detail.trigger_object')}</span>
-          <CaseDetailTriggerObject
-            className="max-h-[50dvh] overflow-auto"
-            dataModel={dataModel}
-            triggerObject={detailDecisionQuery.data.decision.triggerObject}
-            triggerObjectType={detailDecisionQuery.data.decision.triggerObjectType}
-            onLinkClicked={(tableName, objectId) => setObjectLink({ tableName, objectId })}
-          />
-          {objectLink ? (
-            <IngestedObjectDetailModal
+        {/* Rules */}
+        {match(detailDecisionQuery)
+          .with({ isPending: true }, () => (
+            <div className="flex items-center justify-center p-md">
+              <Spinner className="size-8" />
+            </div>
+          ))
+          .with({ isError: true }, () => (
+            <div className="text-grey-secondary p-md text-center text-xs">{t('common:global_error')}</div>
+          ))
+          .otherwise(() => {
+            const allRules = detailDecisionQuery.data?.decision.rules ?? [];
+            if (allRules.length === 0) return null;
+
+            return (
+              <div className="flex flex-col gap-sm">
+                <div className="flex items-center justify-between">
+                  <span className="text-m text-grey-primary font-medium">{t('cases:decisions.rules')}</span>
+                  <div className="flex items-center gap-sm">
+                    <label htmlFor="showHitOnly" className="text-grey-primary cursor-pointer select-none text-xs">
+                      {t('cases:case_detail.rules_execution.show_hit_only')}
+                    </label>
+                    <Switch id="showHitOnly" checked={showHitOnly} onCheckedChange={setShowHitOnly} />
+                  </div>
+                </div>
+                {filteredRuleExecutions.length > 0 ? (
+                  <RulesExecutionsContainer className="h-fit">
+                    {filteredRuleExecutions.map((ruleExecution) => (
+                      <RuleExecutionCollapsible key={ruleExecution.ruleId}>
+                        <RuleExecutionTitle ruleExecution={ruleExecution} />
+                        <RuleExecutionContent>
+                          <RuleExecutionDescription description={ruleExecution.description} />
+                          {scenarioIterationRules.data ? (
+                            <RuleExecutionDetail
+                              scenarioId={detailDecisionQuery.data?.decision.scenario.id ?? ''}
+                              ruleExecution={ruleExecution}
+                              rules={scenarioIterationRules.data.rules}
+                              isIterationArchived={scenarioIterationRules.data.archived}
+                            />
+                          ) : null}
+                        </RuleExecutionContent>
+                      </RuleExecutionCollapsible>
+                    ))}
+                  </RulesExecutionsContainer>
+                ) : null}
+              </div>
+            );
+          })}
+
+        {/* Trigger Object */}
+        {detailDecisionQuery.data ? (
+          <div className="flex flex-col gap-sm">
+            <span className="text-m text-grey-primary font-medium">{t('cases:case_detail.trigger_object')}</span>
+            <CaseDetailTriggerObject
+              className="max-h-[50dvh] overflow-auto"
               dataModel={dataModel}
-              tableName={objectLink.tableName}
-              objectId={objectLink.objectId}
-              onClose={() => setObjectLink(null)}
+              triggerObject={detailDecisionQuery.data.decision.triggerObject}
+              triggerObjectType={detailDecisionQuery.data.decision.triggerObjectType}
+              onLinkClicked={(tableName, objectId) => setObjectLink({ tableName, objectId })}
             />
-          ) : null}
-        </div>
-      ) : null}
-    </div>
+            {objectLink ? (
+              <IngestedObjectDetailModal
+                dataModel={dataModel}
+                tableName={objectLink.tableName}
+                objectId={objectLink.objectId}
+                onClose={() => setObjectLink(null)}
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </Panel.Content>
   );
 }

--- a/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ScreeningCaseDetailPage.tsx
+++ b/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ScreeningCaseDetailPage.tsx
@@ -1,8 +1,7 @@
 import { Callout, Page } from '@app-builder/components';
 import { BreadCrumbs } from '@app-builder/components/Breadcrumbs';
 import { DataListGrid } from '@app-builder/components/DataModelExplorer/DataListGrid';
-import { PanelContainer, PanelContent } from '@app-builder/components/Panel';
-import { PanelRoot, PanelSharpFactory } from '@app-builder/components/Panel/Panel';
+import { Panel, PanelSharpFactory } from '@app-builder/components/Panel';
 import { EntityProperties } from '@app-builder/components/Screenings/EntityProperties';
 import { EntityDatasetsList } from '@app-builder/components/Screenings/MatchCard/match-card-entity-components';
 import { TopicTag } from '@app-builder/components/Screenings/TopicTag';
@@ -164,9 +163,9 @@ const IndirectScreeningRequestDetail = ({ screening }: { screening: ContinuousSc
           </div>
         </DataListGrid>
       </div>
-      <PanelRoot open={open} onOpenChange={setOpen}>
+      <Panel.Root open={open} onOpenChange={setOpen}>
         <ScreeningEntityDetailsPanel entity={screening.opensanctionEntityPayload} />
-      </PanelRoot>
+      </Panel.Root>
     </>
   );
 };
@@ -176,13 +175,15 @@ const ScreeningEntityDetailsPanel = ({ entity }: { entity: OpenSanctionEntityPay
   const { t } = useTranslation(['continuousScreening', 'screenings']);
 
   return (
-    <PanelContainer size="xxxl">
-      <PanelContent>
-        <div className="flex flex-col gap-md">
+    <Panel.Container size="medium">
+      <Panel.Content>
+        <Panel.Header>
           <Button variant="secondary" mode="icon" onClick={panelSharp.actions.close}>
             <Icon icon="left-panel-close" className="size-4" />
           </Button>
           <div className="text-h1">{t('continuousScreening:review.entity_details.title')}</div>
+        </Panel.Header>
+        <div className="flex flex-col gap-md">
           <div className="flex items-center gap-sm">
             <span className="font-medium">{entity.caption}</span>
             <span className="text-small text-grey-placeholder">{entity.schema}</span>
@@ -208,7 +209,7 @@ const ScreeningEntityDetailsPanel = ({ entity }: { entity: OpenSanctionEntityPay
             }
           />
         </div>
-      </PanelContent>
-    </PanelContainer>
+      </Panel.Content>
+    </Panel.Container>
   );
 };

--- a/packages/app-builder/src/components/CaseManagerV2/AiReview/AiReviewPanel.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/AiReview/AiReviewPanel.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import { type AiCaseReviewListItem, type AiCaseReviewStatus } from '@app-builder/models/cases';
 import { useAddReviewToCaseCommentsMutation } from '@app-builder/queries/add-review-to-case-comments';
 import { useEnqueueCaseReviewMutation } from '@app-builder/queries/ask-case-review';
@@ -9,7 +10,6 @@ import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Markdown, Tag, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { PanelContainer, PanelRoot } from '../../Panel';
 
 type AiReviewPanelProps = {
   caseId: string;
@@ -21,9 +21,9 @@ type AiReviewPanelProps = {
 
 export function AiReviewPanel({ caseId, canManuallyReview, open, onOpenChange, reviews }: AiReviewPanelProps) {
   return (
-    <PanelRoot open={open} onOpenChange={onOpenChange}>
+    <Panel.Root open={open} onOpenChange={onOpenChange}>
       <AiReviewPanelContent {...{ caseId, canManuallyReview, open, onOpenChange, reviews }} />
-    </PanelRoot>
+    </Panel.Root>
   );
 }
 
@@ -42,64 +42,66 @@ function AiReviewPanelContent({ caseId, canManuallyReview, onOpenChange, reviews
   if (!selectedListItem) return null;
 
   return (
-    <PanelContainer size="max" className="max-w-[80vw]!">
-      <div className="flex items-center gap-sm pb-md border-b border-grey-border">
-        <Icon
-          icon="cross"
-          className="size-5 cursor-pointer text-grey-secondary hover:text-grey-primary shrink-0"
-          onClick={() => onOpenChange(false)}
-          aria-label={t('common:close')}
-        />
-        <Icon icon="ai-review" className="size-4 text-purple-primary shrink-0" />
-        <Typo variant="title2" className="text-grey-primary">
-          {t('cases:case_detail.ai_review.panel.title')}
-        </Typo>
-        <ReviewStatusBadge status={selectedListItem.status} />
-        <time className="text-xs text-grey-secondary" dateTime={selectedListItem.createdAt}>
-          {formatDateTime(selectedListItem.createdAt, { dateStyle: 'short', timeStyle: 'short' })}
-        </time>
-        <div className="ms-auto flex items-center gap-xs">
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={() => setSelectedIndex((i) => Math.min(i + 1, reviews.length - 1))}
-            disabled={!hasPreviousReport}
-          >
-            {t('cases:case.ai_reviews.see_previous_report')}
-          </Button>
-          {canManuallyReview ? (
+    <Panel.Container size="medium">
+      <Panel.Content>
+        <div className="flex items-center gap-sm pb-md border-b border-grey-border">
+          <Icon
+            icon="cross"
+            className="size-5 cursor-pointer text-grey-secondary hover:text-grey-primary shrink-0"
+            onClick={() => onOpenChange(false)}
+            aria-label={t('common:close')}
+          />
+          <Icon icon="ai-review" className="size-4 text-purple-primary shrink-0" />
+          <Typo variant="title2" className="text-grey-primary">
+            {t('cases:case_detail.ai_review.panel.title')}
+          </Typo>
+          <ReviewStatusBadge status={selectedListItem.status} />
+          <time className="text-xs text-grey-secondary" dateTime={selectedListItem.createdAt}>
+            {formatDateTime(selectedListItem.createdAt, { dateStyle: 'short', timeStyle: 'short' })}
+          </time>
+          <div className="ms-auto flex items-center gap-xs">
             <Button
               variant="secondary"
               size="small"
-              onClick={() => enqueueReviewMutation.mutate(caseId)}
-              disabled={enqueueReviewMutation.isPending}
+              onClick={() => setSelectedIndex((i) => Math.min(i + 1, reviews.length - 1))}
+              disabled={!hasPreviousReport}
             >
-              <Icon icon="wand" className="size-4 text-purple-primary" />
-              <span className="text-purple-primary">{t('cases:case.ai_reviews.generate')}</span>
+              {t('cases:case.ai_reviews.see_previous_report')}
             </Button>
-          ) : null}
+            {canManuallyReview ? (
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={() => enqueueReviewMutation.mutate(caseId)}
+                disabled={enqueueReviewMutation.isPending}
+              >
+                <Icon icon="wand" className="size-4 text-purple-primary" />
+                <span className="text-purple-primary">{t('cases:case.ai_reviews.generate')}</span>
+              </Button>
+            ) : null}
+          </div>
         </div>
-      </div>
 
-      <div className="flex gap-md flex-1 overflow-y-auto py-md">
-        <div className="flex-1 min-w-0 text-small">
-          {reviewQuery.isLoading ? (
-            <div className="flex h-full items-center justify-center">
-              <Icon icon="spinner" className="size-6 animate-spin text-grey-secondary" />
-            </div>
-          ) : reviewQuery.isError ? (
-            <div className="flex h-full items-center justify-center text-s text-red-primary">
-              {t('cases:case.ai_reviews.error_loading')}
-            </div>
-          ) : review ? (
-            <Markdown>{review.review.output}</Markdown>
-          ) : null}
+        <div className="flex gap-md flex-1 overflow-y-auto py-md">
+          <div className="flex-1 min-w-0 text-small">
+            {reviewQuery.isLoading ? (
+              <div className="flex h-full items-center justify-center">
+                <Icon icon="spinner" className="size-6 animate-spin text-grey-secondary" />
+              </div>
+            ) : reviewQuery.isError ? (
+              <div className="flex h-full items-center justify-center text-s text-red-primary">
+                {t('cases:case.ai_reviews.error_loading')}
+              </div>
+            ) : review ? (
+              <Markdown>{review.review.output}</Markdown>
+            ) : null}
+          </div>
+          {review && !review.review.ok ? <SanityCheckWarning message={review.review.sanityCheck} /> : null}
         </div>
-        {review && !review.review.ok ? <SanityCheckWarning message={review.review.sanityCheck} /> : null}
-      </div>
+      </Panel.Content>
 
       {review ? <PanelFooter caseId={caseId} reviewId={review.id} reaction={review.reaction} /> : null}
-    </PanelContainer>
+    </Panel.Container>
   );
 }
 

--- a/packages/app-builder/src/components/CaseManagerV2/DataExplorerPanel.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/DataExplorerPanel.tsx
@@ -1,9 +1,9 @@
+import { Panel } from '@app-builder/components/Panel';
 import { DataModel } from '@app-builder/models';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataModelExplorer } from '../DataModelExplorer/DataModelExplorer';
 import { DataModelExplorerContext } from '../DataModelExplorer/Provider';
-import { PanelContainer, PanelContent, PanelHeader, PanelRoot } from '../Panel';
 
 type DataExplorerPanelProps = {
   dataModel: DataModel;
@@ -22,13 +22,15 @@ export function DataExplorerPanel({ dataModel, open, onOpenChange }: DataExplore
   }, [dataModelExplorerContext.explorerState]);
 
   return (
-    <PanelRoot open={open} onOpenChange={onOpenChange}>
-      <PanelContainer size="max" className="max-w-[80vw]!">
-        <PanelHeader>{t('cases:case_detail.pivot_panel.breadcrumb_explore')}</PanelHeader>
-        <PanelContent>
-          <DataModelExplorer dataModel={dataModel} />
-        </PanelContent>
-      </PanelContainer>
-    </PanelRoot>
+    <Panel.Root open={open} onOpenChange={onOpenChange}>
+      <Panel.Container size="large">
+        <Panel.Content>
+          <Panel.Header>{t('cases:case_detail.pivot_panel.breadcrumb_explore')}</Panel.Header>
+          <div>
+            <DataModelExplorer dataModel={dataModel} />
+          </div>
+        </Panel.Content>
+      </Panel.Container>
+    </Panel.Root>
   );
 }

--- a/packages/app-builder/src/components/CaseManagerV2/KycEnrichment/KycEnrichmentPanel.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/KycEnrichment/KycEnrichmentPanel.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useAddCommentMutation } from '@app-builder/queries/cases/add-comment';
 import { useCreateKycEnrichmentQuery } from '@app-builder/queries/cases/create-kyc-enrichment';
@@ -8,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { Button, Markdown, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { Callout } from '../../Callout';
-import { PanelContainer, PanelRoot } from '../../Panel';
 import { Spinner } from '../../Spinner';
 
 type KycEnrichmentPanelProps = {
@@ -62,8 +62,8 @@ export function KycEnrichmentPanel({ caseId, open, onOpenChange }: KycEnrichment
   };
 
   return (
-    <PanelRoot open={open} onOpenChange={onOpenChange}>
-      <PanelContainer size="4xl">
+    <Panel.Root open={open} onOpenChange={onOpenChange}>
+      <Panel.Container size="medium">
         <div className="flex items-center gap-sm pb-md border-b border-grey-border">
           <Icon icon="ai-review" className="size-5 text-purple-primary shrink-0" />
           <Typo variant="title2" className="flex-1 text-grey-primary">
@@ -125,8 +125,8 @@ export function KycEnrichmentPanel({ caseId, open, onOpenChange }: KycEnrichment
             {t('common:close')}
           </Button>
         </div>
-      </PanelContainer>
-    </PanelRoot>
+      </Panel.Container>
+    </Panel.Root>
   );
 }
 

--- a/packages/app-builder/src/components/CaseManagerV2/PrincipalPage.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/PrincipalPage.tsx
@@ -2,6 +2,7 @@ import { ClientObjectTagList } from '@app-builder/components/Annotations/ClientO
 import { AiReviewCard } from '@app-builder/components/CaseManagerV2/AiReview/AiReviewCard';
 import { UserScoreBadge } from '@app-builder/components/CaseManagerV2/UserScore/UserScoreBadge';
 import { CaseAlerts } from '@app-builder/components/Cases/CaseAlerts';
+import { Panel } from '@app-builder/components/Panel';
 import { DataModel, DataModelObject } from '@app-builder/models';
 import { CaseDetail, PivotObject } from '@app-builder/models/cases';
 import { FeatureAccesses } from '@app-builder/models/feature-access';
@@ -28,7 +29,6 @@ import { EditCaseInbox } from '../Cases/EditCaseInbox';
 import { CopyToClipboardButton } from '../CopyToClipboardButton';
 import { DataFields } from '../Data/DataVisualisation/DataFields';
 import { DataModelExplorerProvider } from '../DataModelExplorer/Provider';
-import { PanelContainer, PanelContent, PanelRoot } from '../Panel';
 import { DataExplorerPanel } from './DataExplorerPanel';
 import { EscalateCaseButton } from './EscalateCaseButton';
 import { CaseSnoozePanel } from './SnoozePanel/CaseSnoozePanel';
@@ -169,9 +169,9 @@ export function CaseManagerPrincipalPage({
           </div>
         </div>
       </div>
-      <PanelRoot open={snoozePanelOpen} onOpenChange={setSnoozePanelOpen}>
-        <PanelContainer size="max">
-          <PanelContent>
+      <Panel.Root open={snoozePanelOpen} onOpenChange={setSnoozePanelOpen}>
+        <Panel.Container size="medium">
+          <Panel.Content>
             <CaseSnoozePanel
               onClose={() => setSnoozePanelOpen(false)}
               caseDetail={caseDetail}
@@ -179,9 +179,9 @@ export function CaseManagerPrincipalPage({
               pivotObjects={pivotObjects ?? []}
               entitlements={entitlements}
             />
-          </PanelContent>
-        </PanelContainer>
-      </PanelRoot>
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
     </>
   );
 }

--- a/packages/app-builder/src/components/CaseManagerV2/SnoozePanel/CaseSnoozePanel.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/SnoozePanel/CaseSnoozePanel.tsx
@@ -1,6 +1,7 @@
 import { casesI18n } from '@app-builder/components/Cases';
 import { AddRuleSnooze } from '@app-builder/components/Cases/AddRuleSnooze';
 import { Nudge } from '@app-builder/components/Nudge';
+import { Panel } from '@app-builder/components/Panel';
 import { RuleGroup } from '@app-builder/components/Scenario/Rules/RuleGroup';
 import { ScoreModifier } from '@app-builder/components/Scenario/Rules/ScoreModifier';
 import { DataModel } from '@app-builder/models';
@@ -51,13 +52,9 @@ export function CaseSnoozePanel({ onClose, caseDetail, dataModel, pivotObjects, 
   const rulesByPivot = rulesByPivotQuery.data.rulesByPivot;
 
   return (
-    <div className="flex flex-col gap-lg p-md">
-      <Button variant="secondary" size="small" onClick={onClose}>
-        <Icon icon="cross" className="size-5" />
-      </Button>
-
-      <div className="flex w-full flex-col gap-lg px-xs">
-        <span className="text-l font-semibold">Rules</span>
+    <>
+      <Panel.Header>Rules</Panel.Header>
+      <div className="flex w-full flex-col gap-lg px-sm">
         {pivotKeys.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-md py-xl text-center">
             <Icon icon="inbox" className="size-8 text-grey-secondary" />
@@ -188,6 +185,6 @@ export function CaseSnoozePanel({ onClose, caseDetail, dataModel, pivotObjects, 
           </div>
         )}
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/app-builder/src/components/Cases/CaseAlerts.tsx
+++ b/packages/app-builder/src/components/Cases/CaseAlerts.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import { type DetailedCaseDecision } from '@app-builder/models/cases';
 import { DataModel, getTriggerObjectFields } from '@app-builder/models/data-model';
 import { type ReviewStatus } from '@app-builder/models/decision';
@@ -16,7 +17,6 @@ import { Icon } from 'ui-icons';
 import { DecisionPanel } from '../CaseManager/DecisionPanel/DecisionPanel';
 import { ReviewStatusTag } from '../Decisions/ReviewStatusTag';
 import { FormatData } from '../FormatData';
-import { PanelContainer, PanelRoot } from '../Panel';
 import { ScreeningHitsPanel } from '../Screenings/ScreeningPanel/ScreeningHitsPanel';
 import { Spinner } from '../Spinner';
 import { casesI18n } from './cases-i18n';
@@ -218,16 +218,16 @@ export const AlertCard = ({
         </div>
       </div>
       {openDetails ? (
-        <PanelRoot open onOpenChange={(isOpen) => setOpenDetails(isOpen)}>
-          <PanelContainer size="xxl">
+        <Panel.Root open onOpenChange={(isOpen) => setOpenDetails(isOpen)}>
+          <Panel.Container size="medium">
             <DecisionPanel
               dataModel={dataModel}
               decision={decision}
               onClose={() => setOpenDetails(false)}
               onScreeningSelect={setPanelScreeningId}
             />
-          </PanelContainer>
-        </PanelRoot>
+          </Panel.Container>
+        </Panel.Root>
       ) : null}
       {openScreening ? (
         <ScreeningHitsPanel

--- a/packages/app-builder/src/components/Cases/CreateCase.tsx
+++ b/packages/app-builder/src/components/Cases/CreateCase.tsx
@@ -1,6 +1,7 @@
 import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/FormErrorOrDescription';
 import { FormInput } from '@app-builder/components/Form/Tanstack/FormInput';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
+import { Panel } from '@app-builder/components/Panel';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import {
   CreateCasePayload,
@@ -13,8 +14,7 @@ import { useForm } from '@tanstack/react-form';
 import { useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button, SelectV2 } from 'ui-design-system';
-import { Icon } from 'ui-icons';
+import { SelectV2 } from 'ui-design-system';
 
 export function CreateCase({ inboxId }: { inboxId: string | null }) {
   const { t } = useTranslation(['cases', 'common']);
@@ -46,68 +46,70 @@ export function CreateCase({ inboxId }: { inboxId: string | null }) {
     },
   });
 
-  if (inboxesQuery.isPending) return <div>Loading...</div>;
-  if (inboxesQuery.isError) return <div>Error</div>;
-
   return (
-    <form onSubmit={handleSubmit(form)}>
-      <div className="flex flex-col gap-md">
-        <form.Field
-          name="name"
-          validators={{
-            onBlur: createCasePayloadSchema.shape.name,
-            onChange: createCasePayloadSchema.shape.name,
-          }}
-        >
-          {(field) => (
-            <div className="flex flex-col gap-sm">
-              <FormLabel name={field.name} className="text-xs first-letter:capitalize">
-                {t('cases:case.name')}
-              </FormLabel>
-              <FormInput
-                type="text"
-                name={field.name}
-                defaultValue={field.state.value}
-                onChange={(e) => field.handleChange(e.currentTarget.value)}
-                valid={field.state.meta.errors.length === 0}
-                placeholder={t('cases:case.new_case.placeholder')}
-              />
-              <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
-            </div>
-          )}
-        </form.Field>
-        <form.Field
-          name="inboxId"
-          validators={{
-            onBlur: createCasePayloadSchema.shape.inboxId,
-            onChange: createCasePayloadSchema.shape.inboxId,
-          }}
-        >
-          {(field) => (
-            <div className="flex flex-1 flex-col gap-sm">
-              <FormLabel name={field.name} className="text-xs first-letter:capitalize">
-                {t('cases:case.new_case.select_inbox')}
-              </FormLabel>
-              {inboxesQuery.isSuccess ? (
-                <SelectV2
-                  className="w-full overflow-hidden"
-                  placeholder=""
-                  value={field.state.value}
-                  options={inboxesQuery.data.inboxes.map(({ name, id }) => ({ label: name, value: id }))}
-                  onChange={(inboxId) => {
-                    field.handleChange(inboxId);
-                  }}
-                />
-              ) : null}
-              <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
-            </div>
-          )}
-        </form.Field>
-        <Button type="submit">
-          <Icon icon="plus" className="size-5" />
-          {t('cases:case.new_case.create')}
-        </Button>
-      </div>
-    </form>
+    <Panel.Container size="small">
+      <form onSubmit={handleSubmit(form)}>
+        <Panel.Content>
+          <Panel.Header>{t('cases:case.new_case')}</Panel.Header>
+
+          <div className="flex flex-col gap-md">
+            <form.Field
+              name="name"
+              validators={{
+                onBlur: createCasePayloadSchema.shape.name,
+                onChange: createCasePayloadSchema.shape.name,
+              }}
+            >
+              {(field) => (
+                <div className="flex flex-col gap-sm">
+                  <FormLabel name={field.name} className="text-xs first-letter:capitalize">
+                    {t('cases:case.name')}
+                  </FormLabel>
+                  <FormInput
+                    type="text"
+                    name={field.name}
+                    defaultValue={field.state.value}
+                    onChange={(e) => field.handleChange(e.currentTarget.value)}
+                    valid={field.state.meta.errors.length === 0}
+                    placeholder={t('cases:case.new_case.placeholder')}
+                  />
+                  <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
+                </div>
+              )}
+            </form.Field>
+            <form.Field
+              name="inboxId"
+              validators={{
+                onBlur: createCasePayloadSchema.shape.inboxId,
+                onChange: createCasePayloadSchema.shape.inboxId,
+              }}
+            >
+              {(field) => (
+                <div className="flex flex-1 flex-col gap-sm">
+                  <FormLabel name={field.name} className="text-xs first-letter:capitalize">
+                    {t('cases:case.new_case.select_inbox')}
+                  </FormLabel>
+                  {inboxesQuery.isSuccess ? (
+                    <SelectV2
+                      className="w-full overflow-hidden"
+                      placeholder=""
+                      value={field.state.value}
+                      options={inboxesQuery.data.inboxes.map(({ name, id }) => ({ label: name, value: id }))}
+                      onChange={(inboxId) => {
+                        field.handleChange(inboxId);
+                      }}
+                    />
+                  ) : null}
+                  <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
+                </div>
+              )}
+            </form.Field>
+          </div>
+          <Panel.Footer>
+            <Panel.FooterButton type="submit" label={t('cases:case.new_case.create')} leadingIcon="plus" />
+          </Panel.Footer>
+        </Panel.Content>
+      </form>
+    </Panel.Container>
   );
 }

--- a/packages/app-builder/src/components/Cases/InboxPage.tsx
+++ b/packages/app-builder/src/components/Cases/InboxPage.tsx
@@ -3,6 +3,7 @@ import { CasesList } from '@app-builder/components/Cases/Inbox/CasesList';
 import { FavoriteInboxButton } from '@app-builder/components/Cases/Inbox/FavoriteInboxButton';
 import { InboxFilterBar } from '@app-builder/components/Cases/Inbox/FilterBar/FilterBar';
 import { MultiSelect } from '@app-builder/components/MultiSelect';
+import { Panel } from '@app-builder/components/Panel';
 import { MY_INBOX_ID } from '@app-builder/constants/inboxes';
 import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import { useBase64Query } from '@app-builder/hooks/useBase64Query';
@@ -19,7 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, cn, Input } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { PanelContainer, PanelContent, PanelHeader, PanelRoot } from '../Panel';
 import { Spinner } from '../Spinner';
 import { CreateCase } from './CreateCase';
 import { BatchActions, MassUpdateCasesFn } from './Inbox/BatchActions';
@@ -208,14 +208,9 @@ export const InboxPage = ({
                 >
                   <Icon icon="plus" className="size-4" />
                 </Button>
-                <PanelRoot open={isAddingCase} onOpenChange={setIsAddingCase}>
-                  <PanelContainer size="xl">
-                    <PanelContent>
-                      <PanelHeader>{t('cases:case.new_case')}</PanelHeader>
-                      <CreateCase inboxId={inboxId === MY_INBOX_ID ? null : inboxId} />
-                    </PanelContent>
-                  </PanelContainer>
-                </PanelRoot>
+                <Panel.Root open={isAddingCase} onOpenChange={setIsAddingCase}>
+                  <CreateCase inboxId={inboxId === MY_INBOX_ID ? null : inboxId} />
+                </Panel.Root>
               </div>
             </div>
 

--- a/packages/app-builder/src/components/Cases/Overview/Panel/AIConfigPanelContent.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Panel/AIConfigPanelContent.tsx
@@ -3,7 +3,7 @@ import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { FormErrorOrDescription } from '@app-builder/components/Form/Tanstack/FormErrorOrDescription';
 import { FormLabel } from '@app-builder/components/Form/Tanstack/FormLabel';
 import { FormTextArea } from '@app-builder/components/Form/Tanstack/FormTextArea';
-import { PanelContainer, PanelContent, PanelFooter, PanelHeader } from '@app-builder/components/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { type AiSettingSchema, aiSettingSchema } from '@app-builder/models/ai-settings';
 import { useUpdateAiSettings } from '@app-builder/queries/cases/update-ai-settings';
 import { getFieldErrors, handleSubmit } from '@app-builder/utils/form';
@@ -12,7 +12,6 @@ import toast from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import { Button, Input, Switch, Tooltip } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-
 import { LanguageDropdown } from './LanguageDropdown';
 
 interface AIConfigPanelContentProps {
@@ -56,14 +55,9 @@ export function AIConfigPanelContent({ settings, onSuccess, readOnly }: AIConfig
   });
 
   return (
-    <PanelContainer size="xxl">
-      <PanelHeader>
-        <div className="flex items-center gap-sm">
-          <span>{t('cases:overview.panel.ai_config.title')}</span>
-        </div>
-      </PanelHeader>
-
-      <PanelContent>
+    <Panel.Container size="small">
+      <Panel.Content>
+        <Panel.Header>{t('cases:overview.panel.ai_config.title')}</Panel.Header>
         <form id="ai-config-panel-form" className="flex flex-col gap-sm" onSubmit={handleSubmit(form)}>
           {/* Section: Informations générales */}
           <div className="bg-grey-background-light dark:bg-surface-card border border-grey-border rounded-lg p-md flex flex-col gap-md">
@@ -315,33 +309,25 @@ export function AIConfigPanelContent({ settings, onSuccess, readOnly }: AIConfig
             </form.Field>
           </div>
         </form>
-      </PanelContent>
-
-      {!readOnly && (
-        <PanelFooter>
-          <form.Subscribe selector={(state) => state.isSubmitting}>
-            {(isSubmitting) => {
-              const isPending = isSubmitting || updateMutation.isPending;
-              return (
-                <Button
-                  type="submit"
-                  form="ai-config-panel-form"
-                  variant="primary"
-                  size="medium"
-                  className="w-full justify-center"
-                  disabled={isPending}
-                >
-                  {isPending ? (
-                    <Icon icon="spinner" className="size-4 animate-spin" />
-                  ) : (
-                    t('cases:overview.validate_config')
-                  )}
-                </Button>
-              );
-            }}
-          </form.Subscribe>
-        </PanelFooter>
-      )}
-    </PanelContainer>
+        {!readOnly && (
+          <Panel.Footer>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => {
+                const isPending = isSubmitting || updateMutation.isPending;
+                return (
+                  <Panel.FooterButton
+                    type="submit"
+                    form="ai-config-panel-form"
+                    variant="primary"
+                    label={t('cases:overview.validate_config')}
+                    isLoading={isPending}
+                  />
+                );
+              }}
+            </form.Subscribe>
+          </Panel.Footer>
+        )}
+      </Panel.Content>
+    </Panel.Container>
   );
 }

--- a/packages/app-builder/src/components/Cases/Overview/Panel/AutoAssignmentPanelContent.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Panel/AutoAssignmentPanelContent.tsx
@@ -1,5 +1,4 @@
-import { PanelContainer, PanelContent, PanelFooter, PanelHeader } from '@app-builder/components/Panel';
-import { PanelSharpFactory } from '@app-builder/components/Panel/Panel';
+import { Panel, PanelSharpFactory } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { type InboxWithCasesCount } from '@app-builder/models/inbox';
@@ -9,8 +8,6 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
-import { Button } from 'ui-design-system';
-import { Icon } from 'ui-icons';
 import { InboxCard } from './InboxCard';
 
 interface AutoAssignmentChanges {
@@ -107,55 +104,47 @@ export const AutoAssignmentPanelContent = ({
   const hasChanges = Object.keys(changes.inboxes).length > 0 || Object.keys(changes.users).length > 0;
 
   return (
-    <PanelContainer size="xxl">
-      <PanelHeader>
-        <div className="flex items-center gap-sm">
-          <span>{t('cases:overview.panel.auto_assignment.title')}</span>
+    <Panel.Container size="small">
+      <Panel.Content>
+        <Panel.Header>{t('cases:overview.panel.auto_assignment.title')}</Panel.Header>
+        <div className="grow">
+          {match(inboxesQuery)
+            .with({ isPending: true }, () => (
+              <div className="flex items-center justify-center py-xl">
+                <Spinner className="size-8" />
+              </div>
+            ))
+            .with({ isError: true }, () => (
+              <div className="text-s text-grey-secondary py-sm">{t('cases:overview.config.error_loading')}</div>
+            ))
+            .with({ isSuccess: true }, () => (
+              <div className="flex flex-col gap-md">
+                {inboxes.map((inbox) => (
+                  <InboxCard
+                    key={inbox.id}
+                    inbox={inbox}
+                    inboxChecked={changes.inboxes[inbox.id]}
+                    userCheckedMap={changes.users}
+                    onToggleInbox={handleToggleInbox}
+                    onToggleUser={handleToggleUser}
+                    disabled={!canEditInbox(inbox)}
+                  />
+                ))}
+              </div>
+            ))
+            .exhaustive()}
         </div>
-      </PanelHeader>
-      <PanelContent>
-        {match(inboxesQuery)
-          .with({ isPending: true }, () => (
-            <div className="flex items-center justify-center py-xl">
-              <Spinner className="size-8" />
-            </div>
-          ))
-          .with({ isError: true }, () => (
-            <div className="text-s text-grey-secondary py-sm">{t('cases:overview.config.error_loading')}</div>
-          ))
-          .with({ isSuccess: true }, () => (
-            <div className="flex flex-col gap-md">
-              {inboxes.map((inbox) => (
-                <InboxCard
-                  key={inbox.id}
-                  inbox={inbox}
-                  inboxChecked={changes.inboxes[inbox.id]}
-                  userCheckedMap={changes.users}
-                  onToggleInbox={handleToggleInbox}
-                  onToggleUser={handleToggleUser}
-                  disabled={!canEditInbox(inbox)}
-                />
-              ))}
-            </div>
-          ))
-          .exhaustive()}
-      </PanelContent>
-      {canSave ? (
-        <PanelFooter>
-          <Button
-            size="medium"
-            className="w-full justify-center"
-            onClick={handleSave}
-            disabled={updateAutoAssignMutation.isPending || !hasChanges}
-          >
-            {updateAutoAssignMutation.isPending ? (
-              <Icon icon="spinner" className="size-4 animate-spin" />
-            ) : (
-              t('cases:overview.validate')
-            )}
-          </Button>
-        </PanelFooter>
-      ) : null}
-    </PanelContainer>
+        {canSave ? (
+          <Panel.Footer>
+            <Panel.FooterButton
+              onClick={handleSave}
+              disabled={!hasChanges}
+              isLoading={updateAutoAssignMutation.isPending}
+              label={t('cases:overview.validate')}
+            />
+          </Panel.Footer>
+        ) : null}
+      </Panel.Content>
+    </Panel.Container>
   );
 };

--- a/packages/app-builder/src/components/Cases/Overview/Panel/EscalationConditionsPanelContent.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Panel/EscalationConditionsPanelContent.tsx
@@ -1,5 +1,4 @@
-import { PanelContainer, PanelContent, PanelFooter } from '@app-builder/components/Panel';
-import { PanelSharpFactory } from '@app-builder/components/Panel/Panel';
+import { Panel, PanelSharpFactory } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { type InboxMetadata } from '@app-builder/models/inbox';
@@ -9,8 +8,7 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
-import { Button, Typo } from 'ui-design-system';
-import { Icon } from 'ui-icons';
+import { Button } from 'ui-design-system';
 import { type EscalationCondition, EscalationConditionRow } from './EscalationConditionRow';
 
 interface EscalationConditionsPanelContentProps {
@@ -112,11 +110,9 @@ export const EscalationConditionsPanelContent = ({
   };
 
   return (
-    <PanelContainer size="xxl">
-      <div className="flex items-center gap-sm pb-md">
-        <Typo variant="title2">{t('cases:overview.panel.escalation.title')}</Typo>
-      </div>
-      <PanelContent>
+    <Panel.Container size="small">
+      <Panel.Content>
+        <Panel.Header>{t('cases:overview.panel.escalation.title')}</Panel.Header>
         {match(inboxesQuery)
           .with({ isPending: true }, () => (
             <div className="flex items-center justify-center py-xl">
@@ -156,23 +152,16 @@ export const EscalationConditionsPanelContent = ({
             </div>
           ))
           .exhaustive()}
-      </PanelContent>
-      {readOnly ? null : (
-        <PanelFooter>
-          <Button
-            size="medium"
-            className="w-full justify-center"
-            onClick={handleSave}
-            disabled={updateEscalationMutation.isPending}
-          >
-            {updateEscalationMutation.isPending ? (
-              <Icon icon="spinner" className="size-4 animate-spin" />
-            ) : (
-              t('cases:overview.validate_config')
-            )}
-          </Button>
-        </PanelFooter>
-      )}
-    </PanelContainer>
+        {readOnly ? null : (
+          <Panel.Footer>
+            <Panel.FooterButton
+              onClick={handleSave}
+              isLoading={updateEscalationMutation.isPending}
+              label={t('cases:overview.validate_config')}
+            />
+          </Panel.Footer>
+        )}
+      </Panel.Content>
+    </Panel.Container>
   );
 };

--- a/packages/app-builder/src/components/Cases/Overview/Panel/WorkflowConfigPanelContent.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Panel/WorkflowConfigPanelContent.tsx
@@ -1,5 +1,4 @@
-import { PanelContainer, PanelContent, PanelFooter, PanelHeader } from '@app-builder/components/Panel';
-import { PanelSharpFactory } from '@app-builder/components/Panel/Panel';
+import { Panel, PanelSharpFactory } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useGetInboxesQuery } from '@app-builder/queries/cases/get-inboxes';
@@ -8,8 +7,6 @@ import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
-import { Button } from 'ui-design-system';
-import { Icon } from 'ui-icons';
 import { WorkflowInboxCard, type WorkflowSettings } from './WorkflowInboxCard';
 
 type InboxWorkflowState = Map<string, WorkflowSettings>;
@@ -103,13 +100,9 @@ export const WorkflowConfigPanelContent = ({ readOnly }: WorkflowConfigPanelCont
   };
 
   return (
-    <PanelContainer size="xxl">
-      <PanelHeader>
-        <div className="flex items-center gap-sm">
-          <span>{t('cases:overview.panel.workflow.title')}</span>
-        </div>
-      </PanelHeader>
-      <PanelContent>
+    <Panel.Container size="small">
+      <Panel.Content>
+        <Panel.Header>{t('cases:overview.panel.workflow.title')}</Panel.Header>
         {match(inboxesQuery)
           .with({ isPending: true }, () => (
             <div className="flex items-center justify-center py-xl">
@@ -139,23 +132,16 @@ export const WorkflowConfigPanelContent = ({ readOnly }: WorkflowConfigPanelCont
             </div>
           ))
           .exhaustive()}
-      </PanelContent>
-      {readOnly ? null : (
-        <PanelFooter>
-          <Button
-            size="medium"
-            className="w-full justify-center"
-            onClick={handleSave}
-            disabled={updateWorkflowMutation.isPending}
-          >
-            {updateWorkflowMutation.isPending ? (
-              <Icon icon="spinner" className="size-4 animate-spin" />
-            ) : (
-              t('cases:overview.validate_config')
-            )}
-          </Button>
-        </PanelFooter>
-      )}
-    </PanelContainer>
+        {readOnly ? null : (
+          <Panel.Footer>
+            <Panel.FooterButton
+              onClick={handleSave}
+              isLoading={updateWorkflowMutation.isPending}
+              label={t('cases:overview.validate_config')}
+            />
+          </Panel.Footer>
+        )}
+      </Panel.Content>
+    </Panel.Container>
   );
 };

--- a/packages/app-builder/src/components/Cases/Overview/Section/AIConfigSection.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Section/AIConfigSection.tsx
@@ -1,4 +1,4 @@
-import { PanelRoot } from '@app-builder/components/Panel/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useGetAiSettingsQuery } from '@app-builder/queries/cases/get-ai-settings';
@@ -104,7 +104,7 @@ export function AIConfigSection({ isGlobalAdmin, access }: AIConfigSectionProps)
                 upsaleDescription={t('cases:overview.upsale.ai_config.description')}
                 onClick={handleOpenPanel}
               />
-              <PanelRoot open={aiConfigPanelOpen} onOpenChange={setAiConfigPanelOpen}>
+              <Panel.Root open={aiConfigPanelOpen} onOpenChange={setAiConfigPanelOpen}>
                 <AIConfigPanelContent
                   settings={data.settings}
                   readOnly={!canEdit}
@@ -114,7 +114,7 @@ export function AIConfigSection({ isGlobalAdmin, access }: AIConfigSectionProps)
                     aiSettingsQuery.refetch();
                   }}
                 />
-              </PanelRoot>
+              </Panel.Root>
             </>
           );
         })

--- a/packages/app-builder/src/components/Cases/Overview/Section/AutoAssignmentSection.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Section/AutoAssignmentSection.tsx
@@ -1,4 +1,4 @@
-import { PanelRoot } from '@app-builder/components/Panel/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { type InboxWithCasesCount } from '@app-builder/models/inbox';
 import { useGetInboxesQuery } from '@app-builder/queries/cases/get-inboxes';
@@ -138,13 +138,13 @@ export const AutoAssignmentSection = ({ currentUserId, isGlobalAdmin, access }: 
             .exhaustive()}
         </div>
       ) : null}
-      <PanelRoot open={autoAssignPanelOpen} onOpenChange={setAutoAssignPanelOpen}>
+      <Panel.Root open={autoAssignPanelOpen} onOpenChange={setAutoAssignPanelOpen}>
         <AutoAssignmentPanelContent
           currentUserId={currentUserId}
           isGlobalAdmin={isGlobalAdmin}
           hasEntitlement={hasAccess}
         />
-      </PanelRoot>
+      </Panel.Root>
     </div>
   );
 };

--- a/packages/app-builder/src/components/Cases/Overview/Section/WorkflowConfigSection.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Section/WorkflowConfigSection.tsx
@@ -1,4 +1,4 @@
-import { PanelRoot } from '@app-builder/components/Panel/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { type InboxMetadata } from '@app-builder/models/inbox';
 import { useGetInboxesQuery } from '@app-builder/queries/cases/get-inboxes';
@@ -118,12 +118,12 @@ export const WorkflowConfigSection = ({
           );
         })
         .exhaustive()}
-      <PanelRoot open={escalationPanelOpen} onOpenChange={setEscalationPanelOpen}>
+      <Panel.Root open={escalationPanelOpen} onOpenChange={setEscalationPanelOpen}>
         <EscalationConditionsPanelContent readOnly={!isGlobalAdmin} allInboxesMetadata={allInboxesMetadata} />
-      </PanelRoot>
-      <PanelRoot open={workflowPanelOpen} onOpenChange={setWorkflowPanelOpen}>
+      </Panel.Root>
+      <Panel.Root open={workflowPanelOpen} onOpenChange={setWorkflowPanelOpen}>
         <WorkflowConfigPanelContent readOnly={!canEditAiReview} />
-      </PanelRoot>
+      </Panel.Root>
     </div>
   );
 };

--- a/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ClientDetailPage.tsx
@@ -1,5 +1,6 @@
 import { BackButton } from '@app-builder/components/Breadcrumbs';
 import { Page } from '@app-builder/components/Page';
+import { Panel } from '@app-builder/components/Panel';
 import { DataModelObject, isAnalyst } from '@app-builder/models';
 import { SCORING_LEVELS_COLORS, SCORING_LEVELS_LABEL_KEYS, type ScoringSettings } from '@app-builder/models/scoring';
 import { useRelatedCasesByObjectQuery } from '@app-builder/queries/cases/related-cases-by-object';
@@ -21,7 +22,6 @@ import { ClientDocumentsPopover } from '../Annotations/ClientDocumentsPopover';
 import { DataFields } from '../Data/DataVisualisation/DataFields';
 import { DataModelExplorer } from '../DataModelExplorer/DataModelExplorer';
 import { DataModelExplorerProvider } from '../DataModelExplorer/Provider';
-import { PanelContainer, PanelHeader, PanelRoot } from '../Panel';
 import { Spinner } from '../Spinner';
 import { AlertHitsList } from './AlertHitsList';
 import { ClientComments } from './ClientComments';
@@ -277,44 +277,48 @@ export const ClientDetailPage = ({
           </Page.Content>
         </Page.Container>
       </Page.Main>
-      <PanelRoot open={showAlertHitsPanel} onOpenChange={setShowAlertHitsPanel}>
-        <PanelContainer size="xxl">
-          <PanelHeader>{t('client360:client_detail.alert_hits.panel_title')}</PanelHeader>
-          <div className="text-small">
+      <Panel.Root open={showAlertHitsPanel} onOpenChange={setShowAlertHitsPanel}>
+        <Panel.Container size="medium">
+          <Panel.Content>
+            <Panel.Header>{t('client360:client_detail.alert_hits.panel_title')}</Panel.Header>
             <AlertHitsList alertHitsQuery={alertHitsQuery} showAll />
-          </div>
-        </PanelContainer>
-      </PanelRoot>
-      <PanelRoot open={showMonitoringHitsPanel} onOpenChange={setShowMonitoringHitsPanel}>
-        <PanelContainer size="xxl">
-          <PanelHeader>{t('client360:client_detail.monitoring_hits.panel_title')}</PanelHeader>
-          <div className="text-small">
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
+      <Panel.Root open={showMonitoringHitsPanel} onOpenChange={setShowMonitoringHitsPanel}>
+        <Panel.Container size="medium">
+          <Panel.Content>
+            <Panel.Header>{t('client360:client_detail.monitoring_hits.panel_title')}</Panel.Header>
             <MonitoringHitsList monitoringHitsQuery={monitoringHitsQuery} showAll />
-          </div>
-        </PanelContainer>
-      </PanelRoot>
-      <PanelRoot open={showHierarchyPanel} onOpenChange={setShowHierarchyPanel}>
-        <PanelContainer size="xxl">
-          <PanelHeader>{t('client360:client_detail.hierarchy.title')}</PanelHeader>
-          <ObjectHierarchy
-            showAll
-            objectType={objectType}
-            objectId={objectId}
-            metadata={metadata}
-            allMetadata={allMetadata}
-            dataModelQuery={dataModelQuery}
-            handleExplore={() => setShowExplorer(true)}
-          />
-        </PanelContainer>
-      </PanelRoot>
-      <PanelRoot open={showExplorer} onOpenChange={setShowExplorer}>
-        <PanelContainer className="max-w-[90vw]">
-          <PanelHeader>{t('client360:client_detail.data_exploration.panel_title')}</PanelHeader>
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            <DataModelExplorer dataModel={dataModelQuery.data?.dataModel ?? []} />
-          </div>
-        </PanelContainer>
-      </PanelRoot>
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
+      <Panel.Root open={showHierarchyPanel} onOpenChange={setShowHierarchyPanel}>
+        <Panel.Container size="small">
+          <Panel.Content>
+            <Panel.Header>{t('client360:client_detail.hierarchy.title')}</Panel.Header>
+            <ObjectHierarchy
+              showAll
+              objectType={objectType}
+              objectId={objectId}
+              metadata={metadata}
+              allMetadata={allMetadata}
+              dataModelQuery={dataModelQuery}
+              handleExplore={() => setShowExplorer(true)}
+            />
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
+      <Panel.Root open={showExplorer} onOpenChange={setShowExplorer}>
+        <Panel.Container className="max-w-[90vw]">
+          <Panel.Content>
+            <Panel.Header>{t('client360:client_detail.data_exploration.panel_title')}</Panel.Header>
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <DataModelExplorer dataModel={dataModelQuery.data?.dataModel ?? []} />
+            </div>
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
       {scoringSettings && activeScore && isAccessible(userScoringAccess) ? (
         <ScoreDetailPanel
           open={showScorePanel}

--- a/packages/app-builder/src/components/ClientDetail/DocumentsList.tsx
+++ b/packages/app-builder/src/components/ClientDetail/DocumentsList.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import { User } from '@app-builder/models/user';
 import { useGetCaseNameQuery } from '@app-builder/queries/cases/get-name';
 import { useGetAnnotationsQuery } from '@app-builder/queries/data/get-annotations';
@@ -14,7 +15,6 @@ import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, CtaV2ClassName, useFormatLanguage } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { PanelContainer, PanelHeader, PanelRoot } from '../Panel';
 import { Spinner } from '../Spinner';
 
 type DocumentsListProps = {
@@ -67,11 +67,13 @@ export const DocumentsList = ({ objectType, objectId }: DocumentsListProps) => {
             ));
           })}
           {currentFileView ? (
-            <PanelRoot open onOpenChange={() => setCurrentFileView(null)}>
-              <PanelContainer size="xxl">
-                <img src={currentFileView.fileUrl} />
-              </PanelContainer>
-            </PanelRoot>
+            <Panel.Root open onOpenChange={() => setCurrentFileView(null)}>
+              <Panel.Container size="medium">
+                <Panel.Content>
+                  <img src={currentFileView.fileUrl} />
+                </Panel.Content>
+              </Panel.Container>
+            </Panel.Root>
           ) : null}
         </div>
       );
@@ -178,32 +180,34 @@ const FileItem = ({
         </div>
       </button>
       {previewUrl ? (
-        <PanelRoot open onOpenChange={() => setPreviewUrl(null)}>
-          <PanelContainer size="xxl">
-            <PanelHeader>
-              <div className="flex items-baseline gap-md">
-                <div>{file.filename}</div>
-                <span className="text-default text-grey-secondary font-normal flex gap-sm">
-                  <span>
-                    {formatDistanceToNow(new Date(document.created_at), {
-                      locale: getDateFnsLocale(language),
-                      addSuffix: true,
-                    })}
+        <Panel.Root open onOpenChange={() => setPreviewUrl(null)}>
+          <Panel.Container size="medium">
+            <Panel.Content>
+              <Panel.Header>
+                <div className="flex items-baseline gap-md">
+                  <div>{file.filename}</div>
+                  <span className="text-default text-grey-secondary font-normal flex gap-sm">
+                    <span>
+                      {formatDistanceToNow(new Date(document.created_at), {
+                        locale: getDateFnsLocale(language),
+                        addSuffix: true,
+                      })}
+                    </span>
+                    <span>-</span>
+                    <span>
+                      {t('client360:client_detail.documents.annotated_by', {
+                        name: annotatedBy
+                          ? getFullName(annotatedBy)
+                          : t('client360:client_detail.documents.unknown_user'),
+                      })}
+                    </span>
                   </span>
-                  <span>-</span>
-                  <span>
-                    {t('client360:client_detail.documents.annotated_by', {
-                      name: annotatedBy
-                        ? getFullName(annotatedBy)
-                        : t('client360:client_detail.documents.unknown_user'),
-                    })}
-                  </span>
-                </span>
-              </div>
-            </PanelHeader>
-            <img src={previewUrl} />
-          </PanelContainer>
-        </PanelRoot>
+                </div>
+              </Panel.Header>
+              <img src={previewUrl} />
+            </Panel.Content>
+          </Panel.Container>
+        </Panel.Root>
       ) : null}
     </>
   );

--- a/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ScoreDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import {
   SCORING_LEVELS_COLORS,
   SCORING_LEVELS_LABEL_KEYS,
@@ -8,8 +9,7 @@ import { useGetScoringRulesetQuery } from '@app-builder/queries/scoring/get-rule
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { type ScoringScore } from 'marble-api';
 import { useTranslation } from 'react-i18next';
-import { Tag } from 'ui-design-system';
-import { PanelContainer, PanelContent, PanelHeader, PanelRoot } from '../Panel';
+import { Tag, Typo } from 'ui-design-system';
 
 interface ScoreDetailPanelProps {
   open: boolean;
@@ -137,18 +137,22 @@ export function ScoreDetailPanel({
   );
 
   return (
-    <PanelRoot open={open} onOpenChange={onOpenChange}>
-      <PanelContainer size="lg" className="flex flex-col">
-        <PanelHeader>{t('client360:client_detail.score_panel.title')}</PanelHeader>
-        <div className="flex flex-wrap gap-xs pb-md">
-          <Tag color="grey">{objectType}</Tag>
-          <Tag color="grey">
-            {t('client360:client_detail.score_panel.last_computed', {
-              date: formatDateTime(activeScore.created_at, { dateStyle: 'medium' }),
-            })}
-          </Tag>
-        </div>
-        <PanelContent className="flex flex-col gap-lg">
+    <Panel.Root open={open} onOpenChange={onOpenChange}>
+      <Panel.Container size="small">
+        <Panel.Content className="flex flex-col gap-lg">
+          <Panel.Header>
+            <div className="flex flex-col">
+              <div className="flex flex-wrap gap-xs">
+                <Typo variant="title2">{t('client360:client_detail.score_panel.title')}</Typo>
+                <Tag color="grey">{objectType}</Tag>
+                <Tag color="grey">
+                  {t('client360:client_detail.score_panel.last_computed', {
+                    date: formatDateTime(activeScore.created_at, { dateStyle: 'medium' }),
+                  })}
+                </Tag>
+              </div>
+            </div>
+          </Panel.Header>
           {/* Risk level card */}
           <div
             className="flex items-center gap-sm rounded-lg border p-md"
@@ -168,8 +172,8 @@ export function ScoreDetailPanel({
             </span>
             <ScoreScale maxRiskLevel={maxRiskLevel} currentLevel={activeScore.risk_level} thresholds={thresholds} />
           </div>
-        </PanelContent>
-      </PanelContainer>
-    </PanelRoot>
+        </Panel.Content>
+      </Panel.Container>
+    </Panel.Root>
   );
 }

--- a/packages/app-builder/src/components/ContinuousScreening/ConfigurationPanel.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/ConfigurationPanel.tsx
@@ -6,9 +6,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button } from 'ui-design-system';
-import { Icon } from 'ui-icons';
-import { PanelContainer } from '../Panel';
-import { PanelSharpFactory } from '../Panel/Panel';
+import { Panel } from '../Panel';
 import {
   ContinuousScreeningConfigurationStepper,
   PartialCreateContinuousScreeningConfig,
@@ -52,45 +50,48 @@ export const ConfigurationPanel = ({
   }, [baseStep]);
 
   return (
-    <PanelContainer size="max" className="p-0 bg-surface-page overflow-y-auto flex flex-col isolate">
+    <Panel.Container size="medium" className="isolate">
       <ContinuousScreeningConfigurationStepper.Provider value={configurationStepper}>
         <ListAndTopicDatasetConfigurationBridge useCase="continuous_monitoring">
-          <ConfigurationPanelHeader />
-          <div className="p-lg grow">
-            {match(configurationStepper.value.__internals.currentStep)
-              .with(0, () => <GeneralInfo stableId={baseConfig.stableId} />)
-              .with(1, () => <ObjectMapping baseConfig={baseConfig} />)
-              .with(2, () => <DatasetSelection useCase="continuous_monitoring" />)
-              .with(3, () => <ScoringConfiguration />)
-              .otherwise(() => null)}
-          </div>
-          <FormPagination finalButtonText={t('continuousScreening:edition.validate_button')} />
+          <Panel.Content>
+            <ConfigurationPanelHeader />
+            <div className="grow">
+              {match(configurationStepper.value.__internals.currentStep)
+                .with(0, () => <GeneralInfo stableId={baseConfig.stableId} />)
+                .with(1, () => <ObjectMapping baseConfig={baseConfig} />)
+                .with(2, () => <DatasetSelection useCase="continuous_monitoring" />)
+                .with(3, () => <ScoringConfiguration />)
+                .otherwise(() => null)}
+            </div>
+            <FormPagination
+              className="bg-surface-card"
+              finalButtonText={t('continuousScreening:edition.validate_button')}
+            />
+          </Panel.Content>
         </ListAndTopicDatasetConfigurationBridge>
       </ContinuousScreeningConfigurationStepper.Provider>
-    </PanelContainer>
+    </Panel.Container>
   );
 };
 
 const ConfigurationPanelHeader = () => {
-  const panelSharp = PanelSharpFactory.useSharp();
   const { t } = useTranslation(['continuousScreening']);
   const configurationStepper = ContinuousScreeningConfigurationStepper.useSharp();
   const mode = ContinuousScreeningConfigurationStepper.select((state) => state.__internals.mode);
 
   return (
-    <div className="flex items-center justify-between gap-md bg-surface-card h-16 px-md border-b border-grey-border shrink-0 sticky top-0 z-10">
-      <Button variant="secondary" mode="icon" onClick={panelSharp.actions.close}>
-        <Icon icon="arrow-left" className="size-4" />
-      </Button>
-      <span className="text-h1 me-auto font-bold">
-        {mode === 'view' ? t('continuousScreening:panel.title.view') : t('continuousScreening:panel.title.edit')}
-      </span>
-      <Stepper fromZero getStepLabel={(stepName) => t(`continuousScreening:panel.stepper.${stepName}`)} />
-      {mode === 'view' ? (
-        <Button variant="primary" onClick={() => configurationStepper.actions.setMode('edit', 0)}>
-          {t('common:edit')}
-        </Button>
-      ) : null}
-    </div>
+    <Panel.Header>
+      <div className="flex items-center justify-between gap-md shrink-0 sticky top-0 z-10">
+        <span className="me-auto">
+          {mode === 'view' ? t('continuousScreening:panel.title.view') : t('continuousScreening:panel.title.edit')}
+        </span>
+        <Stepper fromZero getStepLabel={(stepName) => t(`continuousScreening:panel.stepper.${stepName}`)} />
+        {mode === 'view' ? (
+          <Button variant="primary" onClick={() => configurationStepper.actions.setMode('edit', 0)}>
+            {t('common:edit')}
+          </Button>
+        ) : null}
+      </div>
+    </Panel.Header>
   );
 };

--- a/packages/app-builder/src/components/ContinuousScreening/ConfigurationsPage.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/ConfigurationsPage.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import {
   ContinuousScreeningConfig,
@@ -16,7 +17,6 @@ import GridTable from '../GridTable';
 import { makeDatasetsMap } from '../ListAndTopicConfiguration/dataset-selection-provider-utils';
 import { findDatasetOrTopicByKey, useDatasetTitle } from '../ListAndTopicConfiguration/dataset-utils';
 import { Page } from '../Page';
-import { PanelRoot } from '../Panel/Panel';
 import { ConfigurationPanel } from './ConfigurationPanel';
 import { CreationModal } from './CreationModal';
 import { PartialCreateContinuousScreeningConfig } from './context/CreationStepper';
@@ -152,7 +152,7 @@ export const ConfigurationsPage = ({ canEdit, configurations, datasets }: Config
 
         <CreationModal open={creationModalOpen} onOpenChange={setCreationModalOpen} onSubmit={handleCreationSubmit} />
         {editingConfig && draft ? (
-          <PanelRoot open onOpenChange={handlePanelOpenChange}>
+          <Panel.Root open onOpenChange={handlePanelOpenChange}>
             <ConfigurationPanel
               baseConfig={editingConfig}
               newConfig={draft}
@@ -168,7 +168,7 @@ export const ConfigurationsPage = ({ canEdit, configurations, datasets }: Config
                 onCancel={() => setUpdatedConfig(null)}
               />
             ) : null}
-          </PanelRoot>
+          </Panel.Root>
         ) : null}
       </Page.Content>
     </Page.Main>

--- a/packages/app-builder/src/components/ContinuousScreening/EditionValidationPanel.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/EditionValidationPanel.tsx
@@ -8,10 +8,8 @@ import { ScreeningAvailableFiltersAdapted } from '@app-builder/models/screening'
 import { useUpdateContinuousScreeningConfigurationMutation } from '@app-builder/queries/continuous-screening/update-configuration';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button } from 'ui-design-system';
-import { Icon } from 'ui-icons';
 import { Callout } from '../Callout';
-import { PanelContainer, PanelSharpFactory } from '../Panel/Panel';
+import { Panel, PanelSharpFactory } from '../Panel';
 import { DatasetSelectionSection } from './validation/DatasetSelectionSection';
 import { GeneralInfoSection } from './validation/GeneralInfoSection';
 import { ObjectMappingSection } from './validation/ObjectMappingSection';
@@ -55,30 +53,23 @@ export const EditionValidationPanel = ({
   };
 
   return (
-    <PanelContainer size="max" className="p-0 bg-surface-page overflow-y-auto flex flex-col">
-      <div className="flex items-center justify-between gap-md bg-surface-card h-16 px-md border-b border-grey-border shrink-0 sticky top-0">
-        <Button variant="secondary" mode="icon" onClick={panelSharp.actions.close}>
-          <Icon icon="arrow-left" className="size-4" />
-        </Button>
-        <span className="text-h1 me-auto font-bold">{t('continuousScreening:edition.validation.title')}</span>
-      </div>
-      <div className="p-lg grow flex flex-col gap-md">
-        <Callout bordered className="bg-surface-card mx-md">
-          {t('continuousScreening:edition.validation.validation_callout')}
-        </Callout>
-        <GeneralInfoSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
-        <DatasetSelectionSection updatedConfig={updatedConfig} baseConfig={baseConfig} datasets={datasets} />
-        <ScoringConfigurationSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
-        <ObjectMappingSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
-      </div>
-      <div className="shrink-0 sticky bottom-0 p-lg pt-sm flex justify-end bg-purple-99 gap-md bg-surface-page border-t border-grey-border">
-        <Button variant="secondary" onClick={() => onCancel(updatedConfig)}>
-          {t('common:cancel')}
-        </Button>
-        <Button variant="primary" onClick={handleValidateClick}>
-          {t('common:save')}
-        </Button>
-      </div>
-    </PanelContainer>
+    <Panel.Container size="medium">
+      <Panel.Content>
+        <Panel.Header>{t('continuousScreening:edition.validation.title')}</Panel.Header>
+        <div className="p-lg grow flex flex-col gap-md">
+          <Callout bordered className="bg-surface-card mx-md">
+            {t('continuousScreening:edition.validation.validation_callout')}
+          </Callout>
+          <GeneralInfoSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
+          <DatasetSelectionSection updatedConfig={updatedConfig} baseConfig={baseConfig} datasets={datasets} />
+          <ScoringConfigurationSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
+          <ObjectMappingSection updatedConfig={updatedConfig} baseConfig={baseConfig} />
+        </div>
+        <Panel.Footer>
+          <Panel.FooterButton variant="secondary" onClick={() => onCancel(updatedConfig)} label={t('common:cancel')} />
+          <Panel.FooterButton variant="primary" onClick={handleValidateClick} label={t('common:save')} />
+        </Panel.Footer>
+      </Panel.Content>
+    </Panel.Container>
   );
 };

--- a/packages/app-builder/src/components/ContinuousScreening/context/FormPagination.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/context/FormPagination.tsx
@@ -1,10 +1,10 @@
 import { useCallbackRef } from '@marble/shared';
 import { useTranslation } from 'react-i18next';
-import { Button } from 'ui-design-system';
+import { Button, cn, StickyComponent } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { ContinuousScreeningConfigurationStepper } from '../context/CreationStepper';
 
-export const FormPagination = ({ finalButtonText }: { finalButtonText?: string }) => {
+export const FormPagination = ({ finalButtonText, className }: { finalButtonText?: string; className?: string }) => {
   const { t } = useTranslation(['common', 'continuousScreening']);
   const creationStepper = ContinuousScreeningConfigurationStepper.useSharp();
   const currentStep = creationStepper.computed.currentStep.value;
@@ -26,19 +26,31 @@ export const FormPagination = ({ finalButtonText }: { finalButtonText?: string }
   });
 
   return (
-    <div className="shrink-0 sticky bottom-0 p-lg pt-sm flex justify-end gap-md bg-surface-page border-t border-grey-border shadow-sticky-top">
-      {creationStepper.computed.hasPrevious.value ? (
-        <Button variant="primary" appearance="stroked" onClick={handlePrevious}>
-          <Icon icon="arrow-left" className="size-4" />
-          {t('common:previous')}
-        </Button>
-      ) : null}
-      {creationStepper.computed.hasNext.value || mode !== 'view' ? (
-        <Button variant="primary" disabled={!creationStepper.computed.canGoNext.value} onClick={handleNext}>
-          {creationStepper.computed.hasNext.value ? t('common:next') : finalButtonText}
-          <Icon icon={creationStepper.computed.hasNext.value ? 'arrow-right' : 'tick'} className="size-4" />
-        </Button>
-      ) : null}
-    </div>
+    <StickyComponent inFlow="after" sentinelClassName="top-lg -translate-y-2xs">
+      <div
+        className={cn(
+          'sticky flex justify-end gap-md bottom-0 bg-surface-page -m-lg mt-auto p-lg border-t border-transparent sentinel-intersect:border-grey-border sentinel-intersect:shadow-sticky-bottom',
+          className,
+        )}
+      >
+        {creationStepper.computed.hasPrevious.value ? (
+          <Button variant="secondary" size="large" onClick={handlePrevious}>
+            <Icon icon="arrow-left" className="size-4" />
+            {t('common:previous')}
+          </Button>
+        ) : null}
+        {creationStepper.computed.hasNext.value || mode !== 'view' ? (
+          <Button
+            variant="primary"
+            size="large"
+            disabled={!creationStepper.computed.canGoNext.value}
+            onClick={handleNext}
+          >
+            {creationStepper.computed.hasNext.value ? t('common:next') : finalButtonText}
+            <Icon icon={creationStepper.computed.hasNext.value ? 'arrow-right' : 'tick'} className="size-4" />
+          </Button>
+        ) : null}
+      </div>
+    </StickyComponent>
   );
 };

--- a/packages/app-builder/src/components/ContinuousScreening/form/Content.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/form/Content.tsx
@@ -23,8 +23,8 @@ export const CreationContent = () => {
           .with(3, () => <ScoringConfiguration />)
           .otherwise(() => null)}
         <CreationContentRecap />
+        <FormPagination finalButtonText={t('continuousScreening:creation.save_configuration')} />
       </div>
-      <FormPagination finalButtonText={t('continuousScreening:creation.save_configuration')} />
     </div>
   );
 };

--- a/packages/app-builder/src/components/Data/SemanticTables/CreateTable/CreateTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/CreateTable/CreateTableDrawer.tsx
@@ -1,10 +1,11 @@
 import { Callout } from '@app-builder/components/Callout';
+import { Panel } from '@app-builder/components/Panel';
 import { useDataModel } from '@app-builder/services/data/data-model';
+import { handleSubmit } from '@app-builder/utils/form';
 import { useStore } from '@tanstack/react-form';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, ScrollAreaV2, Stepper, type StepperStep, Typo } from 'ui-design-system';
-import { Icon } from 'ui-icons';
+import { Stepper, type StepperStep, Typo } from 'ui-design-system';
 import { UnsavedChangesDialog } from '../Shared/UnsavedChangesDialog';
 import { CreateTableFormContext, useCreateTableForm } from './CreateTableContext';
 import { CreateTableEntityStep } from './CreateTableEntityStep';
@@ -137,90 +138,81 @@ export function CreateTableDrawer({
     }
   }
 
-  if (!open) return null;
+  if (!open) return;
 
   return (
     <CreateTableFormContext.Provider value={form}>
-      {/* Backdrop */}
-      <div
-        className="animate-overlay-show bg-grey-primary/20 fixed inset-0 z-40 backdrop-blur-xs"
-        onClick={handleBackdropClose}
-      />
-      {/* Drawer panel */}
-      <aside className="animate-slideRightAndFadeIn fixed right-0 top-0 z-50 h-full w-[max(1280px,70vw)] border-l border-grey-border shadow-lg">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
-          }}
-          className="bg-surface-card flex h-full flex-col overflow-y-auto"
-        >
-          <header className="flex shrink-0 items-center gap-md p-lg">
-            <button
-              type="button"
-              onClick={handleBackdropClose}
-              className="rounded-lg p-sm hover:bg-grey-border"
-              title={t('common:close')}
-            >
-              <Icon icon="x" className="size-5" />
-            </button>
-            <Typo variant="subtitle1" className="flex-1">
-              {t('data:create_table.title')}
-            </Typo>
-            <Stepper steps={steps} currentStep={currentStep} />
-          </header>
+      <Panel.Root
+        open={open}
+        onOpenChange={(state) => {
+          if (!state) {
+            handleBackdropClose();
+          }
+        }}
+      >
+        <form onSubmit={handleSubmit(form)}>
+          <Panel.Container size="large">
+            <Panel.Content>
+              <Panel.Header>
+                <div className="flex shrink-0 items-center gap-md">
+                  <Typo variant="subtitle1" className="flex-1">
+                    {t('data:create_table.title')}
+                  </Typo>
+                  <Stepper steps={steps} currentStep={currentStep} />
+                </div>
+              </Panel.Header>
 
-          <div className="flex-1 overflow-hidden flex flex-col px-lg">
-            {currentStep === 0 ? (
-              <ScrollAreaV2 className="flex-1">
-                <CreateTableEntityStep errorFields={tableErrorFields} />
-              </ScrollAreaV2>
-            ) : null}
-            {currentStep === 1 ? (
-              <CreateTableFieldsStep errorFieldIds={fieldErrorIds} hasError={validationErrors.length > 0} />
-            ) : null}
-            {currentStep === 2 ? (
-              <ScrollAreaV2 className="flex-1">
-                <CreateTableLinksStep errorLinkIds={linkErrorIds} hasError={validationErrors.length > 0} />
-              </ScrollAreaV2>
-            ) : null}
-          </div>
-
-          <footer className="flex shrink-0 justify-between gap-md border-t border-grey-border p-lg">
-            {validationErrors.length > 0 ? (
-              <Callout color="red" icon="lightbulb" iconColor="red">
-                <ul className="flex flex-col gap-xs ps-md">
-                  {validationErrors.map((error, index) => (
-                    <li key={`${error.kind}-${index}`}>{error.message}</li>
-                  ))}
-                </ul>
-              </Callout>
-            ) : (
-              <div />
-            )}
-            <div className="flex justify-end gap-md">
-              <Button variant="secondary" appearance="stroked" onClick={handleBackdropClose}>
-                {t('common:cancel')}
-              </Button>
-              {currentStep > 0 ? (
-                <Button variant="secondary" appearance="stroked" onClick={handleBack}>
-                  {t('data:create_table.button_back')}
-                </Button>
-              ) : null}
-              {currentStep === 2 ? (
-                <Button variant="primary" type="submit">
-                  {t('data:create_table.button_save_table')}
-                </Button>
-              ) : (
-                <Button variant="primary" onClick={handleNext} type="button">
-                  {t('data:create_table.button_next')}
-                </Button>
-              )}
-            </div>
-          </footer>
+              <div className="flex-1 flex flex-col">
+                {currentStep === 0 ? <CreateTableEntityStep errorFields={tableErrorFields} /> : null}
+                {currentStep === 1 ? (
+                  <CreateTableFieldsStep errorFieldIds={fieldErrorIds} hasError={validationErrors.length > 0} />
+                ) : null}
+                {currentStep === 2 ? (
+                  <CreateTableLinksStep errorLinkIds={linkErrorIds} hasError={validationErrors.length > 0} />
+                ) : null}
+              </div>
+              <Panel.Footer>
+                {validationErrors.length > 0 ? (
+                  <Callout color="red" icon="lightbulb" iconColor="red">
+                    <ul className="flex flex-col gap-xs ps-md">
+                      {validationErrors.map((error, index) => (
+                        <li key={`${error.kind}-${index}`}>{error.message}</li>
+                      ))}
+                    </ul>
+                  </Callout>
+                ) : (
+                  <div />
+                )}
+                <div className="flex justify-end gap-md ms-auto">
+                  <Panel.FooterButton variant="secondary" onClick={handleBackdropClose} label={t('common:cancel')} />
+                  {currentStep > 0 ? (
+                    <Panel.FooterButton
+                      variant="secondary"
+                      onClick={handleBack}
+                      label={t('data:create_table.button_back')}
+                    />
+                  ) : null}
+                  {currentStep === 2 ? (
+                    <Panel.FooterButton
+                      variant="primary"
+                      type="submit"
+                      label={t('data:create_table.button_save_table')}
+                    />
+                  ) : (
+                    <Panel.FooterButton
+                      variant="primary"
+                      onClick={handleNext}
+                      type="button"
+                      label={t('data:create_table.button_next')}
+                    />
+                  )}
+                </div>
+              </Panel.Footer>
+            </Panel.Content>
+          </Panel.Container>
         </form>
-      </aside>
+      </Panel.Root>
+
       <UnsavedChangesDialog
         open={isUnsavedChangesDialogOpen}
         onOpenChange={setIsUnsavedChangesDialogOpen}

--- a/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/EditTable/EditTableDrawer.tsx
@@ -1,4 +1,5 @@
 import { Callout } from '@app-builder/components/Callout';
+import { Panel } from '@app-builder/components/Panel';
 import { type DataModelField } from '@app-builder/models';
 import { type LinkToSingle, type TableModel } from '@app-builder/models/data-model';
 import { useDataModel } from '@app-builder/services/data/data-model';
@@ -294,73 +295,74 @@ export function EditTableDrawer({
         removeField,
       }}
     >
-      {/* Backdrop */}
-      <div
-        className="animate-overlay-show bg-grey-primary/20 fixed inset-0 z-40 backdrop-blur-xs"
-        onClick={requestClose}
-      />
-      {/* Drawer panel */}
-      <aside className="animate-slideRightAndFadeIn fixed right-0 top-0 z-50 h-full w-[max(1280px,70vw)] border-l border-grey-border shadow-lg">
-        <div ref={containerRef} className="bg-surface-card flex h-full flex-col overflow-y-auto">
-          <header className="flex shrink-0 items-center gap-md border-b border-grey-border p-lg">
-            <button type="button" onClick={requestClose} className="rounded-lg p-sm hover:bg-grey-border">
-              <Icon icon="x" className="size-5" />
-            </button>
-            <span className="text-l">{t('data:edit_table.header_prefix')}</span>
-            <EditableAlias alias={tableState.alias} onChange={(alias) => updateTableState(tableModel.id, { alias })} />
-            {(hasTableNameError || (tableState.alias && tableState.alias !== tableState.name)) && (
-              <span
-                className={cn(
-                  'text-s text-grey-secondary',
-                  hasTableNameError && 'text-red-primary underline decoration-red-primary decoration-wavy',
+      <Panel.Root
+        open={open}
+        onOpenChange={(state) => {
+          if (!state) {
+            requestClose();
+          }
+        }}
+      >
+        <Panel.Container size="large">
+          <Panel.Content>
+            <Panel.Header>
+              <div className="flex shrink-0 items-center gap-md">
+                <span>{t('data:edit_table.header_prefix')}</span>
+                <EditableAlias
+                  alias={tableState.alias}
+                  onChange={(alias) => updateTableState(tableModel.id, { alias })}
+                />
+                {(hasTableNameError || (tableState.alias && tableState.alias !== tableState.name)) && (
+                  <span
+                    className={cn(
+                      'text-s text-grey-secondary',
+                      hasTableNameError && 'text-red-primary underline decoration-red-primary decoration-wavy',
+                    )}
+                  >
+                    ({tableState.name})
+                  </span>
                 )}
-              >
-                ({tableState.name})
-              </span>
-            )}
 
-            <EntityTypeMenu
-              entityType={tableState.entityType}
-              entitySubtype={tableState.subEntity}
-              isChanged={isSemanticTypeChanged}
-              onSelect={(entityType, subEntity) => updateTableState(tableModel.id, { entityType, subEntity })}
-            />
-          </header>
+                <EntityTypeMenu
+                  entityType={tableState.entityType}
+                  entitySubtype={tableState.subEntity}
+                  isChanged={isSemanticTypeChanged}
+                  onSelect={(entityType, subEntity) => updateTableState(tableModel.id, { entityType, subEntity })}
+                />
+              </div>
+            </Panel.Header>
 
-          <div className="flex-1 overflow-hidden flex flex-col px-lg py-lg">
-            <FormTable
-              tableId={tableModel.id}
-              errorFieldIds={fieldErrorIds}
-              errorLinkIds={linkErrorIds}
-              destinationTableOptions={destinationTableOptions}
-            />
-          </div>
-
-          <footer className="flex shrink-0 items-start justify-between gap-md border-t border-grey-border p-lg">
-            {validationErrors.length > 0 || isSemanticTypeChanged ? (
-              <Callout color="red" icon="lightbulb" iconColor="red" className="min-w-0 flex-1">
-                <ul className="flex flex-col gap-xs ps-md">
-                  {validationErrors.map((error, index) => (
-                    <li key={`${error.kind}-${index}`}>{error.message}</li>
-                  ))}
-                  {isSemanticTypeChanged ? <li>{t('data:edit_table.entity_type_change_warning')}</li> : null}
-                </ul>
-              </Callout>
-            ) : (
-              <div className="min-w-0 flex-1" />
-            )}
-
-            <div className="flex shrink-0 items-center gap-md self-center">
-              <Button variant="secondary" appearance="stroked" onClick={requestClose}>
-                {t('common:cancel')}
-              </Button>
-              <Button variant="primary" onClick={handleSave}>
-                {t('data:edit_table.button_accept')}
-              </Button>
+            <div className="flex-1 overflow-hidden flex flex-col">
+              <FormTable
+                tableId={tableModel.id}
+                errorFieldIds={fieldErrorIds}
+                errorLinkIds={linkErrorIds}
+                destinationTableOptions={destinationTableOptions}
+              />
             </div>
-          </footer>
-        </div>
-      </aside>
+            <Panel.Footer>
+              {validationErrors.length > 0 || isSemanticTypeChanged ? (
+                <Callout color="red" icon="lightbulb" iconColor="red" className="min-w-0 flex-1">
+                  <ul className="flex flex-col gap-xs ps-md">
+                    {validationErrors.map((error, index) => (
+                      <li key={`${error.kind}-${index}`}>{error.message}</li>
+                    ))}
+                    {isSemanticTypeChanged ? <li>{t('data:edit_table.entity_type_change_warning')}</li> : null}
+                  </ul>
+                </Callout>
+              ) : (
+                <div className="min-w-0 flex-1" />
+              )}
+
+              <div className="flex shrink-0 items-center gap-md self-center ms-auto">
+                <Panel.FooterButton variant="secondary" onClick={requestClose} label={t('common:cancel')} />
+                <Panel.FooterButton variant="primary" onClick={handleSave} label={t('data:edit_table.button_accept')} />
+              </div>
+            </Panel.Footer>
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
+
       <UnsavedChangesDialog
         open={isUnsavedChangesDialogOpen}
         onOpenChange={setIsUnsavedChangesDialogOpen}

--- a/packages/app-builder/src/components/Data/SemanticTables/Flow/TableRecordPreviewDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Flow/TableRecordPreviewDrawer.tsx
@@ -1,5 +1,5 @@
 import { DataFields } from '@app-builder/components/Data/DataVisualisation/DataFields';
-import { PanelContainer, PanelContent, PanelHeader, PanelRoot } from '@app-builder/components/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { Spinner } from '@app-builder/components/Spinner';
 import { useObjectDetailsQuery } from '@app-builder/queries/data/get-object-details';
 import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
@@ -42,54 +42,55 @@ export function TableRecordPreviewDrawer({ open, onOpenChange, tableName }: Tabl
   };
 
   return (
-    <PanelRoot open={open} onOpenChange={onOpenChange}>
-      <PanelContainer size="4xl" className="z-50 p-0">
-        <PanelHeader className="border-b border-grey-border px-lg py-md">
-          {t('data:viewer.view_ingested_data')}
-        </PanelHeader>
-        <PanelContent className="flex flex-col gap-lg px-lg py-lg">
-          <div className="flex items-center gap-sm">
-            <Tag color="grey">{tableName}</Tag>
-          </div>
+    <Panel.Root open={open} onOpenChange={onOpenChange}>
+      <Panel.Container size="medium" className="z-50 p-0">
+        <Panel.Content>
+          <Panel.Header>{t('data:viewer.view_ingested_data')}</Panel.Header>
 
-          <form className="flex items-end gap-sm" onSubmit={handleSubmit}>
-            <div className="flex flex-1 flex-col gap-xs">
-              <label htmlFor={`objectIdField-${tableName}`} className="text-s">
-                {t('data:viewer.object_id')}
-              </label>
-              <Input
-                ref={inputRef}
-                id={`objectIdField-${tableName}`}
-                name="objectId"
-                type="text"
-                value={objectId}
-                onChange={(event) => setObjectId(event.target.value)}
-              />
+          <div className="flex flex-col gap-lg">
+            <div className="flex items-center gap-sm">
+              <Tag color="grey">{tableName}</Tag>
             </div>
-            <Button type="submit" variant="primary" disabled={!trimmedObjectId || isLoading} className="h-10">
-              {t('common:search')}
-            </Button>
-          </form>
 
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {isLoading ? (
-              <div className="flex min-h-32 items-center justify-center">
-                <Spinner className="size-5" />
+            <form className="flex items-end gap-sm" onSubmit={handleSubmit}>
+              <div className="flex flex-1 flex-col gap-xs">
+                <label htmlFor={`objectIdField-${tableName}`} className="text-s">
+                  {t('data:viewer.object_id')}
+                </label>
+                <Input
+                  ref={inputRef}
+                  id={`objectIdField-${tableName}`}
+                  name="objectId"
+                  type="text"
+                  value={objectId}
+                  onChange={(event) => setObjectId(event.target.value)}
+                />
               </div>
-            ) : searchedObjectId && query.data !== undefined ? (
-              query.data ? (
-                <div className="rounded-md border border-grey-border bg-grey-background-light p-md">
-                  <DataFields table={tableName} object={query.data} options={{ showHeader: true }} />
+              <Button type="submit" variant="primary" disabled={!trimmedObjectId || isLoading} className="h-10">
+                {t('common:search')}
+              </Button>
+            </form>
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {isLoading ? (
+                <div className="flex min-h-32 items-center justify-center">
+                  <Spinner className="size-5" />
                 </div>
-              ) : (
-                <div className="rounded-sm border border-grey-border bg-surface-card p-md text-center">
-                  {t('data:viewer.no_object_found', { tableName, objectId: searchedObjectId })}
-                </div>
-              )
-            ) : null}
+              ) : searchedObjectId && query.data !== undefined ? (
+                query.data ? (
+                  <div className="rounded-md border border-grey-border bg-grey-background-light p-md">
+                    <DataFields table={tableName} object={query.data} options={{ showHeader: true }} />
+                  </div>
+                ) : (
+                  <div className="rounded-sm border border-grey-border bg-surface-card p-md text-center">
+                    {t('data:viewer.no_object_found', { tableName, objectId: searchedObjectId })}
+                  </div>
+                )
+              ) : null}
+            </div>
           </div>
-        </PanelContent>
-      </PanelContainer>
-    </PanelRoot>
+        </Panel.Content>
+      </Panel.Container>
+    </Panel.Root>
   );
 }

--- a/packages/app-builder/src/components/Data/SemanticTables/UploadData/UploadTableDrawer.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/UploadData/UploadTableDrawer.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from '@app-builder/components/ExternalLink';
+import { Panel } from '@app-builder/components/Panel';
 import { LoadingIcon } from '@app-builder/components/Spinner';
 import { type TableModel } from '@app-builder/models';
 import { useUploadTableQuery } from '@app-builder/queries/data/upload-table';
@@ -41,70 +42,139 @@ export function UploadTableDrawer({
   const uploadLogs = uploadLogsQuery.data ?? [];
 
   return (
-    <>
-      {/* Backdrop */}
-      <div className="animate-overlay-show bg-grey-primary/20 fixed inset-0 z-40 backdrop-blur-xs" onClick={onClose} />
-      {/* Drawer panel */}
-      <aside className="animate-slideRightAndFadeIn fixed right-0 top-0 z-50 h-full w-[max(900px,50vw)] border-l border-grey-border shadow-lg">
-        <div className="bg-surface-card flex h-full flex-col overflow-hidden">
-          <header className="flex shrink-0 items-center gap-md border-b border-grey-border p-lg">
-            <button type="button" onClick={onClose} className="rounded-lg p-sm hover:bg-grey-border">
-              <Icon icon="x" className="size-5" />
-            </button>
-            <Icon icon="upload" className="size-5" />
-            <Typo variant="subtitle1">{t('upload:upload_cta', { replace: { objectType: tableName } })}</Typo>
-            <Tag color="grey">{tableName}</Tag>
-          </header>
-
-          <div className="flex-1 overflow-y-auto p-lg">
-            <div className="flex flex-col gap-lg">
-              <p className="text-s whitespace-pre-wrap text-grey-secondary">
-                <Trans
-                  t={t}
-                  i18nKey="upload:upload_callout_1"
-                  components={{
-                    DocLink: <ExternalLink href={ingestingDataByCsvDocHref} />,
-                  }}
-                  values={{ objectType: tableName }}
-                />
-                <br />
-                {t('upload:upload_callout_2')}
-              </p>
-
-              <div className="flex">
-                <a
-                  href={generateCsvTemplateLink(tableModel)}
-                  download={`${tableName}_template.csv`}
-                  className="text-s flex flex-row items-center justify-center gap-xs rounded-sm border border-solid px-sm py-xs font-semibold outline-hidden hover:bg-grey-background active:bg-grey-border bg-surface-card border-grey-border text-grey-primary disabled:text-grey-secondary disabled:border-grey-background disabled:bg-grey-background focus:border-purple-primary"
-                >
-                  <Icon icon="download" className="me-sm size-6" />
-                  {t('upload:download_template_cta')}
-                </a>
-              </div>
-
-              <UploadForm objectType={tableName} onSuccess={handleUploadSuccess} />
-
-              {uploadLogs.length > 0 ? (
-                <div className="flex flex-col gap-sm">
-                  <div className="flex items-center justify-between">
-                    <Typo variant="subtitle2">{t('upload:past_uploads')}</Typo>
-                    <Button
-                      variant="secondary"
-                      size="small"
-                      onClick={handleRefresh}
-                      disabled={uploadLogsQuery.isFetching}
-                      aria-label={t('upload:refresh')}
-                    >
-                      <LoadingIcon icon="restart-alt" loading={uploadLogsQuery.isFetching} className="size-4" />
-                    </Button>
-                  </div>
-                  <PastUploads uploadLogs={uploadLogs} />
-                </div>
-              ) : null}
+    <Panel.Root
+      open={open}
+      onOpenChange={(state) => {
+        if (!state) {
+          onClose();
+        }
+      }}
+    >
+      <Panel.Container size="medium">
+        <Panel.Content>
+          <Panel.Header>
+            <div className="flex shrink-0 items-center gap-md">
+              <Icon icon="upload" className="size-5" />
+              <Typo variant="subtitle1">{t('upload:upload_cta', { replace: { objectType: tableName } })}</Typo>
+              <Tag color="grey">{tableName}</Tag>
             </div>
+          </Panel.Header>
+
+          <div className="flex flex-col gap-lg">
+            <p className="text-s whitespace-pre-wrap text-grey-secondary">
+              <Trans
+                t={t}
+                i18nKey="upload:upload_callout_1"
+                components={{
+                  DocLink: <ExternalLink href={ingestingDataByCsvDocHref} />,
+                }}
+                values={{ objectType: tableName }}
+              />
+              <br />
+              {t('upload:upload_callout_2')}
+            </p>
+
+            <div className="flex">
+              <a
+                href={generateCsvTemplateLink(tableModel)}
+                download={`${tableName}_template.csv`}
+                className="text-s flex flex-row items-center justify-center gap-xs rounded-sm border border-solid px-sm py-xs font-semibold outline-hidden hover:bg-grey-background active:bg-grey-border bg-surface-card border-grey-border text-grey-primary disabled:text-grey-secondary disabled:border-grey-background disabled:bg-grey-background focus:border-purple-primary"
+              >
+                <Icon icon="download" className="me-sm size-6" />
+                {t('upload:download_template_cta')}
+              </a>
+            </div>
+
+            <UploadForm objectType={tableName} onSuccess={handleUploadSuccess} />
+
+            {uploadLogs.length > 0 ? (
+              <div className="flex flex-col gap-sm">
+                <div className="flex items-center justify-between">
+                  <Typo variant="subtitle2">{t('upload:past_uploads')}</Typo>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={handleRefresh}
+                    disabled={uploadLogsQuery.isFetching}
+                    aria-label={t('upload:refresh')}
+                  >
+                    <LoadingIcon icon="restart-alt" loading={uploadLogsQuery.isFetching} className="size-4" />
+                  </Button>
+                </div>
+                <PastUploads uploadLogs={uploadLogs} />
+              </div>
+            ) : null}
           </div>
-        </div>
-      </aside>
-    </>
+        </Panel.Content>
+      </Panel.Container>
+    </Panel.Root>
   );
+
+  // return (
+  //   <>
+  //     {/* Backdrop */}
+  //     <div className="animate-overlay-show bg-grey-primary/20 fixed inset-0 z-40 backdrop-blur-xs" onClick={onClose} />
+  //     {/* Drawer panel */}
+  //     <aside className="animate-slideRightAndFadeIn fixed right-0 top-0 z-50 h-full w-[max(900px,50vw)] border-l border-grey-border shadow-lg">
+  //       <div className="bg-surface-card flex h-full flex-col overflow-hidden">
+  //         <header className="flex shrink-0 items-center gap-md border-b border-grey-border p-lg">
+  //           <button type="button" onClick={onClose} className="rounded-lg p-sm hover:bg-grey-border">
+  //             <Icon icon="x" className="size-5" />
+  //           </button>
+  //           <Icon icon="upload" className="size-5" />
+  //           <Typo variant="subtitle1">{t('upload:upload_cta', { replace: { objectType: tableName } })}</Typo>
+  //           <Tag color="grey">{tableName}</Tag>
+  //         </header>
+
+  //         <div className="flex-1 overflow-y-auto p-lg">
+  //           <div className="flex flex-col gap-lg">
+  //             <p className="text-s whitespace-pre-wrap text-grey-secondary">
+  //               <Trans
+  //                 t={t}
+  //                 i18nKey="upload:upload_callout_1"
+  //                 components={{
+  //                   DocLink: <ExternalLink href={ingestingDataByCsvDocHref} />,
+  //                 }}
+  //                 values={{ objectType: tableName }}
+  //               />
+  //               <br />
+  //               {t('upload:upload_callout_2')}
+  //             </p>
+
+  //             <div className="flex">
+  //               <a
+  //                 href={generateCsvTemplateLink(tableModel)}
+  //                 download={`${tableName}_template.csv`}
+  //                 className="text-s flex flex-row items-center justify-center gap-xs rounded-sm border border-solid px-sm py-xs font-semibold outline-hidden hover:bg-grey-background active:bg-grey-border bg-surface-card border-grey-border text-grey-primary disabled:text-grey-secondary disabled:border-grey-background disabled:bg-grey-background focus:border-purple-primary"
+  //               >
+  //                 <Icon icon="download" className="me-sm size-6" />
+  //                 {t('upload:download_template_cta')}
+  //               </a>
+  //             </div>
+
+  //             <UploadForm objectType={tableName} onSuccess={handleUploadSuccess} />
+
+  //             {uploadLogs.length > 0 ? (
+  //               <div className="flex flex-col gap-sm">
+  //                 <div className="flex items-center justify-between">
+  //                   <Typo variant="subtitle2">{t('upload:past_uploads')}</Typo>
+  //                   <Button
+  //                     variant="secondary"
+  //                     size="small"
+  //                     onClick={handleRefresh}
+  //                     disabled={uploadLogsQuery.isFetching}
+  //                     aria-label={t('upload:refresh')}
+  //                   >
+  //                     <LoadingIcon icon="restart-alt" loading={uploadLogsQuery.isFetching} className="size-4" />
+  //                   </Button>
+  //                 </div>
+  //                 <PastUploads uploadLogs={uploadLogs} />
+  //               </div>
+  //             ) : null}
+  //           </div>
+  //         </div>
+  //       </div>
+  //     </aside>
+  //   </>
+  // );
 }

--- a/packages/app-builder/src/components/Panel/Panel.tsx
+++ b/packages/app-builder/src/components/Panel/Panel.tsx
@@ -1,22 +1,19 @@
-import { type ReactNode, useEffect, useRef } from 'react';
+import { VariantProps } from 'class-variance-authority';
+import { IconProps } from 'packages/ui-icons/src/Icon';
+import { forwardRef, type ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { createSharpFactory } from 'sharpstate';
-import { cn, Typo } from 'ui-design-system';
+import { match } from 'ts-pattern';
+import { Button, CtaV2ClassName, cn, StickyComponent, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { PanelOverlay } from './PanelOverlay';
 
-export type PanelSize = 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl' | '4xl' | '5xl' | 'max';
+export type PanelSize = 'small' | 'medium' | 'large';
 
 const sizeClasses: Record<PanelSize, string> = {
-  sm: 'max-w-sm',
-  md: 'max-w-md',
-  lg: 'max-w-lg',
-  xl: 'max-w-xl',
-  xxl: 'max-w-2xl',
-  xxxl: 'max-w-3xl',
-  '4xl': 'max-w-4xl',
-  '5xl': 'max-w-5xl',
-  max: 'max-w-[1000px]',
+  small: 'max-w-[calc(100vw_/_3)]',
+  medium: 'max-w-[50vw]',
+  large: 'max-w-[calc(100vw_*_(2_/_3))]',
 };
 
 type OnOpenChangeFn = (state: boolean) => void;
@@ -60,7 +57,7 @@ export const PanelSharpFactory = createSharpFactory({
   },
 });
 
-export function PanelRoot({ children, open, onOpenChange }: PanelRootProps) {
+function PanelRoot({ children, open, onOpenChange }: PanelRootProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const sharp = PanelSharpFactory.createSharp({
     open,
@@ -73,6 +70,10 @@ export function PanelRoot({ children, open, onOpenChange }: PanelRootProps) {
     }
     sharp.value.isOpen = !!open;
   }, [sharp, open]);
+
+  useEffect(() => {
+    sharp.value.onOpenChange = onOpenChange;
+  }, [onOpenChange]);
 
   return (
     <PanelSharpFactory.Provider value={sharp}>
@@ -95,7 +96,7 @@ interface PanelContainerProps {
   size?: PanelSize;
 }
 
-export function PanelContainer({ children, className, size = 'md' }: PanelContainerProps) {
+function PanelContainer({ children, className, size = 'small' }: PanelContainerProps) {
   const sharp = PanelSharpFactory.useSharp();
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -150,7 +151,7 @@ export function PanelContainer({ children, className, size = 'md' }: PanelContai
     <div
       ref={panelRef}
       className={cn(
-        'fixed inset-y-0 z-20 right-0 bg-surface-card border-l border-grey-border overflow-y-auto p-lg w-full flex flex-col animate-slideRightAndFadeIn',
+        'fixed inset-y-0 z-20 right-0 bg-surface-card border-l border-grey-border w-full flex flex-col animate-slideRightAndFadeIn overflow-y-auto',
         sizeClasses[size],
         className,
       )}
@@ -167,19 +168,27 @@ interface PanelHeaderProps {
   className?: string;
 }
 
-export function PanelHeader({ children, className }: PanelHeaderProps) {
+function PanelHeader({ children, className }: PanelHeaderProps) {
   const sharp = PanelSharpFactory.useSharp();
 
   return (
-    <div className={cn('flex items-center justify-between pb-md', className)}>
-      <Typo variant="title2">{children}</Typo>
-      <Icon
-        icon="cross"
-        className="size-5 cursor-pointer text-grey-secondary hover:text-grey-primary"
-        onClick={sharp.actions.close}
-        aria-label="Close panel"
-      />
-    </div>
+    <StickyComponent sentinelClassName="h-0 top-0">
+      <div
+        className={cn(
+          'sticky top-0 -m-lg mb-0 p-lg flex gap-md items-center bg-surface-card z-1 border-b border-transparent sentinel-intersect:border-grey-border sentinel-intersect:shadow-sticky-top',
+        )}
+      >
+        <Icon
+          icon="x"
+          className="size-6 cursor-pointer text-grey-secondary hover:text-grey-primary"
+          onClick={sharp.actions.close}
+          aria-label="Close panel"
+        />
+        <Typo as="div" variant="title2" className={cn('grow', className)}>
+          {children}
+        </Typo>
+      </div>
+    </StickyComponent>
   );
 }
 
@@ -189,7 +198,7 @@ interface PanelContentProps {
 }
 
 export function PanelContent({ children, className }: PanelContentProps) {
-  return <div className={cn('flex-1 overflow-y-auto pb-md', className)}>{children}</div>;
+  return <div className={cn('relative min-h-screen p-lg flex flex-col grow', className)}>{children}</div>;
 }
 
 interface PanelFooterProps {
@@ -197,6 +206,92 @@ interface PanelFooterProps {
   className?: string;
 }
 
-export function PanelFooter({ children, className }: PanelFooterProps) {
-  return <div className={cn('pt-md border-t border-grey-border mt-auto', className)}>{children}</div>;
+function PanelFooter({ children, className }: PanelFooterProps) {
+  return (
+    <StickyComponent inFlow="after" sentinelClassName="top-lg -translate-y-2xs">
+      <div
+        className={cn(
+          'sticky flex justify-end gap-md bottom-0 bg-surface-card -m-lg mt-auto p-lg border-t border-transparent sentinel-intersect:border-grey-border sentinel-intersect:shadow-sticky-bottom',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </StickyComponent>
+  );
 }
+
+type PanelButtonVariant = Extract<
+  VariantProps<typeof CtaV2ClassName>['variant'],
+  'primary' | 'destructive' | 'secondary'
+>;
+type PanelButtonAppearance = Extract<VariantProps<typeof CtaV2ClassName>['appearance'], 'stroked' | 'filled'>;
+
+type PanelFooterButtonProps = Omit<React.ComponentPropsWithoutRef<typeof Button>, 'variant' | 'appearance' | 'size'> & {
+  label: string;
+  variant?: PanelButtonVariant;
+  isLoading?: boolean;
+  leadingIcon?: IconProps['icon'];
+  trailingIcon?: IconProps['icon'];
+  children?: ReactNode;
+};
+
+const PanelFooterButton = forwardRef<HTMLButtonElement, PanelFooterButtonProps>(function ModalFooterButton(
+  { variant, isLoading, leadingIcon, trailingIcon, disabled, label, children, className, ...props },
+  ref,
+) {
+  const { variant: buttonVariant, appearance } = match(variant)
+    .with('secondary', () => ({
+      variant: 'secondary' as PanelButtonVariant,
+      appearance: 'stroked' as PanelButtonAppearance,
+    }))
+    .with('destructive', () => ({
+      variant: 'destructive' as PanelButtonVariant,
+      appearance: 'filled' as PanelButtonAppearance,
+    }))
+    .otherwise(() => ({
+      variant: 'primary' as PanelButtonVariant,
+      appearance: 'filled' as PanelButtonAppearance,
+    }));
+
+  return (
+    <Button
+      ref={ref}
+      variant={buttonVariant}
+      appearance={appearance}
+      disabled={disabled || isLoading}
+      aria-busy={isLoading || undefined}
+      aria-disabled={disabled || isLoading || undefined}
+      size="large"
+      className={cn(isLoading && 'pointer-events-none', className)}
+      {...props}
+    >
+      {leadingIcon ? (
+        isLoading ? (
+          <Icon icon="spinner" className="size-5 animate-spin" />
+        ) : (
+          <Icon icon={leadingIcon} className="size-5" />
+        )
+      ) : null}
+      {label}
+      {children}
+      {trailingIcon ? (
+        isLoading && !leadingIcon ? (
+          <Icon icon="spinner" className="size-5 animate-spin" />
+        ) : (
+          <Icon icon={trailingIcon} className="size-5" />
+        )
+      ) : null}
+      {isLoading && !leadingIcon && !trailingIcon ? <Icon icon="spinner" className="size-5 animate-spin" /> : null}
+    </Button>
+  );
+});
+
+export const Panel = {
+  Root: PanelRoot,
+  Container: PanelContainer,
+  Content: PanelContent,
+  Header: PanelHeader,
+  Footer: PanelFooter,
+  FooterButton: PanelFooterButton,
+};

--- a/packages/app-builder/src/components/Panel/index.ts
+++ b/packages/app-builder/src/components/Panel/index.ts
@@ -1,2 +1,2 @@
-export { PanelContainer, PanelContent, PanelFooter, PanelHeader, PanelRoot, type PanelSize } from './Panel';
+export { Panel, PanelSharpFactory, type PanelSize } from './Panel';
 export { PanelOverlay } from './PanelOverlay';

--- a/packages/app-builder/src/components/Scenario/Rules/ScoreModifier.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/ScoreModifier.tsx
@@ -1,17 +1,11 @@
 import { type ComponentProps } from 'react';
-import { cn } from 'ui-design-system';
+import { Tag } from 'ui-design-system';
 
 export const ScoreModifier = ({ score, className, ...rest }: ComponentProps<'span'> & { score: number }) => {
   return (
-    <span
-      {...rest}
-      className={cn(
-        'bg-purple-background text-purple-primary inline-flex items-center gap-xs rounded-full px-xs py-2xs text-xs font-normal',
-        className,
-      )}
-    >
+    <Tag color="grey">
       <span>{score >= 0 ? '+' : '-'}</span>
       <span>{Math.abs(score)}</span>
-    </span>
+    </Tag>
   );
 };

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/ViewSavedResults.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/ViewSavedResults.tsx
@@ -1,6 +1,6 @@
 import { CursorPaginationButtons, usePaginationsButton } from '@app-builder/components/Decisions/PaginationButtons';
 import { DateRangeFilter } from '@app-builder/components/Filters';
-import { PanelContainer, PanelContent, PanelFooter, PanelRoot } from '@app-builder/components/Panel/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { IconDot } from '@app-builder/components/Screenings/MatchCard/match-card-entity-components';
 import { SEARCH_ENTITIES, SearchableSchema } from '@app-builder/constants/screening-entity';
 import { User } from '@app-builder/models';
@@ -18,7 +18,7 @@ import { ScreeningConfigBodySectionDto } from 'marble-api';
 import { Fragment, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Temporal } from 'temporal-polyfill';
-import { Avatar, Button, Collapsible, cn, MenuCommand, Separator, Switch, Tag, Typo } from 'ui-design-system';
+import { Avatar, Button, Collapsible, cn, MenuCommand, Separator, Switch, Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import FreeformMatchCard from './FreeformMatchCard';
 
@@ -98,53 +98,41 @@ export const ViewSavedResults = () => {
       <Button variant="primary" appearance="stroked" onClick={() => setOpen(true)}>
         {t('screenings:freeform_search.saved_results.button')}
       </Button>
-      <PanelRoot open={open} onOpenChange={setOpen}>
-        <PanelContainer size="5xl">
-          <div className="flex items-center gap-sm pb-md">
-            <button
-              type="button"
-              aria-label={t('common:close')}
-              className="cursor-pointer text-grey-secondary hover:text-grey-primary"
-              onClick={() => setOpen(false)}
-            >
-              <Icon icon="cross" className="size-5" />
-            </button>
-            <Typo variant="title2" className="text-grey-primary">
-              {t('screenings:freeform_search.saved_results.title')}
-            </Typo>
-          </div>
+      <Panel.Root open={open} onOpenChange={setOpen}>
+        <Panel.Container size="medium">
+          <Panel.Content>
+            <Panel.Header>{t('screenings:freeform_search.saved_results.title')}</Panel.Header>
 
-          <div className="grid grid-cols-3 gap-md pb-md">
-            <PeriodFilter
-              value={dateRange}
-              onChange={(v) => {
-                setDateRange(v);
-                resetPagination();
-              }}
-            />
-            <OwnerFilter
-              value={ownerId}
-              onChange={(v) => {
-                setOwnerId(v);
-                resetPagination();
-              }}
-            />
-            <div className="flex h-10 items-center gap-sm">
-              <Switch
-                id="saved-only"
-                checked={isSaved}
-                onCheckedChange={(value) => {
-                  setIsSaved(value);
+            <div className="grid grid-cols-3 gap-md pb-md">
+              <PeriodFilter
+                value={dateRange}
+                onChange={(v) => {
+                  setDateRange(v);
                   resetPagination();
                 }}
               />
-              <label htmlFor="saved-only" className="text-s text-grey-primary">
-                {t('screenings:freeform_search.saved_results.saved_only')}
-              </label>
+              <OwnerFilter
+                value={ownerId}
+                onChange={(v) => {
+                  setOwnerId(v);
+                  resetPagination();
+                }}
+              />
+              <div className="flex h-10 items-center gap-sm">
+                <Switch
+                  id="saved-only"
+                  checked={isSaved}
+                  onCheckedChange={(value) => {
+                    setIsSaved(value);
+                    resetPagination();
+                  }}
+                />
+                <label htmlFor="saved-only" className="text-s text-grey-primary">
+                  {t('screenings:freeform_search.saved_results.saved_only')}
+                </label>
+              </div>
             </div>
-          </div>
 
-          <PanelContent>
             {query.isLoading ? (
               <div className="text-s text-grey-secondary p-md">
                 {t('screenings:freeform_search.saved_results.loading')}
@@ -164,31 +152,30 @@ export const ViewSavedResults = () => {
                 ))}
               </ul>
             )}
-          </PanelContent>
-
-          <PanelFooter>
-            <div className="flex w-full items-center justify-between">
-              <SavedResultsPageSizeSelector
-                limit={limit}
-                onLimitChange={(pageSize) => setPaginationParams({ limit: pageSize })}
-              />
-              <CursorPaginationButtons
-                items={paginationItems}
-                onPaginationChange={(newPaginationParams) =>
-                  setPaginationParams((prev) => ({
-                    limit: prev.limit ?? 25,
-                    ...newPaginationParams,
-                  }))
-                }
-                paginationState={paginationState}
-                boundariesDisplay="dates"
-                hasNextPage={hasNextPage}
-                itemsPerPage={limit}
-              />
-            </div>
-          </PanelFooter>
-        </PanelContainer>
-      </PanelRoot>
+            <Panel.Footer>
+              <div className="flex w-full items-center justify-between">
+                <SavedResultsPageSizeSelector
+                  limit={limit}
+                  onLimitChange={(pageSize) => setPaginationParams({ limit: pageSize })}
+                />
+                <CursorPaginationButtons
+                  items={paginationItems}
+                  onPaginationChange={(newPaginationParams) =>
+                    setPaginationParams((prev) => ({
+                      limit: prev.limit ?? 25,
+                      ...newPaginationParams,
+                    }))
+                  }
+                  paginationState={paginationState}
+                  boundariesDisplay="dates"
+                  hasNextPage={hasNextPage}
+                  itemsPerPage={limit}
+                />
+              </div>
+            </Panel.Footer>
+          </Panel.Content>
+        </Panel.Container>
+      </Panel.Root>
     </>
   );
 };

--- a/packages/app-builder/src/components/Screenings/ScreeningPanel/ScreeningHitsPanel.tsx
+++ b/packages/app-builder/src/components/Screenings/ScreeningPanel/ScreeningHitsPanel.tsx
@@ -1,4 +1,5 @@
 import { CalloutV2 } from '@app-builder/components/Callout';
+import { Panel } from '@app-builder/components/Panel';
 import { LoaderRevalidatorContext } from '@app-builder/contexts/LoaderRevalidatorContext';
 import type { Screening, ScreeningMatch } from '@app-builder/models/screening';
 import { type ScreeningMatchPayload, type ScreeningStatus } from '@app-builder/models/screening';
@@ -22,7 +23,6 @@ import { filter } from 'remeda';
 import { match } from 'ts-pattern';
 import { Button, Checkbox, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { PanelContainer, PanelContent, PanelRoot } from '../../Panel/Panel';
 import { Spinner } from '../../Spinner';
 import { MatchCard } from '../MatchCard';
 import { sortScreeningMatchesByTopics } from '../match-sorting';
@@ -161,51 +161,47 @@ export function ScreeningHitsPanel({
   }, [bulkReviewMutation, selectedMatchIds, revalidateAfterBulk, t]);
 
   return (
-    <PanelRoot open={open} onOpenChange={handleOpenChange}>
-      <PanelContainer size="max" className="!max-w-[80vw]">
-        {/* Header: X | Name + Status Badge | Bulk action buttons */}
-        <div className="flex items-center gap-md pb-lg">
-          <Icon
-            icon="cross"
-            className="size-6 shrink-0 cursor-pointer text-grey-secondary hover:text-grey-primary"
-            onClick={() => handleOpenChange(false)}
-            aria-label="Close panel"
-          />
-          <div className="flex flex-1 items-center gap-sm">
-            <Typo variant="title2">{currentName}</Typo>
-            <ScreeningStatusTag
-              status={currentStatus}
-              pendingHitCount={screeningQuery.data?.matches.filter((m) => m.status === 'pending').length}
-            />
-          </div>
-          <div className="flex items-center gap-sm shrink-0">
-            {showBulkButton ? (
-              <Button
-                variant="primary"
-                size="small"
-                onClick={handleBulkMarkFalsePositive}
-                disabled={bulkReviewMutation.isPending}
-              >
-                {t('screenings:panel.mark_all_false_positive')}
-              </Button>
-            ) : null}
-            {showDismissButton ? (
-              <Button
-                variant="secondary"
-                appearance="stroked"
-                size="small"
-                onClick={handleDismissFalsePositives}
-                disabled={bulkReviewMutation.isPending}
-              >
-                <Icon icon="wand" className="size-4" />
-                {t('screenings:panel.dismiss_false_positives')}
-              </Button>
-            ) : null}
-          </div>
-        </div>
+    <Panel.Root open={open} onOpenChange={handleOpenChange}>
+      <Panel.Container size="large">
+        <Panel.Content>
+          <Panel.Header>
+            {/* Header: X | Name + Status Badge | Bulk action buttons */}
+            <div className="flex items-center gap-md pb-lg">
+              <div className="flex flex-1 items-center gap-sm">
+                <Typo variant="title2">{currentName}</Typo>
+                <ScreeningStatusTag
+                  status={currentStatus}
+                  pendingHitCount={screeningQuery.data?.matches.filter((m) => m.status === 'pending').length}
+                />
+              </div>
+              <div className="flex items-center gap-sm shrink-0">
+                {showBulkButton ? (
+                  <Button
+                    variant="primary"
+                    size="small"
+                    onClick={handleBulkMarkFalsePositive}
+                    disabled={bulkReviewMutation.isPending}
+                  >
+                    {t('screenings:panel.mark_all_false_positive')}
+                  </Button>
+                ) : null}
+                {showDismissButton ? (
+                  <Button
+                    variant="secondary"
+                    appearance="stroked"
+                    size="small"
+                    onClick={handleDismissFalsePositives}
+                    disabled={bulkReviewMutation.isPending}
+                  >
+                    <Icon icon="wand" className="size-4" />
+                    {t('screenings:panel.dismiss_false_positives')}
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          </Panel.Header>
 
-        {/* Body */}
-        <PanelContent>
+          {/* Body */}
           {match(screeningQuery)
             .with({ isPending: true }, () => (
               <div className="flex items-center justify-center p-xl">
@@ -249,9 +245,9 @@ export function ScreeningHitsPanel({
                 </LoaderRevalidatorContext.Provider>
               );
             })}
-        </PanelContent>
-      </PanelContainer>
-    </PanelRoot>
+        </Panel.Content>
+      </Panel.Container>
+    </Panel.Root>
   );
 }
 

--- a/packages/app-builder/src/components/Settings/AuditEvents/AuditEventDetailPanel.tsx
+++ b/packages/app-builder/src/components/Settings/AuditEvents/AuditEventDetailPanel.tsx
@@ -1,10 +1,9 @@
 import { CopyToClipboardButton } from '@app-builder/components/CopyToClipboardButton';
-import { PanelContainer, PanelContent, PanelHeader } from '@app-builder/components/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { type AuditEvent } from '@app-builder/models/audit-event';
 import { formatDateTimeWithoutPresets, useFormatLanguage } from '@app-builder/utils/format';
 import { type FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-
 import { JsonDiff } from './JsonDiff';
 import { OperationBadge } from './OperationBadge';
 
@@ -17,9 +16,9 @@ export const AuditEventDetailPanel: FunctionComponent<AuditEventDetailPanelProps
   const language = useFormatLanguage();
 
   return (
-    <PanelContainer size="xl">
-      <PanelHeader>{t('settings:audit.detail.title')}</PanelHeader>
-      <PanelContent>
+    <Panel.Container size="medium">
+      <Panel.Content>
+        <Panel.Header>{t('settings:audit.detail.title')}</Panel.Header>
         <div className="flex flex-col gap-lg">
           {/* Event metadata */}
           <div className="grid grid-cols-2 gap-md">
@@ -72,7 +71,7 @@ export const AuditEventDetailPanel: FunctionComponent<AuditEventDetailPanelProps
             <JsonDiff oldData={event.oldData} newData={event.newData} />
           </div>
         </div>
-      </PanelContent>
-    </PanelContainer>
+      </Panel.Content>
+    </Panel.Container>
   );
 };

--- a/packages/app-builder/src/components/Settings/AuditEvents/AuditEventsTable.tsx
+++ b/packages/app-builder/src/components/Settings/AuditEvents/AuditEventsTable.tsx
@@ -1,5 +1,5 @@
 import { CopyToClipboardButton } from '@app-builder/components/CopyToClipboardButton';
-import { PanelRoot } from '@app-builder/components/Panel/Panel';
+import { Panel } from '@app-builder/components/Panel';
 import { ApiKey } from '@app-builder/models/api-keys';
 import { type AuditEvent } from '@app-builder/models/audit-event';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
@@ -141,9 +141,9 @@ export const AuditEventsTable: FunctionComponent<AuditEventsTableProps> = ({ aud
         ))}
       </Table.Body>
       {currentAuditEvent ? (
-        <PanelRoot open onOpenChange={() => setCurrentAuditEvent(null)}>
+        <Panel.Root open onOpenChange={() => setCurrentAuditEvent(null)}>
           <AuditEventDetailPanel event={currentAuditEvent} />
-        </PanelRoot>
+        </Panel.Root>
       ) : null}
     </Table.Container>
   );

--- a/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
+++ b/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
@@ -1,3 +1,4 @@
+import { Panel, PanelSharpFactory } from '@app-builder/components/Panel';
 import { useAgnosticNavigation } from '@app-builder/contexts/AgnosticNavigationContext';
 import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
 import {
@@ -22,10 +23,8 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Fragment, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button, NumberInput, type SelectOption, SelectV2, Tooltip, Typo } from 'ui-design-system';
+import { Button, NumberInput, type SelectOption, SelectV2, Tooltip } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { PanelContainer, PanelRoot } from '../Panel';
-import { PanelSharpFactory } from '../Panel/Panel';
 import { ScoringLevelThresholds } from './ScoringLevelThresholds';
 
 interface GeneralInfoCardProps {
@@ -136,9 +135,9 @@ export function GeneralInfoCard({ ruleset, settings, preparationStatus }: Genera
 
       <RiskLevelBadges maxRiskLevel={settings.maxRiskLevel} thresholds={ruleset.thresholds} />
 
-      <PanelRoot open={editPanelOpen} onOpenChange={setEditPanelOpen}>
+      <Panel.Root open={editPanelOpen} onOpenChange={setEditPanelOpen}>
         <EditGeneralSettingsPanel ruleset={ruleset} maxRiskLevel={settings.maxRiskLevel} />
-      </PanelRoot>
+      </Panel.Root>
     </div>
   );
 }
@@ -219,60 +218,64 @@ function EditGeneralSettingsPanel({
   });
 
   return (
-    <PanelContainer size="lg" className="flex-col gap-md">
-      <form className="contents" onSubmit={handleSubmit(form)}>
-        <div className="flex items-center gap-md">
-          <button type="button" onClick={() => panelSharp.actions.close()}>
-            <Icon icon="x" className="size-6" />
-          </button>
-          <Typo variant="title2">{t('user-scoring:ruleset.edit_settings_title')}</Typo>
-        </div>
-        <div className="flex flex-col gap-sm">
-          {t('user-scoring:section.create_panel.general_settings')}
-          <div className="border border-grey-border rounded-md p-md grid grid-cols-[1fr_repeat(3,_auto)] gap-x-sm gap-y-md">
-            <div className="grid grid-cols-subgrid col-span-full items-center">
-              <span className="text-small">{t('user-scoring:section.create_panel.lower_score_duration')}</span>
-              <form.Field name="cooldownSeconds">
-                {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
-              </form.Field>
-              <Tooltip.Default content={t('user-scoring:section.create_panel.lower_score_duration_tooltip')}>
-                <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
-              </Tooltip.Default>
+    <form className="contents" onSubmit={handleSubmit(form)}>
+      <Panel.Container size="small">
+        <Panel.Content>
+          <Panel.Header>{t('user-scoring:ruleset.edit_settings_title')}</Panel.Header>
+          <div className="flex flex-col gap-md">
+            <div className="flex flex-col gap-sm">
+              {t('user-scoring:section.create_panel.general_settings')}
+              <div className="border border-grey-border rounded-md p-md grid grid-cols-[1fr_repeat(3,_auto)] gap-x-sm gap-y-md">
+                <div className="grid grid-cols-subgrid col-span-full items-center">
+                  <span className="text-small">{t('user-scoring:section.create_panel.lower_score_duration')}</span>
+                  <form.Field name="cooldownSeconds">
+                    {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
+                  </form.Field>
+                  <Tooltip.Default content={t('user-scoring:section.create_panel.lower_score_duration_tooltip')}>
+                    <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
+                  </Tooltip.Default>
+                </div>
+                <div className="grid grid-cols-subgrid col-span-full items-center">
+                  <span className="text-small">{t('user-scoring:section.create_panel.recalculation_duration')}</span>
+                  <form.Field name="scoringIntervalSeconds">
+                    {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
+                  </form.Field>
+                  <Tooltip.Default content={t('user-scoring:section.create_panel.recalculation_duration_tooltip')}>
+                    <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
+                  </Tooltip.Default>
+                </div>
+              </div>
             </div>
-            <div className="grid grid-cols-subgrid col-span-full items-center">
-              <span className="text-small">{t('user-scoring:section.create_panel.recalculation_duration')}</span>
-              <form.Field name="scoringIntervalSeconds">
-                {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
-              </form.Field>
-              <Tooltip.Default content={t('user-scoring:section.create_panel.recalculation_duration_tooltip')}>
-                <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
-              </Tooltip.Default>
-            </div>
+            <form.Field name="thresholds">
+              {(field) => (
+                <ScoringLevelThresholds
+                  maxRiskLevel={maxRiskLevel}
+                  thresholds={field.state.value}
+                  onThresholdsChange={field.handleChange}
+                />
+              )}
+            </form.Field>
           </div>
-        </div>
-        <form.Field name="thresholds">
-          {(field) => (
-            <ScoringLevelThresholds
-              maxRiskLevel={maxRiskLevel}
-              thresholds={field.state.value}
-              onThresholdsChange={field.handleChange}
+          <Panel.Footer>
+            <Panel.FooterButton
+              variant="secondary"
+              onClick={() => panelSharp.actions.close()}
+              label={t('user-scoring:section.create_panel.cancel')}
             />
-          )}
-        </form.Field>
-        <div className="flex gap-sm justify-end mt-auto">
-          <Button appearance="stroked" onClick={() => panelSharp.actions.close()}>
-            {t('user-scoring:section.create_panel.cancel')}
-          </Button>
-          <form.Subscribe selector={(s) => [s.canSubmit, s.isSubmitting]}>
-            {([canSubmit, isSubmitting]) => (
-              <Button disabled={!canSubmit || isSubmitting} type="submit">
-                {t('user-scoring:section.create_panel.validate')}
-              </Button>
-            )}
-          </form.Subscribe>
-        </div>
-      </form>
-    </PanelContainer>
+            <form.Subscribe selector={(s) => [s.canSubmit, s.isSubmitting]}>
+              {([canSubmit, isSubmitting]) => (
+                <Panel.FooterButton
+                  disabled={!canSubmit}
+                  isLoading={isSubmitting}
+                  type="submit"
+                  label={t('user-scoring:section.create_panel.validate')}
+                />
+              )}
+            </form.Subscribe>
+          </Panel.Footer>
+        </Panel.Content>
+      </Panel.Container>
+    </form>
   );
 }
 

--- a/packages/app-builder/src/components/UserScoring/RulesTable.tsx
+++ b/packages/app-builder/src/components/UserScoring/RulesTable.tsx
@@ -1,3 +1,4 @@
+import { Panel } from '@app-builder/components/Panel';
 import { NewAstNode } from '@app-builder/models';
 import { NewAggregatorAstNode } from '@app-builder/models/astNode/aggregation';
 import { NewSwitchAstNode } from '@app-builder/models/astNode/control-flow';
@@ -20,7 +21,6 @@ import { match } from 'ts-pattern';
 import { Button, cn, MenuCommand, Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { v7 as uuidv7 } from 'uuid';
-import { PanelRoot } from '../Panel';
 import { Spinner } from '../Spinner';
 import { ScoringRuleEditPanel } from './ScoringRuleEditPanel';
 import { SwitchNode } from './SwitchNode';
@@ -279,7 +279,7 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
             .exhaustive()
         )}
       </div>
-      <PanelRoot
+      <Panel.Root
         open={panelRule !== null}
         onOpenChange={(isOpen) => {
           if (!isOpen) setPanelRule(null);
@@ -296,7 +296,7 @@ export function RulesTable({ ruleset, maxRiskLevel, customLists, hasValidLicense
             onChange={handleRuleAdd}
           />
         ) : null}
-      </PanelRoot>
+      </Panel.Root>
     </>
   );
 }
@@ -350,7 +350,7 @@ function RuleRow({
         >
           <Icon icon="edit" className="size-4" />
         </button>
-        <PanelRoot open={isEditing} onOpenChange={setIsEditing}>
+        <Panel.Root open={isEditing} onOpenChange={setIsEditing}>
           <ScoringRuleEditPanel
             rule={rule}
             dataModel={dataModel}
@@ -368,7 +368,7 @@ function RuleRow({
                 : undefined
             }
           />
-        </PanelRoot>
+        </Panel.Root>
       </div>
     </div>
   );

--- a/packages/app-builder/src/components/UserScoring/ScoringRuleEditPanel.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringRuleEditPanel.tsx
@@ -1,4 +1,5 @@
 import { AstBuilder } from '@app-builder/components/AstBuilder';
+import { Panel, PanelSharpFactory } from '@app-builder/components/Panel';
 import { type DataModel } from '@app-builder/models';
 import { type CustomList } from '@app-builder/models/custom-list';
 import {
@@ -17,10 +18,8 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
-import { Button, cn, type SelectOption, SelectV2, Tag } from 'ui-design-system';
+import { cn, type SelectOption, SelectV2, Tag } from 'ui-design-system';
 import { Icon } from 'ui-icons';
-import { PanelContainer, PanelContent, PanelFooter } from '../Panel';
-import { PanelSharpFactory } from '../Panel/Panel';
 import { SwitchNode } from './SwitchNode';
 
 type ScoringRuleEditPanelProps = {
@@ -110,63 +109,57 @@ export function ScoringRuleEditPanel({
 
   return (
     <AstBuilder.StaticProvider data={builderOptionsData} mode="edit">
-      <PanelContainer size="xxxl" className="flex flex-col">
-        <div className="flex items-center gap-md pb-md">
-          <Icon
-            icon="cross"
-            className="size-6 shrink-0 cursor-pointer text-grey-secondary hover:text-grey-primary"
-            onClick={sharp.actions.close}
-            aria-label="Close panel"
-          />
-          <div className="flex flex-1 flex-col">
-            <input
-              ref={nameInputRef}
-              className={cn(
-                'text-l font-semibold outline-none',
-                nameTouched && !name.trim() ? 'border-b border-red-primary' : '',
-              )}
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onBlur={() => setNameTouched(true)}
-              placeholder={t('user-scoring:rule_edit.name_placeholder')}
-            />
-            {nameTouched && !name.trim() ? (
-              <span className="text-xs text-red-primary mt-xs">{t('user-scoring:rule_edit.name_required')}</span>
+      <Panel.Container size="small">
+        <Panel.Content>
+          <Panel.Header className="flex items-center">
+            <div className="flex flex-1 flex-col">
+              <input
+                ref={nameInputRef}
+                className={cn(
+                  'text-h2 font-semibold outline-none h-6',
+                  nameTouched && !name.trim() ? 'border-b border-red-primary' : '',
+                )}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onBlur={() => setNameTouched(true)}
+                placeholder={t('user-scoring:rule_edit.name_placeholder')}
+              />
+              {nameTouched && !name.trim() ? (
+                <span className="text-xs text-red-primary mt-1">{t('user-scoring:rule_edit.name_required')}</span>
+              ) : null}
+            </div>
+            {onDelete ? (
+              <button
+                onClick={onDelete}
+                className="ms-auto flex size-6 shrink-0 items-center justify-center rounded-lg border border-red-primary text-red-primary hover:bg-red-primary hover:text-white"
+                aria-label="Delete rule"
+              >
+                <Icon icon="delete" className="size-4" />
+              </button>
             ) : null}
+          </Panel.Header>
+          <div className="flex flex-wrap items-center gap-2 pb-md">
+            <Tag color="grey">{entityType}</Tag>
+            {currentModel ? (
+              <Tag color="grey">
+                {match(currentModel)
+                  .with({ type: 'user_attribute' }, () => t('user-scoring:rule_edit.model_type.user_attribute'))
+                  .with({ type: 'aggregate' }, () => t('user-scoring:rule_edit.model_type.aggregate'))
+                  .with({ type: 'screening_tags' }, () => t('user-scoring:rule_edit.model_type.screening_tags'))
+                  .with({ type: 'entity_tags' }, () => t('user-scoring:rule_edit.model_type.entity_tags'))
+                  .with({ type: 'past_alerts' }, () => t('user-scoring:rule_edit.model_type.past_alerts'))
+                  .exhaustive()}
+              </Tag>
+            ) : null}
+            <SelectV2
+              variant="tag"
+              options={RISK_TYPE_OPTIONS}
+              value={riskType}
+              onChange={setRiskType}
+              placeholder={t('user-scoring:rule_edit.risk_type_placeholder')}
+              menuClassName="min-w-40"
+            />
           </div>
-          {onDelete ? (
-            <button
-              onClick={onDelete}
-              className="flex size-6 shrink-0 items-center justify-center rounded-lg border border-red-primary text-red-primary hover:bg-red-primary hover:text-white"
-              aria-label="Delete rule"
-            >
-              <Icon icon="delete" className="size-4" />
-            </button>
-          ) : null}
-        </div>
-        <div className="flex flex-wrap items-center gap-sm pb-md">
-          <Tag color="grey">{entityType}</Tag>
-          {currentModel ? (
-            <Tag color="grey">
-              {match(currentModel)
-                .with({ type: 'user_attribute' }, () => t('user-scoring:rule_edit.model_type.user_attribute'))
-                .with({ type: 'aggregate' }, () => t('user-scoring:rule_edit.model_type.aggregate'))
-                .with({ type: 'screening_tags' }, () => t('user-scoring:rule_edit.model_type.screening_tags'))
-                .with({ type: 'entity_tags' }, () => t('user-scoring:rule_edit.model_type.entity_tags'))
-                .with({ type: 'past_alerts' }, () => t('user-scoring:rule_edit.model_type.past_alerts'))
-                .exhaustive()}
-            </Tag>
-          ) : null}
-          <SelectV2
-            variant="tag"
-            options={RISK_TYPE_OPTIONS}
-            value={riskType}
-            onChange={setRiskType}
-            placeholder={t('user-scoring:rule_edit.risk_type_placeholder')}
-            menuClassName="min-w-40"
-          />
-        </div>
-        <PanelContent>
           <div className="flex flex-col gap-md p-md border border-grey-border rounded-md">
             <SwitchNode
               mode="edit"
@@ -178,18 +171,21 @@ export function ScoringRuleEditPanel({
               onModelChange={(model) => setCurrentModel(model)}
             />
           </div>
-        </PanelContent>
-        <PanelFooter>
-          <div className="flex justify-end gap-sm">
-            <Button variant="secondary" onClick={sharp.actions.close}>
-              {t('user-scoring:rule_edit.cancel')}
-            </Button>
-            <Button variant="primary" onClick={handleValidate} disabled={!isValid}>
-              {t('user-scoring:rule_edit.save')}
-            </Button>
-          </div>
-        </PanelFooter>
-      </PanelContainer>
+          <Panel.Footer>
+            <Panel.FooterButton
+              variant="secondary"
+              onClick={sharp.actions.close}
+              label={t('user-scoring:rule_edit.cancel')}
+            />
+            <Panel.FooterButton
+              variant="primary"
+              onClick={handleValidate}
+              disabled={!isValid}
+              label={t('user-scoring:rule_edit.save')}
+            />
+          </Panel.Footer>
+        </Panel.Content>
+      </Panel.Container>
     </AstBuilder.StaticProvider>
   );
 }

--- a/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringSectionLayout.tsx
@@ -13,8 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, NumberInput, type SelectOption, SelectV2, Tabs, Tooltip, Typo, tabClassName } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { Page } from '../Page';
-import { PanelContainer, PanelRoot } from '../Panel';
-import { PanelSharpFactory } from '../Panel/Panel';
+import { Panel, PanelSharpFactory } from '../Panel';
 import { Spinner } from '../Spinner';
 import { ScoringLevelThresholds } from './ScoringLevelThresholds';
 
@@ -58,9 +57,9 @@ export function ScoringSectionLayout({ maxRiskLevel }: { maxRiskLevel: number | 
           </Tabs>
           <Outlet />
           {maxRiskLevel ? (
-            <PanelRoot open={panelOpen} onOpenChange={setPanelOpen}>
+            <Panel.Root open={panelOpen} onOpenChange={setPanelOpen}>
               <ScoringRulesetCreationPanel maxRiskLevel={maxRiskLevel} />
-            </PanelRoot>
+            </Panel.Root>
           ) : null}
         </Page.Content>
       </Page.Main>
@@ -166,77 +165,78 @@ function ScoringRulesetCreationPanel({ maxRiskLevel }: { maxRiskLevel: number })
   }));
 
   return (
-    <PanelContainer size="lg" className="flex-col gap-md">
-      <form className="contents" onSubmit={handleSubmit(form)}>
-        <div className="flex items-center gap-md">
-          <button type="button" onClick={() => panelSharp.actions.close()}>
-            <Icon icon="x" className="size-6" />
-          </button>
-          <Typo variant="title2">{t('user-scoring:section.create_panel.title')}</Typo>
-        </div>
-        <div>
-          <form.Field name="recordType">
-            {(field) => (
-              <SelectV2
-                placeholder={t('user-scoring:section.create_panel.entity_placeholder')}
-                value={field.state.value}
-                options={entityOptions}
-                onChange={field.handleChange}
-                className="w-full"
-              />
-            )}
-          </form.Field>
-        </div>
-        <div className="flex flex-col gap-sm">
-          {t('user-scoring:section.create_panel.general_settings')}
-          <div className="border border-grey-border rounded-md p-md grid grid-cols-[1fr_repeat(3,_auto)] gap-x-sm gap-y-md">
-            <div className="grid grid-cols-subgrid col-span-full items-center">
-              <span className="text-small">{t('user-scoring:section.create_panel.lower_score_duration')}</span>
-              <form.Field name="cooldownSeconds">
-                {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
+    <form className="contents" onSubmit={handleSubmit(form)}>
+      <Panel.Container size="small">
+        <Panel.Content>
+          <Panel.Header>{t('user-scoring:section.create_panel.title')}</Panel.Header>
+          <div className="flex flex-col gap-md">
+            <div>
+              <form.Field name="recordType">
+                {(field) => (
+                  <SelectV2
+                    placeholder={t('user-scoring:section.create_panel.entity_placeholder')}
+                    value={field.state.value}
+                    options={entityOptions}
+                    onChange={field.handleChange}
+                    className="w-full"
+                  />
+                )}
               </form.Field>
-              <Tooltip.Default content={t('user-scoring:section.create_panel.lower_score_duration_tooltip')}>
-                <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
-              </Tooltip.Default>
             </div>
-            <div className="grid grid-cols-subgrid col-span-full items-center">
-              <span className="text-small">{t('user-scoring:section.create_panel.recalculation_duration')}</span>
-              <form.Field name="scoringIntervalSeconds">
-                {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
-              </form.Field>
-              <Tooltip.Default content={t('user-scoring:section.create_panel.recalculation_duration_tooltip')}>
-                <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
-              </Tooltip.Default>
+            <div className="flex flex-col gap-sm">
+              {t('user-scoring:section.create_panel.general_settings')}
+              <div className="border border-grey-border rounded-md p-md grid grid-cols-[1fr_repeat(3,_auto)] gap-x-sm gap-y-md">
+                <div className="grid grid-cols-subgrid col-span-full items-center">
+                  <span className="text-small">{t('user-scoring:section.create_panel.lower_score_duration')}</span>
+                  <form.Field name="cooldownSeconds">
+                    {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
+                  </form.Field>
+                  <Tooltip.Default content={t('user-scoring:section.create_panel.lower_score_duration_tooltip')}>
+                    <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
+                  </Tooltip.Default>
+                </div>
+                <div className="grid grid-cols-subgrid col-span-full items-center">
+                  <span className="text-small">{t('user-scoring:section.create_panel.recalculation_duration')}</span>
+                  <form.Field name="scoringIntervalSeconds">
+                    {(field) => <DurationDaysField value={field.state.value} onChange={field.handleChange} />}
+                  </form.Field>
+                  <Tooltip.Default content={t('user-scoring:section.create_panel.recalculation_duration_tooltip')}>
+                    <Icon icon="helpcenter" className="size-5 text-grey-secondary" />
+                  </Tooltip.Default>
+                </div>
+              </div>
             </div>
+            <form.Field name="thresholds">
+              {(field) => (
+                <ScoringLevelThresholds
+                  maxRiskLevel={maxRiskLevel}
+                  thresholds={field.state.value}
+                  onThresholdsChange={field.handleChange}
+                />
+              )}
+            </form.Field>
           </div>
-        </div>
-        <form.Field name="thresholds">
-          {(field) => (
-            <ScoringLevelThresholds
-              maxRiskLevel={maxRiskLevel}
-              thresholds={field.state.value}
-              onThresholdsChange={field.handleChange}
+          <Panel.Footer>
+            <Panel.FooterButton
+              variant="secondary"
+              onClick={() => {
+                panelSharp.actions.close();
+              }}
+              label={t('user-scoring:section.create_panel.cancel')}
             />
-          )}
-        </form.Field>
-        <div className="flex gap-sm justify-end mt-auto">
-          <Button
-            appearance="stroked"
-            onClick={() => {
-              panelSharp.actions.close();
-            }}
-          >
-            {t('user-scoring:section.create_panel.cancel')}
-          </Button>
-          <form.Subscribe selector={(s) => [s.canSubmit, s.isSubmitting]}>
-            {([canSubmit, isSubmitting]) => (
-              <Button disabled={!canSubmit || isSubmitting} type="submit">
-                {t('user-scoring:section.create_panel.validate')}
-              </Button>
-            )}
-          </form.Subscribe>
-        </div>
-      </form>
-    </PanelContainer>
+            <form.Subscribe selector={(s) => [s.canSubmit, s.isSubmitting]}>
+              {([canSubmit, isSubmitting]) => (
+                <Panel.FooterButton
+                  disabled={!canSubmit}
+                  isLoading={isSubmitting}
+                  type="submit"
+                  label={t('user-scoring:section.create_panel.validate')}
+                />
+              )}
+            </form.Subscribe>
+          </Panel.Footer>
+        </Panel.Content>
+      </Panel.Container>
+    </form>
   );
 }

--- a/packages/tailwind-preset/src/tailwind.css
+++ b/packages/tailwind-preset/src/tailwind.css
@@ -194,7 +194,7 @@
  * ======================================== */
 @variant dark (&:where(.dark, .dark *));
 
-@custom-variant sentinel-intersect ([data-sentinel][data-intersect] + &);
+@custom-variant sentinel-intersect ([data-sentinel][data-intersect] + &, &:has(+ [data-sentinel][data-intersect]));
 
 .dark {
   /* ========================================

--- a/packages/ui-design-system/src/Modal/Modal.tsx
+++ b/packages/ui-design-system/src/Modal/Modal.tsx
@@ -65,7 +65,7 @@ const ModalTitle = forwardRef<HTMLHeadingElement, Dialog.DialogTitleProps>(funct
   ref,
 ) {
   return (
-    <StickyComponent inFlow>
+    <StickyComponent inFlow="before">
       <Dialog.Title
         ref={ref}
         className={typoClassName({
@@ -95,7 +95,7 @@ interface ModalFooterProps {
 
 const ModalFooter = forwardRef<HTMLDivElement, ModalFooterProps>(function ModalFooter({ children, className }, ref) {
   return (
-    <StickyComponent inFlow>
+    <StickyComponent inFlow="after">
       <div
         ref={ref}
         className={cn(

--- a/packages/ui-design-system/src/Popover/Popover.tsx
+++ b/packages/ui-design-system/src/Popover/Popover.tsx
@@ -39,7 +39,7 @@ interface PopoverFooterProps {
 
 function PopoverFooter({ children, className }: PopoverFooterProps) {
   return (
-    <StickyComponent inFlow>
+    <StickyComponent inFlow="after">
       <div
         className={cn(
           'sticky bottom-0 z-10 border-t border-transparent bg-surface-card flex justify-end gap-sm p-md sentinel-intersect:border-t-grey-border sentinel-intersect:shadow-sticky-bottom',

--- a/packages/ui-design-system/src/StickyComponent/StickyComponent.tsx
+++ b/packages/ui-design-system/src/StickyComponent/StickyComponent.tsx
@@ -8,8 +8,9 @@ type StickyComponentProps = {
   /**
    * Use an in-flow sentinel for sticky elements inside a scroll container.
    * Absolute sentinels only work when the containing block spans the full scrollable content.
+   * As the sentinel is not absolute let the element be place in the content via value.
    */
-  inFlow?: boolean;
+  inFlow?: 'before' | 'after';
 };
 
 function getScrollParent(element: HTMLElement) {
@@ -28,7 +29,7 @@ function getScrollParent(element: HTMLElement) {
   return null;
 }
 
-export function StickyComponent({ children, sentinelClassName, inFlow = false }: StickyComponentProps) {
+export function StickyComponent({ children, sentinelClassName, inFlow }: StickyComponentProps) {
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -57,12 +58,17 @@ export function StickyComponent({ children, sentinelClassName, inFlow = false }:
 
   return (
     <>
-      <div
-        ref={sentinelRef}
-        data-sentinel
-        className={cn(inFlow ? 'h-px w-full shrink-0' : 'absolute', sentinelClassName)}
-      />
+      {inFlow !== 'after' ? (
+        <div
+          ref={sentinelRef}
+          data-sentinel
+          className={cn(inFlow ? 'relative h-px w-full shrink-0' : 'absolute', sentinelClassName)}
+        />
+      ) : null}
       {children}
+      {inFlow === 'after' ? (
+        <div ref={sentinelRef} data-sentinel className={cn('relative h-px w-full shrink-0', sentinelClassName)} />
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized panels/drawers using a unified `Panel.*` API with sticky headers/footers and a dedicated `PanelFooterButton` that handles loading, disabled state, and ARIA consistently.
* **Bug Fixes**
  * Improved panel close behavior by removing per-panel header close controls in favor of consistent open/close state handling.
  * Refined Create Case flow to always render the form, showing the inbox selector only after inbox data successfully loads.
* **Style**
  * Updated panel sizing and header/footer hierarchy for a clearer, more consistent layout across screens.
  * Refined sticky “sentinel” behavior for improved footer/header reliability.
* **Chores**
  * Migrated multiple screens to the shared `Panel` component structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->