### PR TITLE
feat: enhance AstBuilder components with excludeFields support

### DIFF
--- a/packages/app-builder/src/components/AstBuilder/Operand.tsx
+++ b/packages/app-builder/src/components/AstBuilder/Operand.tsx
@@ -7,15 +7,19 @@ import { AstBuilderDataSharpFactory } from './Provider';
 import { type AstBuilderBaseProps } from './types';
 import { ViewingAstBuilderOperand } from './viewing/ViewingOperand';
 
+export type AstBuilderValidationStatus = 'valid' | 'error' | 'light-error';
+
 export type AstBuilderOperandProps = AstBuilderBaseProps<KnownOperandAstNode> & {
   enumValues?: EnumValue[];
   showErrors?: boolean;
   placeholder?: string;
   onChange?: (node: AstNode) => void;
   optionsDataType?: DataType[] | ((o: EnrichedMenuOption) => boolean);
+  excludeFields?: string[];
   coerceDataType?: DataType[];
   returnValue?: string;
-} & { validationStatus?: 'valid' | 'error' | 'light-error' };
+  validationStatus?: AstBuilderValidationStatus;
+};
 
 export function AstBuilderOperand(props: AstBuilderOperandProps) {
   const builderMode = AstBuilderDataSharpFactory.select((s) => s.mode);

--- a/packages/app-builder/src/components/AstBuilder/edition/EditionAnyRoot.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditionAnyRoot.tsx
@@ -14,6 +14,7 @@ export function EditionAstBuilderAnyRoot(props: AstBuilderRootProps) {
         path="root"
         coerceDataType={props.coerceDataType}
         optionsDataType={props.optionsDataType}
+        excludeFields={props.excludeFields}
       />
       <EditionEvaluationErrors id={nodeStore.value.node.id} />
     </AstBuilderNodeSharpFactory.Provider>

--- a/packages/app-builder/src/components/AstBuilder/edition/EditionNode.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditionNode.tsx
@@ -73,10 +73,12 @@ export const EditionAstBuilderNode = memo(function EditionAstBuilderNode(props: 
   path: string;
   coerceDataType?: AstBuilderOperandProps['coerceDataType'];
   optionsDataType?: AstBuilderOperandProps['optionsDataType'];
+  excludeFields?: AstBuilderOperandProps['excludeFields'];
 }) {
   const operandProps = {
     coerceDataType: props.coerceDataType,
     optionsDataType: props.optionsDataType,
+    excludeFields: props.excludeFields,
   };
   const dataSharp = AstBuilderDataSharpFactory.useSharp();
   const data = dataSharp.value.$data!.value;

--- a/packages/app-builder/src/components/AstBuilder/edition/EditionOperand.tsx
+++ b/packages/app-builder/src/components/AstBuilder/edition/EditionOperand.tsx
@@ -22,7 +22,7 @@ import { MenuCommand } from 'ui-design-system';
 
 import { OperandEditModal } from './EditModal/EditModal';
 import { EditionEvaluationErrors } from './EvaluationErrors';
-import { type EnrichedMenuOption, getOperandMenuOptions } from './helpers';
+import { type EnrichedMenuOption, getFieldName, getOperandMenuOptions } from './helpers';
 import { AstBuilderNodeSharpFactory } from './node-store';
 import { AstBuilderOperandMenu, type BottomAction } from './OperandMenu';
 
@@ -52,6 +52,7 @@ type EditionOperandStore = {
   options: EnrichedMenuOption[];
   optionsDataType: DataType[] | ((o: EnrichedMenuOption) => boolean) | undefined;
   coerceDataType: DataType[] | undefined;
+  excludeFields?: string[];
 };
 
 export const EditionOperandSharpFactory = createSharpFactory({
@@ -61,19 +62,35 @@ export const EditionOperandSharpFactory = createSharpFactory({
   }),
 })
   .withActions({
-    setEnumsAndOptions(api, enums: EnumValue[] | undefined, options: EnrichedMenuOption[]) {
+    setEnumsAndOptions(
+      api,
+      enums: EnumValue[] | undefined,
+      options: EnrichedMenuOption[],
+      excludeFields: string[] | undefined,
+    ) {
       api.batch(() => {
         api.value.enumValues = enums;
         api.value.options = options;
+        api.value.excludeFields = excludeFields;
       });
     },
   })
   .withComputed({
     filteredOptions(state) {
       const dataTypes = state.optionsDataType;
-      return dataTypes
-        ? state.options.filter((o) => (typeof dataTypes === 'function' ? dataTypes(o) : dataTypes.includes(o.dataType)))
-        : state.options;
+      const excludeFields = state.excludeFields;
+
+      return state.options.filter((option) => {
+        const matchesDataType = dataTypes
+          ? typeof dataTypes === 'function'
+            ? dataTypes(option)
+            : dataTypes.includes(option.dataType)
+          : true;
+        const fieldName = getFieldName(option.astNode);
+        const isExcludedField = fieldName !== 'unknown' ? excludeFields?.includes(fieldName) : false;
+
+        return matchesDataType && !isExcludedField;
+      });
     },
   });
 
@@ -97,9 +114,11 @@ export function EditionAstBuilderOperand({ onChange, ...props }: AstBuilderOpera
       node,
       language,
       t,
+      excludeFields: props.excludeFields,
     }),
     optionsDataType: props.optionsDataType,
     coerceDataType: props.coerceDataType,
+    excludeFields: props.excludeFields,
   });
   const onSelect = useCallbackRef(onChange);
   const onCreateSelect = useCallbackRef((node: AstNode) => {
@@ -124,9 +143,11 @@ export function EditionAstBuilderOperand({ onChange, ...props }: AstBuilderOpera
         node,
         language,
         t,
+        excludeFields: props.excludeFields,
       }),
+      props.excludeFields,
     );
-  }, [operandSharp, props.enumValues, data.value, triggerObjectTable.value, node, t, language]);
+  }, [operandSharp, props.enumValues, props.excludeFields, data.value, triggerObjectTable.value, node, t, language]);
 
   const bottomActions: BottomAction[] = [
     ...(!isUndefinedAstNode(node)

--- a/packages/app-builder/src/components/AstBuilder/edition/helpers.ts
+++ b/packages/app-builder/src/components/AstBuilder/edition/helpers.ts
@@ -37,7 +37,7 @@ export type EnrichedMenuOption = Omit<OperandMenuOption, 'operandType' | 'displa
   dataType: NonNullable<OperandMenuOption['dataType']>;
 };
 
-function getFieldName(astNode: IdLessAstNode) {
+export function getFieldName(astNode: IdLessAstNode) {
   return match(astNode)
     .when(isDatabaseAccess, (n) => n.namedChildren.fieldName.constant)
     .when(isPayload, (n) => n.children[0].constant)
@@ -64,6 +64,7 @@ export function getOperandMenuOptions(params: {
   triggerObjectTable: TableModel;
   language: string;
   t: TFunction<['common', 'scenarios'], undefined>;
+  excludeFields?: string[];
 }) {
   const mapOption = createMapOption({
     enumValues: params.enums,
@@ -76,11 +77,17 @@ export function getOperandMenuOptions(params: {
 
   return [
     ...AST_BUILDER_STATIC_OPTIONS,
-    ...params.data.databaseAccessors.map((a) => ({
-      astNode: a,
-      displayName: a.namedChildren.fieldName.constant,
-    })),
-    ...params.data.payloadAccessors.map((a) => ({ astNode: a })),
+    ...params.data.databaseAccessors
+      .filter((a) => !params.excludeFields?.includes(getFieldName(a)))
+      .map((a) => ({
+        astNode: a,
+        displayName: a.namedChildren.fieldName.constant,
+      })),
+    ...params.data.payloadAccessors
+      .filter((a) => !params.excludeFields?.includes(getFieldName(a)))
+      .map((a) => ({
+        astNode: a,
+      })),
     ...params.data.customLists.map((l) => ({
       astNode: NewCustomListAstNode(l.id),
     })),

--- a/packages/app-builder/src/components/AstBuilder/types.ts
+++ b/packages/app-builder/src/components/AstBuilder/types.ts
@@ -28,4 +28,5 @@ export type AstBuilderRootProps<NodeType extends AstNode = AstNode> = {
   returnType?: ReturnValueType;
   coerceDataType?: AstBuilderOperandProps['coerceDataType'];
   optionsDataType?: AstBuilderOperandProps['optionsDataType'];
+  excludeFields?: AstBuilderOperandProps['excludeFields'];
 };

--- a/packages/app-builder/src/components/Scenario/Screening/FieldEntityType.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/FieldEntityType.tsx
@@ -20,7 +20,7 @@ export const FieldEntityType = ({
     <div className="flex flex-col gap-md">
       <MenuCommand.Menu persistOnSelect={false} open={open} onOpenChange={setOpen}>
         <MenuCommand.Trigger>
-          <Button variant="secondary" className="w-52 justify-between" disabled={editor === 'view'}>
+          <Button variant="secondary" className="w-52 justify-between" size="large" disabled={editor === 'view'}>
             <span className="text-grey-primary text-s font-medium">{getEntityName(entityType)}</span>
             <Icon icon="caret-down" className="text-grey-secondary size-4" />
           </Button>

--- a/packages/app-builder/src/components/Scenario/Screening/FieldNodeConcat.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/FieldNodeConcat.tsx
@@ -23,6 +23,7 @@ export function FieldNodeConcat({
   onChange,
   viewOnly,
   placeholder,
+  withDate,
 }: {
   value?: StringConcatAstNode;
   limit?: number;
@@ -30,6 +31,7 @@ export function FieldNodeConcat({
   onChange?: (node: AstNode | null) => void;
   onBlur?: () => void;
   viewOnly?: boolean;
+  withDate?: boolean;
 }) {
   const [nodes, setNodes] = useState<KnownOperandAstNode[]>(() =>
     value?.children?.length ? value.children : [NewUndefinedAstNode()],
@@ -138,6 +140,7 @@ export function FieldNodeConcat({
                             applyNodes(replace(nodes, { ...savedNode, id: node.id }, (_, i) => i === index));
                           }
                         }}
+                        withDate={withDate}
                       />
                     </div>
                   )}

--- a/packages/app-builder/src/components/Scenario/Screening/FieldSkipIfUnder.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/FieldSkipIfUnder.tsx
@@ -40,7 +40,7 @@ export const FieldSkipIfUnder = ({ value, onBlur, onChange, editor, name }: Fiel
               <Input
                 type="number"
                 name={name}
-                className="z-0 h-6 w-14 py-0"
+                className="z-0 w-14 py-0"
                 value={inputValue}
                 min={0}
                 onChange={handleInputChange}

--- a/packages/app-builder/src/components/Scenario/Screening/MatchOperand.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/MatchOperand.tsx
@@ -7,16 +7,19 @@ export const MatchOperand = memo(function MatchOperand({
   node,
   onSave,
   placeholder,
+  withDate,
 }: {
   node?: KnownOperandAstNode;
   onSave?: (astNode: AstNode) => void;
   placeholder?: string;
+  withDate?: boolean;
 }) {
   return (
     <AstBuilder.Operand
       placeholder={placeholder}
       node={node ?? NewUndefinedAstNode()}
-      optionsDataType={['String']}
+      optionsDataType={withDate ? ['String', 'Timestamp'] : ['String']}
+      excludeFields={withDate ? ['updated_at'] : undefined}
       validationStatus="valid"
       onChange={onSave}
     />

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/i/$iterationId/screenings.$screeningId.tsx
@@ -800,6 +800,7 @@ function ScreeningDetail() {
                                         onBlur={field.handleBlur}
                                         placeholder={t('scenarios:edit_sanction.birthdate_placeholder')}
                                         limit={5}
+                                        withDate
                                       />
                                       <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
                                     </div>


### PR DESCRIPTION
- Added excludeFields property to AstBuilderOperandProps for filtering options.
- Updated related components (EditionAnyRoot, EditionNode, EditionOperand) to utilize excludeFields.
- Modified filtering logic in EditionOperandSharpFactory to respect excludeFields.
- Enhanced getOperandMenuOptions to filter out excluded fields from database and payload accessors.
- Introduced withDate prop in MatchOperand to conditionally exclude fields based on date context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hiding specific fields from builder options, improving control over available selections.
  * Enabled date-aware matching for screening fields so date-related inputs can offer the right options.

* **Bug Fixes**
  * Updated screening behavior to exclude an unavailable field from date-based matching.
  * Refined a few input and button styles for a cleaner, more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->