### PR TITLE
fix: fix gt to gte in customer scoring configuration

### DIFF
--- a/packages/app-builder/src/locales/ar/user-scoring.json
+++ b/packages/app-builder/src/locales/ar/user-scoring.json
@@ -91,7 +91,7 @@
   "switch.floor_label": "الحد الأدنى =",
   "switch.no_condition": "لا توجد شروط محددة",
   "switch.number.and": "و",
-  "switch.number.default": "وإلا، >",
+  "switch.number.default": "وإلا، ≥",
 
   "switch.number.first": "إذا كانت القيمة ≤",
   "switch.number.middle": "إذا كانت القيمة بين",

--- a/packages/app-builder/src/locales/en/user-scoring.json
+++ b/packages/app-builder/src/locales/en/user-scoring.json
@@ -91,7 +91,7 @@
   "switch.floor_label": "floor =",
   "switch.no_condition": "No condition defined",
   "switch.number.and": "and",
-  "switch.number.default": "otherwise, > to",
+  "switch.number.default": "otherwise, ≥ to",
 
   "switch.number.first": "if value ≤ to",
   "switch.number.middle": "if value is between",

--- a/packages/app-builder/src/locales/fr/user-scoring.json
+++ b/packages/app-builder/src/locales/fr/user-scoring.json
@@ -91,7 +91,7 @@
   "switch.floor_label": "seuil =",
   "switch.no_condition": "Aucune condition définie",
   "switch.number.and": "et",
-  "switch.number.default": "si non, > à",
+  "switch.number.default": "si non, ≥ à",
 
   "switch.number.first": "si la valeur est ≤ à",
   "switch.number.middle": "si la valeur est entre",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the numeric condition text in the app’s switch logic to show “greater than or equal to” instead of “greater than.”
  * Applied the same correction across Arabic, English, and French displays for consistent wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->