### PR TITLE
fix(sentry): set commits explicitly instead of --auto

### DIFF
--- a/packages/app-builder/vite.config.ts
+++ b/packages/app-builder/vite.config.ts
@@ -37,7 +37,14 @@ const plugins = [
           ? sentryVitePlugin({
               telemetry: false,
               release: {
-                setCommits: { auto: true },
+                // Associate commits explicitly via the SHA we already inject as
+                // SENTRY_RELEASE. Avoids `auto: true`, which needs a local .git
+                // (excluded from the Docker build).
+                setCommits: {
+                  auto: false,
+                  repo: 'checkmarble/marble-frontend',
+                  commit: process.env['SENTRY_RELEASE'] ?? '',
+                },
               },
               sourcemaps: {
                 filesToDeleteAfterUpload: ['./build/**/*.map'],


### PR DESCRIPTION
`setCommits: { auto: true }` reads commits from a local .git, which is excluded from the Docker build (.dockerignore), so commit association always failed — silently before, and as a hard failure once upload errors were made fatal.

Pass repo + commit (SENTRY_RELEASE) explicitly instead; Sentry resolves it via the GitHub integration with no .git needed. Verified against the real org for both a SHA (staging) and a tag ref (production).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release tracking configuration for builds so commits are associated more reliably in deployment environments.
  * Reduced dependence on local repository metadata during containerized builds, helping make builds more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->