### PR TITLE
fix some weird edgecases in data display

### DIFF
--- a/packages/app-builder/src/components/CopyToClipboardButton.tsx
+++ b/packages/app-builder/src/components/CopyToClipboardButton.tsx
@@ -5,7 +5,7 @@ import { cn } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 const variances = cva(
-  'border-grey-border text-grey-primary bg-purple-background-light hover:bg-grey-background active:bg-grey-border flex w-fit shrink-0 cursor-pointer select-none items-center break-all border font-normal transition-colors',
+  'border-grey-border text-grey-primary bg-purple-background-light hover:bg-grey-background active:bg-grey-border flex w-fit shrink-0 cursor-pointer select-none items-center break-all border font-normal transition-colors max-w-full',
   {
     variants: {
       size: {

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataField.tsx
@@ -378,7 +378,7 @@ function StringId() {
   if (!value) return <EmptyValue className={codeClassName()} />;
   return (
     <CopyToClipboardButton toCopy={value}>
-      <span>{value}</span>
+      <span className="truncate">{value}</span>
     </CopyToClipboardButton>
   );
 }

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
@@ -117,9 +117,9 @@ export function DataFields({ table, object, preset, customFields, className, opt
         <div
           className={cn(
             'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-md gap-y-sm break-all',
-            'grid-cols-[minmax(0,20ch)_minmax(0,1fr)]',
-            options?.layout === '2-columns' && '@[700px]:grid-cols-[repeat(2,minmax(0,20ch)_minmax(0,1fr))]',
-            options?.layout === '3-columns' && '@[700px]:grid-cols-[repeat(3,minmax(0,20ch)_minmax(0,1fr))]',
+            'grid-cols-[fit-content(20ch)_minmax(0,1fr)]',
+            options?.layout === '2-columns' && '@[700px]:grid-cols-[repeat(2,fit-content(20ch)_minmax(0,1fr))]',
+            options?.layout === '3-columns' && '@[700px]:grid-cols-[repeat(3,fit-content(20ch)_minmax(0,1fr))]',
             className,
           )}
         >

--- a/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
+++ b/packages/app-builder/src/components/Data/DataVisualisation/DataFields.tsx
@@ -113,7 +113,7 @@ export function DataFields({ table, object, preset, customFields, className, opt
   return (
     <DataVisualisationProvider value={contextValue}>
       {options?.showHeader ? <DataFieldsHeader object={object} /> : null}
-      <div className="@container">
+      <div className={options?.layout === '2-columns' || options?.layout === '3-columns' ? '@container' : undefined}>
         <div
           className={cn(
             'grid auto-rows-[minmax(2rem,auto)] items-stretch gap-x-md gap-y-sm break-all',

--- a/packages/app-builder/src/components/Screenings/MatchCard/MatchCard.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/MatchCard.tsx
@@ -86,9 +86,6 @@ export const MatchCard = ({
         </div>
       ) : null}
       <Collapsible.Content>
-        {match.comments.map((comment) => {
-          return <CommentLine key={comment.id} comment={comment} />;
-        })}
         <div className="bg-grey-background-light border-grey-border flex flex-col gap-sm rounded-lg border p-sm">
           {entitySchema === 'person' && entity.datasets?.length ? (
             <div className="grid grid-cols-[146px_1fr] gap-md">
@@ -104,6 +101,9 @@ export const MatchCard = ({
             </div>
           ) : null}
 
+          {match.comments.map((comment) => {
+            return <CommentLine key={comment.id} comment={comment} />;
+          })}
           <MatchDetails entity={entity} />
         </div>
       </Collapsible.Content>

--- a/packages/app-builder/src/components/Screenings/MatchCard/MatchCard.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/MatchCard.tsx
@@ -86,6 +86,9 @@ export const MatchCard = ({
         </div>
       ) : null}
       <Collapsible.Content>
+        {match.comments.map((comment) => {
+          return <CommentLine key={comment.id} comment={comment} />;
+        })}
         <div className="bg-grey-background-light border-grey-border flex flex-col gap-sm rounded-lg border p-sm">
           {entitySchema === 'person' && entity.datasets?.length ? (
             <div className="grid grid-cols-[146px_1fr] gap-md">
@@ -101,9 +104,6 @@ export const MatchCard = ({
             </div>
           ) : null}
 
-          {match.comments.map((comment) => {
-            return <CommentLine key={comment.id} comment={comment} />;
-          })}
           <MatchDetails entity={entity} />
         </div>
       </Collapsible.Content>

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
@@ -435,7 +435,7 @@ function ScreeningDetail() {
       <Page.Container ref={containerRef}>
         <Page.Content width="form">
           <form className="relative flex max-w-[800px] flex-col" onSubmit={handleSubmit(form)}>
-            <div className="sticky top-0 z-40 flex flex-col gap-md bg-surface-page py-sm">
+            <div className="sticky top-0 flex flex-col gap-md bg-surface-page py-sm">
               <div
                 className={cn('flex h-fit items-center justify-between gap-md', {
                   'border-b-grey-border border-b': !intersection?.isIntersecting,

--- a/packages/ui-design-system/src/Tag/Tag.tsx
+++ b/packages/ui-design-system/src/Tag/Tag.tsx
@@ -21,7 +21,7 @@ export const tagClassName = cva('inline-flex items-center justify-center border 
     },
     appearance: {
       default: null,
-      monospace: 'font-mono font-normal bg-grey-white rounded-sm',
+      monospace: 'font-mono font-normal bg-surface-card rounded-sm',
     },
   },
   defaultVariants: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the copy-to-clipboard button base styling to better handle long text with improved word-wrapping and overflow prevention.
  * Added truncation styling for string value displays in data fields.
  * Refined the data fields responsive layout so container styling applies only in 2- and 3-column modes, with improved grid sizing.
  * Adjusted the sticky screening header to remove an extra stacking layer while keeping the same spacing and layout.
  * Updated the monospace Tag appearance background to match the current surface styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->