### PR TITLE
workflow inbox creation auto-fill

### DIFF
--- a/packages/app-builder/src/components/Auth/SignInFirstConnection.tsx
+++ b/packages/app-builder/src/components/Auth/SignInFirstConnection.tsx
@@ -1,7 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import { CtaV2ClassName } from 'ui-design-system';
-import { ExternalLink } from '../ExternalLink';
 
 export function SignInFirstConnection({
   isSignInHomepage,
@@ -18,23 +17,25 @@ export function SignInFirstConnection({
         className={CtaV2ClassName({
           variant: 'secondary',
           size: 'large',
-          className: 'w-full justify-center text-center',
+          className: 'w-full justify-center text-center h-auto min-h-10 py-sm',
         })}
         to="/create-password"
       >
         {t(isSignInHomepage ? 'auth:sign_up.set_password_sign_in' : 'auth:sign_up.set_password_sign_in_email')}
       </Link>
       {showAskDemoButton ? (
-        <ExternalLink
+        <a
           className={CtaV2ClassName({
             variant: 'secondary',
             size: 'large',
-            className: 'w-full justify-center text-center',
+            className: 'w-full justify-center text-center h-auto min-h-10 py-sm',
           })}
           href="https://www.checkmarble.com/demo-fraud"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {t('auth:sign_up.no_account')}
-        </ExternalLink>
+        </a>
       ) : null}
     </>
   );

--- a/packages/app-builder/src/components/Settings/Inboxes/CreateInbox.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/CreateInbox.tsx
@@ -19,8 +19,10 @@ import { Icon } from 'ui-icons';
 
 export function CreateInbox({
   redirectRoutePath,
+  onInboxCreated,
 }: {
   redirectRoutePath?: (typeof createInboxRedirectRouteOptions)[number];
+  onInboxCreated?: (inboxId: string) => void;
 }) {
   const { t } = useTranslation(['common', 'settings']);
   const [open, setOpen] = useState(false);
@@ -34,7 +36,7 @@ export function CreateInbox({
         </Button>
       </Modal.Trigger>
       <Modal.Content onClick={(e) => e.stopPropagation()}>
-        <CreateInboxContent setOpen={setOpen} redirectRoutePath={redirectRoutePath} />
+        <CreateInboxContent setOpen={setOpen} redirectRoutePath={redirectRoutePath} onInboxCreated={onInboxCreated} />
       </Modal.Content>
     </Modal.Root>
   );
@@ -43,9 +45,11 @@ export function CreateInbox({
 export function CreateInboxContent({
   redirectRoutePath,
   setOpen,
+  onInboxCreated,
 }: {
   redirectRoutePath?: (typeof createInboxRedirectRouteOptions)[number];
   setOpen: (open: boolean) => void;
+  onInboxCreated?: (inboxId: string) => void;
 }) {
   const { t } = useTranslation(['common', 'settings']);
   const createInboxMutation = useCreateInboxMutation();
@@ -61,11 +65,14 @@ export function CreateInboxContent({
       if (formApi.state.isValid) {
         createInboxMutation
           .mutateAsync(value)
-          .then(() => {
+          .then((result) => {
             toast.success(t('common:success.save'));
             setOpen(false);
             queryClient.invalidateQueries({ queryKey: ['inboxes'] });
             revalidate();
+            if (result?.inboxId) {
+              onInboxCreated?.(result.inboxId);
+            }
           })
           .catch(() => {
             toast.error(t('common:errors.unknown'));

--- a/packages/app-builder/src/components/Settings/Inboxes/CreateInbox.tsx
+++ b/packages/app-builder/src/components/Settings/Inboxes/CreateInbox.tsx
@@ -14,15 +14,19 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button, HiddenInputs, Modal } from 'ui-design-system';
+import { Button, type ButtonV2Props, cn, HiddenInputs, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 export function CreateInbox({
   redirectRoutePath,
   onInboxCreated,
+  className,
+  size,
 }: {
   redirectRoutePath?: (typeof createInboxRedirectRouteOptions)[number];
   onInboxCreated?: (inboxId: string) => void;
+  className?: string;
+  size?: ButtonV2Props['size'];
 }) {
   const { t } = useTranslation(['common', 'settings']);
   const [open, setOpen] = useState(false);
@@ -30,7 +34,7 @@ export function CreateInbox({
   return (
     <Modal.Root open={open} onOpenChange={setOpen}>
       <Modal.Trigger onClick={(e) => e.stopPropagation()} asChild>
-        <Button className="whitespace-nowrap" variant="secondary" appearance="stroked">
+        <Button className={cn('whitespace-nowrap', className)} variant="secondary" appearance="stroked" size={size}>
           <Icon icon="new-inbox" className="size-5 shrink-0" />
           {t('settings:inboxes.new_inbox.create')}
         </Button>

--- a/packages/app-builder/src/components/Workflows/InboxSelector.tsx
+++ b/packages/app-builder/src/components/Workflows/InboxSelector.tsx
@@ -38,7 +38,16 @@ export function InboxSelector({
 
   const getCreateInbox = () => {
     if (isCreateInboxAvailable) {
-      return <CreateInbox onInboxCreated={onSelectedInboxIdChange} />;
+      return (
+        <CreateInbox
+          className="w-full justify-center"
+          size="medium"
+          onInboxCreated={(inboxId) => {
+            onSelectedInboxIdChange(inboxId);
+            setOpen(false);
+          }}
+        />
+      );
     }
     if (inboxes.length === 0) {
       return <p className="p-sm">{t('workflows:detail_panel.inbox.need_inbox_contact_admin')}</p>;

--- a/packages/app-builder/src/components/Workflows/InboxSelector.tsx
+++ b/packages/app-builder/src/components/Workflows/InboxSelector.tsx
@@ -38,7 +38,7 @@ export function InboxSelector({
 
   const getCreateInbox = () => {
     if (isCreateInboxAvailable) {
-      return <CreateInbox />;
+      return <CreateInbox onInboxCreated={onSelectedInboxIdChange} />;
     }
     if (inboxes.length === 0) {
       return <p className="p-sm">{t('workflows:detail_panel.inbox.need_inbox_contact_admin')}</p>;

--- a/packages/app-builder/src/router.tsx
+++ b/packages/app-builder/src/router.tsx
@@ -37,6 +37,9 @@ export function getRouter() {
     routeTree,
     context: { ...rqContext, i18n },
     scrollRestoration: true,
+    // Start route loaders on hover/focus so data is usually ready by click time,
+    // hiding loader RPC latency behind the intent-to-click gap.
+    defaultPreload: 'intent',
     ssr: { nonce: getNonce() },
     Wrap: (props: { children: ReactNode }) => {
       return (

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/index.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/index.tsx
@@ -20,7 +20,7 @@ import clsx from 'clsx';
 import { type TFunction } from 'i18next';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Table, Tag, useVirtualTable } from 'ui-design-system';
+import { Button, Table, Tag, useTable } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 
 const scenariosLoader = createServerFn()
@@ -178,7 +178,7 @@ function DetectionScenariosPage() {
     [t, formatDateTime, hydrated, isEditScenarioAvailable],
   );
 
-  const { table, isEmpty, getBodyProps, rows, getContainerProps } = useVirtualTable({
+  const { table, getBodyProps, rows, getContainerProps } = useTable({
     data: scenarios,
     columns,
     state: {
@@ -192,6 +192,7 @@ function DetectionScenariosPage() {
     getSortedRowModel: getSortedRowModel(),
     rowLink: ({ id }) => <Link to="/detection/scenarios/$scenarioId" params={{ scenarioId: fromUUIDtoSUUID(id) }} />,
   });
+  const isEmpty = rows.length === 0;
 
   return (
     <Page.Main>

--- a/packages/app-builder/src/server-fns/settings.ts
+++ b/packages/app-builder/src/server-fns/settings.ts
@@ -203,6 +203,8 @@ export const createInboxFn = createServerFn({ method: 'POST' })
       if (data.redirectRoute) {
         throw redirect({ to: data.redirectRoute, params: { inboxId: fromUUIDtoSUUID(createdInbox.id) } });
       }
+
+      return { inboxId: createdInbox.id };
     } catch (error) {
       if (error instanceof Response || (error as { _isRedirect?: boolean })._isRedirect) throw error;
       throw new Error('Failed to create inbox');


### PR DESCRIPTION
## Change 1
### Before
<img width="311" height="343" alt="Capture d’écran 2026-06-23 à 21 36 59" src="https://github.com/user-attachments/assets/a433caeb-39b5-4561-b81b-3d1f85512289" />

### After
<img width="344" height="334" alt="Capture d’écran 2026-06-23 à 21 36 18" src="https://github.com/user-attachments/assets/1ede4a5b-f3b2-4077-a97c-72b00cf9b324" />

Plus the inbox is now auto-selected after inbox creation is done.

---
## Change 2
### Before
<img width="437" height="189" alt="Capture d’écran 2026-06-23 à 21 47 08" src="https://github.com/user-attachments/assets/df78dee4-6c34-4c6b-9ba8-3f67b3067905" />


### After
<img width="441" height="204" alt="Capture d’écran 2026-06-23 à 21 46 45" src="https://github.com/user-attachments/assets/241b590e-1e0a-4fc5-a615-b15f8a771709" />

---
## Change 3
No screenshot here, but replace useVirtualTable by useTable for table of scenarios, so that we dont' have 500ms+ rendering time after hydration and content shifting etc, when we first log in to Marble.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbox creation now supports optional post-create callbacks, custom styling, and button sizing, and the inbox selector integrates the full creation flow.
  * “Ask demo” CTA now uses a native link with safe target/rel handling when displayed.
* **Bug Fixes**
  * Inbox creation now reliably returns the created inbox ID when no redirect is used, enabling callback behavior.
* **Performance**
  * Improved TanStack Router data preloading (intent-based) for faster perceived navigation.
  * Updated detection scenarios table rendering approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->