### PR TITLE
encode object_id containing '/' in base64

### DIFF
--- a/packages/app-builder/src/components/CaseManagerV2/ClientsPage.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/ClientsPage.tsx
@@ -2,6 +2,7 @@ import { DataModel, DataModelObject } from '@app-builder/models';
 import { CaseDetail, PivotObject } from '@app-builder/models/cases';
 import { useGetAnnotationsQuery } from '@app-builder/queries/data/get-annotations';
 import { useOrganizationDetails } from '@app-builder/services/organization/organization-detail';
+import { clientDetailLinkParams } from '@app-builder/utils/routes/client-detail-url';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import type { Client360Table } from 'marble-api';
@@ -62,7 +63,7 @@ export function CaseManagerClientsPage({
             {metadata && ingestedInfo ? (
               <Link
                 to="/client-detail/$objectType/$objectId"
-                params={ingestedInfo}
+                params={clientDetailLinkParams(ingestedInfo.objectType, ingestedInfo.objectId)}
                 className={CtaV2ClassName({ appearance: 'link', variant: 'primary' })}
               >
                 <Icon icon="eye" className="size-4" />

--- a/packages/app-builder/src/components/CaseManagerV2/PrincipalPage.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/PrincipalPage.tsx
@@ -11,6 +11,7 @@ import { editTagsPayloadSchema, useEditTagsMutation } from '@app-builder/queries
 import { useCaseDecisionsQuery } from '@app-builder/queries/cases/list-decisions';
 import { useOrganizationDetails } from '@app-builder/services/organization/organization-detail';
 import { useOrganizationTags } from '@app-builder/services/organization/organization-tags';
+import { clientDetailLinkParams } from '@app-builder/utils/routes/client-detail-url';
 import { useForm } from '@tanstack/react-form';
 import { Link } from '@tanstack/react-router';
 import type { Client360Table } from 'marble-api';
@@ -215,7 +216,7 @@ function ClientCard({ caseId, pivotObject, dataModel, client360Tables, userScori
           {metadata && pivotObject.isIngested ? (
             <Link
               to="/client-detail/$objectType/$objectId"
-              params={{ objectId: pivotObject.pivotObjectId!, objectType: pivotObject.pivotObjectName }}
+              params={clientDetailLinkParams(pivotObject.pivotObjectName, pivotObject.pivotObjectId!)}
               className={CtaV2ClassName({ appearance: 'link', variant: 'primary' })}
             >
               <Icon icon="eye" className="size-4" />

--- a/packages/app-builder/src/components/ClientDetail/ObjectHierarchy.tsx
+++ b/packages/app-builder/src/components/ClientDetail/ObjectHierarchy.tsx
@@ -1,6 +1,7 @@
 import { DataModel, type TableModel } from '@app-builder/models';
 import { useHierarchyQuery } from '@app-builder/queries/data/get-hierarchy';
 import { type HierarchyLeaf, type HierarchyNode, type HierarchyTreeBase } from '@app-builder/server-fns/data';
+import { clientDetailLinkParams } from '@app-builder/utils/routes/client-detail-url';
 import { UseQueryResult } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Client360Table } from 'marble-api';
@@ -264,7 +265,7 @@ const TreeItem = ({
             {!isHierarchyLeaf(item) && metadata ? (
               <Link
                 to="/client-detail/$objectType/$objectId"
-                params={{ objectType: item.objectType, objectId: item.data['object_id'] as string }}
+                params={clientDetailLinkParams(item.objectType, item.data['object_id'] as string)}
               >
                 <Icon icon="arrow-up-right" className="size-5" />
               </Link>
@@ -341,10 +342,7 @@ const TreeItemData = ({
           <Fragment key={itemObject['object_id'] as string}>
             <Link
               to="/client-detail/$objectType/$objectId"
-              params={{
-                objectType: item.objectType,
-                objectId: itemObject['object_id'] as string,
-              }}
+              params={clientDetailLinkParams(item.objectType, itemObject['object_id'] as string)}
               className="text-purple-primary hover:underline"
             >
               {itemObject[metadata.caption_field] as string}
@@ -367,10 +365,7 @@ const TreeItemData = ({
                   <Link
                     key={itemObject['object_id'] as string}
                     to="/client-detail/$objectType/$objectId"
-                    params={{
-                      objectType: item.objectType,
-                      objectId: itemObject['object_id'] as string,
-                    }}
+                    params={clientDetailLinkParams(item.objectType, itemObject['object_id'] as string)}
                     className="flex items-center justify-between h-6 hover:text-purple-primary"
                   >
                     <span>{itemObject[metadata.caption_field] as string}</span>

--- a/packages/app-builder/src/components/ClientDetail/SearchForm.tsx
+++ b/packages/app-builder/src/components/ClientDetail/SearchForm.tsx
@@ -1,4 +1,5 @@
 import { handleSubmit } from '@app-builder/utils/form';
+import { clientDetailLinkParams } from '@app-builder/utils/routes/client-detail-url';
 import { useForm } from '@tanstack/react-form';
 import { useNavigate } from '@tanstack/react-router';
 import { Client360Table } from 'marble-api';
@@ -35,7 +36,7 @@ export const SearchForm = ({ table }: SearchFormProps) => {
         if (z.uuid().safeParse(trimmedValue).success) {
           navigate({
             to: '/client-detail/$objectType/$objectId',
-            params: { objectType: table.name, objectId: trimmedValue },
+            params: clientDetailLinkParams(table.name, trimmedValue),
           });
         } else {
           navigate({

--- a/packages/app-builder/src/components/ClientDetail/SearchResults.tsx
+++ b/packages/app-builder/src/components/ClientDetail/SearchResults.tsx
@@ -2,6 +2,7 @@ import { useSearchClient360Query } from '@app-builder/queries/client360/search';
 import { useGetAnnotationsQuery } from '@app-builder/queries/data/get-annotations';
 import { Client360SearchPayload } from '@app-builder/schemas/client360';
 import { useOrganizationObjectTags } from '@app-builder/services/organization/organization-object-tags';
+import { clientDetailLinkParams } from '@app-builder/utils/routes/client-detail-url';
 import { Link } from '@tanstack/react-router';
 import { Client360Table } from 'marble-api';
 import { useTranslation } from 'react-i18next';
@@ -46,7 +47,10 @@ export const SearchResults = ({ payload, tables }: { payload: Client360SearchPay
                 <LinkWrapper
                   key={objectId}
                   link={
-                    <Link to="/client-detail/$objectType/$objectId" params={{ objectType: payload.table, objectId }} />
+                    <Link
+                      to="/client-detail/$objectType/$objectId"
+                      params={clientDetailLinkParams(payload.table, objectId)}
+                    />
                   }
                   className="p-md flex items-center border border-grey-border rounded-md bg-surface-card hover:shadow-md dark:hover:border-purple-primary"
                 >

--- a/packages/app-builder/src/routes/_app/_builder/client-detail/$objectType.$objectId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/client-detail/$objectType.$objectId.tsx
@@ -5,6 +5,8 @@ import { isForbiddenHttpError, isNotFoundHttpError, isUnauthorizedHttpError } fr
 import { DataModelContextProvider } from '@app-builder/services/data/data-model';
 import { dataModelFeatureAccessLoader } from '@app-builder/services/data/data-model-feature-access';
 import { setToast } from '@app-builder/services/toast.server';
+import { loadClientDetailObject } from '@app-builder/utils/routes/client-detail-object';
+import { decodeClientDetailObjectIdParam } from '@app-builder/utils/routes/client-detail-url';
 import { createFileRoute, isRedirect, redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { getRequest } from '@tanstack/react-start/server';
@@ -25,16 +27,18 @@ const getDataFn = createServerFn()
       const t = await i18nextService.getFixedT(request, ['common', 'client360']);
       const { user, dataModelRepository, userScoring, client360, entitlements } = context.authInfo;
 
-      const objectPromise = dataModelRepository.getIngestedObject(objectType, objectId).catch(async (error) => {
-        if (isNotFoundHttpError(error)) {
-          await setToast({
-            type: 'error',
-            message: t('client360:client_detail.no_object_found', { objectType }),
-          });
-          throw redirect({ to: '/client-detail' });
-        }
-        throw error;
-      });
+      const objectPromise = loadClientDetailObject(dataModelRepository, client360, objectType, objectId).catch(
+        async (error) => {
+          if (isNotFoundHttpError(error)) {
+            await setToast({
+              type: 'error',
+              message: t('client360:client_detail.no_object_found', { objectType }),
+            });
+            throw redirect({ to: '/client-detail' });
+          }
+          throw error;
+        },
+      );
 
       const [objectDetails, scoringSettings, tables, dataModel] = await Promise.all([
         objectPromise,
@@ -77,7 +81,8 @@ const getDataFn = createServerFn()
   });
 
 export const Route = createFileRoute('/_app/_builder/client-detail/$objectType/$objectId')({
-  loader: ({ params }) => getDataFn({ data: params }),
+  loader: ({ params: { objectType, objectId } }) =>
+    getDataFn({ data: { objectType, objectId: decodeClientDetailObjectIdParam(objectId) } }),
   errorComponent: ({ error }) => <ErrorComponent error={error} />,
   component: ClientDetailPage,
 });

--- a/packages/app-builder/src/utils/routes/client-detail-object.ts
+++ b/packages/app-builder/src/utils/routes/client-detail-object.ts
@@ -1,0 +1,23 @@
+import { isNotFoundHttpError } from '@app-builder/models';
+import { type DataModelObject, type DataModelObjectValue } from '@app-builder/models/data-model';
+import { type Client360Repository } from '@app-builder/repositories/Client360Repository';
+import { type DataModelRepository } from '@app-builder/repositories/DataModelRepository';
+
+export async function loadClientDetailObject(
+  dataModelRepository: DataModelRepository,
+  client360: Client360Repository,
+  objectType: string,
+  objectId: string,
+): Promise<DataModelObject> {
+  try {
+    return await dataModelRepository.getIngestedObject(objectType, objectId);
+  } catch (error) {
+    if (!isNotFoundHttpError(error)) throw error;
+
+    const searchResult = await client360.searchClient360({ table: objectType, terms: objectId });
+    const item = searchResult.items.find((entry) => String(entry['object_id']) === objectId);
+    if (!item) throw error;
+
+    return { data: item as Record<string, DataModelObjectValue> };
+  }
+}

--- a/packages/app-builder/src/utils/routes/client-detail-url.spec.ts
+++ b/packages/app-builder/src/utils/routes/client-detail-url.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { decodeClientDetailObjectIdParam, encodeClientDetailObjectIdParam } from './client-detail-url';
+
+describe('client-detail-url', () => {
+  it('keeps ids without slashes unchanged', () => {
+    expect(encodeClientDetailObjectIdParam('abc-123')).toBe('abc-123');
+    expect(decodeClientDetailObjectIdParam('abc-123')).toBe('abc-123');
+  });
+
+  it('encodes ids containing slashes as a single path segment', () => {
+    const encoded = encodeClientDetailObjectIdParam('/test');
+    expect(encoded).not.toContain('/');
+    expect(encoded.startsWith('b64.')).toBe(true);
+    expect(decodeClientDetailObjectIdParam(encoded)).toBe('/test');
+  });
+
+  it('round-trips unicode ids with slashes', () => {
+    const objectId = '/données/été';
+    const encoded = encodeClientDetailObjectIdParam(objectId);
+    expect(encoded).not.toContain('/');
+    expect(decodeClientDetailObjectIdParam(encoded)).toBe(objectId);
+  });
+});

--- a/packages/app-builder/src/utils/routes/client-detail-url.ts
+++ b/packages/app-builder/src/utils/routes/client-detail-url.ts
@@ -19,7 +19,7 @@ function fromBase64Url(encoded: string): string {
 
 /** Encode an ingested object id for the client-detail route param. */
 export function encodeClientDetailObjectIdParam(objectId: string): string {
-  if (!objectId.includes('/')) {
+  if (!objectId.includes('/') && !objectId.startsWith(B64_PREFIX)) {
     return objectId;
   }
   return `${B64_PREFIX}${toBase64Url(objectId)}`;

--- a/packages/app-builder/src/utils/routes/client-detail-url.ts
+++ b/packages/app-builder/src/utils/routes/client-detail-url.ts
@@ -1,0 +1,38 @@
+const B64_PREFIX = 'b64.';
+
+function toBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(encoded: string): string {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(base64 + padding);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/** Encode an ingested object id for the client-detail route param. */
+export function encodeClientDetailObjectIdParam(objectId: string): string {
+  if (!objectId.includes('/')) {
+    return objectId;
+  }
+  return `${B64_PREFIX}${toBase64Url(objectId)}`;
+}
+
+/** Decode the client-detail route param back to the ingested object id. */
+export function decodeClientDetailObjectIdParam(objectIdParam: string): string {
+  if (!objectIdParam.startsWith(B64_PREFIX)) {
+    return objectIdParam;
+  }
+  return fromBase64Url(objectIdParam.slice(B64_PREFIX.length));
+}
+
+export function clientDetailLinkParams(objectType: string, objectId: string) {
+  return { objectType, objectId: encodeClientDetailObjectIdParam(objectId) };
+}

--- a/packages/app-builder/src/utils/routes/index.ts
+++ b/packages/app-builder/src/utils/routes/index.ts
@@ -1,3 +1,10 @@
 export function getReferer(request: Request, options: { fallback: string }) {
   return request.headers.get('referer') ?? options.fallback;
 }
+
+export { loadClientDetailObject } from './client-detail-object';
+export {
+  clientDetailLinkParams,
+  decodeClientDetailObjectIdParam,
+  encodeClientDetailObjectIdParam,
+} from './client-detail-url';


### PR DESCRIPTION
if the `obect_id` contains a `/` it is converted in base64 and decoded in the route loader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved client-detail navigation so links now safely support IDs that include special characters, including slashes, with consistent URL handling across search, hierarchy, and “see all” entry points.

* **Bug Fixes**
  * Fixed client-detail pages to properly decode encoded IDs before loading data.
  * Improved client-detail loading reliability with a stronger fallback when the primary lookup fails, helping the page resolve more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->