### PR TITLE
CI allows rc versions, as backend

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -5,27 +5,27 @@ on:
     inputs:
       environment:
         type: string
-        description: 'Github environment to use'
+        description: "Github environment to use"
         required: true
       version:
         type: string
-        description: 'version to deploy'
+        description: "version to deploy"
         required: true
       SENTRY_RELEASE:
         type: string
         required: true
-        description: 'Sentry release name'
+        description: "Sentry release name"
     secrets:
       SENTRY_AUTH_TOKEN:
         required: true
-        description: 'Sentry Auth Token'
+        description: "Sentry Auth Token"
       SEGMENT_WRITE_KEY_OPENSOURCE:
         description: write key for segment (open source deployment). Can be overridden at runtime
 
 permissions:
   contents: read
   actions: read
-  id-token: 'write' # needed for using open id token to authenticate with GCP
+  id-token: "write" # needed for using open id token to authenticate with GCP
 
 jobs:
   main:
@@ -82,8 +82,8 @@ jobs:
           secrets: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v3'
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v3"
         with:
           install_components: beta
 
@@ -92,4 +92,4 @@ jobs:
           gcloud run deploy marble-frontend \
             --quiet \
             --region="europe-west1" \
-            --image="${{ env.IMAGE }}"
+            --image="$IMAGE"

--- a/.github/workflows/tags_push.yaml
+++ b/.github/workflows/tags_push.yaml
@@ -3,10 +3,11 @@ name: Push a tag (Check & Deploy)
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+" # stable
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+" # release candidate (e.g. v1.2.0-rc.1)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -21,10 +22,10 @@ jobs:
     permissions:
       contents: read
       actions: read
-      id-token: 'write' # needed for using open id token to authenticate with GCP
+      id-token: "write" # needed for using open id token to authenticate with GCP
     uses: ./.github/workflows/build_and_deploy.yaml
     with:
-      environment: 'production'
+      environment: "production"
       version: ${{ github.ref_name }}
       SENTRY_RELEASE: ${{ github.ref_name }}
     secrets:

--- a/.github/workflows/tags_push.yaml
+++ b/.github/workflows/tags_push.yaml
@@ -3,8 +3,8 @@ name: Push a tag (Check & Deploy)
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # stable
-      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+" # release candidate (e.g. v1.2.0-rc.1)
+      - "v[0-9]+\\.[0-9]+\\.[0-9]+" # stable
+      - "v[0-9]+\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+" # release candidate (e.g. v1.2.0-rc.1)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
Frontend version of this backend PR https://github.com/checkmarble/marble-backend/pull/1794
Allow to create and release versions like vX.X.X-rc.Y, before we release for open-source