### PR TITLE
fix sentry upload from frontend build + make it blocking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ RUN mkdir -p \
 FROM ${BUN_IMAGE} AS build
 WORKDIR /usr/src/app
 
+# The bun base image (debian-slim) ships without a CA bundle. sentry-cli needs
+# it to verify TLS when uploading releases/source maps, otherwise it fails with
+# "unable to get local issuer certificate".
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy full source AFTER deps to leverage layer caching
 COPY . .
 # Reuse cached node_modules from deps stage

--- a/packages/app-builder/src/routeTree.gen.ts
+++ b/packages/app-builder/src/routeTree.gen.ts
@@ -803,7 +803,7 @@ export interface FileRoutesByFullPath {
   '/sign-in-email': typeof AppAuthSignInEmailRoute
   '/account': typeof AppBuilderAccountRoute
   '/analytics-legacy': typeof AppBuilderAnalyticsLegacyRoute
-  '/cases': typeof AppBuilderCasesDetailRouteWithChildren
+  '/cases': typeof AppBuilderCasesRouteWithChildren
   '/continuous-screening': typeof AppBuilderContinuousScreeningRouteWithChildren
   '/data': typeof AppBuilderDataRouteWithChildren
   '/design': typeof AppBuilderDesignRoute
@@ -878,7 +878,7 @@ export interface FileRoutesByFullPath {
   '/cases/$caseId/d/$decisionId/screenings': typeof AppBuilderCasesCaseIdDDecisionIdScreeningsRouteWithChildren
   '/cases/s/$caseId': typeof AppBuilderCasesDetailSCaseIdNewRouteWithChildren
   '/cases/s/$caseId/old': typeof AppBuilderCasesDetailSCaseIdOldRoute
-  '/detection/scenarios/$scenarioId/i/$iterationId': typeof AppBuilderDetectionScenariosScenarioIdIIterationIdEditViewRouteWithChildren
+  '/detection/scenarios/$scenarioId/i/$iterationId': typeof AppBuilderDetectionScenariosScenarioIdIIterationIdRouteWithChildren
   '/detection/scenarios/$scenarioId/test-run/': typeof AppBuilderDetectionScenariosScenarioIdTestRunIndexRoute
   '/cases/$caseId/d/$decisionId/screenings/$screeningId': typeof AppBuilderCasesCaseIdDDecisionIdScreeningsScreeningIdRouteWithChildren
   '/cases/s/$caseId/clients': typeof AppBuilderCasesDetailSCaseIdNewClientsRouteWithChildren

--- a/packages/app-builder/vite.config.ts
+++ b/packages/app-builder/vite.config.ts
@@ -42,6 +42,11 @@ const plugins = [
               sourcemaps: {
                 filesToDeleteAfterUpload: ['./build/**/*.map'],
               },
+              // Source-map upload is non-fatal by default; rethrow so a failed
+              // upload fails the (CI-only) release build instead of passing silently.
+              errorHandler: (err) => {
+                throw err;
+              },
             })
           : []),
       ]),


### PR DESCRIPTION
A version bump in the sentry CLI makes uploading release & source maps fail (silently), because it now depends on local CA certificates.
I also changed a config to make it blocking when this happens, because I found out totally randomly by reading the CI logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by ensuring certificate verification works during container builds.
  * Surfaced sourcemap upload failures so release builds don’t pass when uploads fail.

* **Refactor**
  * Updated route mappings to match the current app navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->