### PR TITLE
add a small delay before sidebar unfolds

### DIFF
--- a/packages/app-builder/src/components/Layout/LeftSidebar.tsx
+++ b/packages/app-builder/src/components/Layout/LeftSidebar.tsx
@@ -3,7 +3,7 @@ import type * as React from 'react';
 export function LeftSidebar({ children }: { children: React.ReactNode }) {
   return (
     <div className="group/sidebar sticky top-0 left-0 z-20 h-screen max-h-screen w-14 shrink-0">
-      <div className="group/nav flex h-full w-14 flex-col border-e border-e-grey-border bg-surface-sidebar transition-all delay-300 group-hover/sidebar:absolute group-hover/sidebar:top-0 group-hover/sidebar:left-0 group-hover/sidebar:w-58.5 group-hover/sidebar:shadow-sticky-left group-hover/sidebar:delay-0 motion-reduce:delay-0 motion-reduce:duration-0">
+      <div className="group/nav flex h-full w-14 flex-col border-e border-e-grey-border bg-surface-sidebar transition-all delay-400 group-hover/sidebar:absolute group-hover/sidebar:top-0 group-hover/sidebar:left-0 group-hover/sidebar:w-58.5 group-hover/sidebar:shadow-sticky-left group-hover/sidebar:delay-200 motion-reduce:delay-0 motion-reduce:duration-0">
         {children}
       </div>
     </div>


### PR DESCRIPTION
Increase delay before the sidebar expands on hover from 0ms (any time the mouse gets close to it it expands) to 200ms (still fast, but requires a level of intent)