### PR TITLE
MAR-2080 &  MAR-2079

### DIFF
--- a/packages/app-builder/src/components/CaseManagerV2/KycEnrichment/KycEnrichmentPanel.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/KycEnrichment/KycEnrichmentPanel.tsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/tanstackstart-react';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button, Markdown, Typo } from 'ui-design-system';
+import { Markdown, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { Callout } from '../../Callout';
 import { Spinner } from '../../Spinner';
@@ -64,20 +64,15 @@ export function KycEnrichmentPanel({ caseId, open, onOpenChange }: KycEnrichment
   return (
     <Panel.Root open={open} onOpenChange={onOpenChange}>
       <Panel.Container size="medium">
-        <div className="flex items-center gap-sm pb-md border-b border-grey-border">
-          <Icon icon="ai-review" className="size-5 text-purple-primary shrink-0" />
-          <Typo variant="title2" className="flex-1 text-grey-primary">
-            {t('cases:kyc_enrichment.title')}
-          </Typo>
-          <Icon
-            icon="cross"
-            className="size-5 cursor-pointer text-grey-secondary hover:text-grey-primary shrink-0"
-            onClick={() => onOpenChange(false)}
-            aria-label={t('common:close')}
-          />
-        </div>
-
-        <div className="flex flex-col gap-md flex-1 overflow-y-auto py-md">
+        <Panel.Content>
+          <Panel.Header>
+            <div className="flex items-center gap-sm">
+              <Icon icon="ai-review" className="size-5 text-purple-primary shrink-0" />
+              <Typo variant="title2" className="flex-1 text-grey-primary">
+                {t('cases:kyc_enrichment.title')}
+              </Typo>
+            </div>
+          </Panel.Header>
           {isPending ? (
             <div className="flex flex-col gap-md">
               <div className="flex justify-center gap-sm">
@@ -89,42 +84,43 @@ export function KycEnrichmentPanel({ caseId, open, onOpenChange }: KycEnrichment
           ) : null}
           {error ? <Callout variant="outlined">{error.message}</Callout> : null}
           {isSuccess && data.success && kycCaseEnrichment ? (
-            <>
+            <div className="flex flex-col gap-md">
               <Callout variant="outlined">
                 {t('cases:kyc_enrichment.for')} <strong>{kycCaseEnrichment.entityName}</strong>
               </Callout>
-              <div>
-                <Markdown>{kycCaseEnrichment.analysis}</Markdown>
-                <div className="mt-md">
-                  {kycCaseEnrichment.citations.map((citation, index) => (
-                    <div key={`citation.${index}`} className="mb-sm">
-                      <span>[{index + 1}]</span>{' '}
-                      <a
-                        className="text-purple-primary hover:bg-purple-background hover:text-grey-secondary"
-                        href={citation.url}
-                      >
-                        {citation.title}
-                      </a>
-                    </div>
-                  ))}
-                </div>
+              <Markdown>{kycCaseEnrichment.analysis}</Markdown>
+              <div className="mt-md">
+                {kycCaseEnrichment.citations.map((citation, index) => (
+                  <div key={`citation.${index}`} className="mb-sm flex gap-sm">
+                    <span>[{index + 1}]</span>
+                    <a
+                      className="text-purple-primary hover:bg-purple-background hover:text-grey-secondary"
+                      href={citation.url}
+                    >
+                      {citation.title}
+                    </a>
+                  </div>
+                ))}
               </div>
-            </>
+            </div>
           ) : null}
-        </div>
 
-        <div className="pt-md border-t border-grey-border mt-auto flex items-center justify-end gap-xs">
-          <Button
-            disabled={addCommentMutation.isPending || !isSuccess || isCommentAdded}
-            variant="primary"
-            onClick={() => handleAddComment()}
-          >
-            {t('cases:kyc_enrichment.attach_to_case')}
-          </Button>
-          <Button disabled={addCommentMutation.isPending} variant="secondary" onClick={() => onOpenChange(false)}>
-            {t('common:close')}
-          </Button>
-        </div>
+          <Panel.Footer>
+            <Panel.FooterButton
+              isCloseButton
+              disabled={addCommentMutation.isPending}
+              variant="secondary"
+              onClick={() => onOpenChange(false)}
+              label={t('common:close')}
+            />
+            <Panel.FooterButton
+              disabled={addCommentMutation.isPending || !isSuccess || isCommentAdded}
+              variant="primary"
+              onClick={() => handleAddComment()}
+              label={t('cases:kyc_enrichment.attach_to_case')}
+            />
+          </Panel.Footer>
+        </Panel.Content>
       </Panel.Container>
     </Panel.Root>
   );

--- a/packages/app-builder/src/components/CaseManagerV2/PageLayout.tsx
+++ b/packages/app-builder/src/components/CaseManagerV2/PageLayout.tsx
@@ -127,10 +127,16 @@ export function CaseManagerPageLayout({
         <Page.Content className="relative">
           <div className="flex justify-between mb-lg">
             <Tabs>
-              <Link className={tabClassName} from="/cases/s/$caseId" to="./principal">
+              <Link className={tabClassName} from="/cases/s/$caseId" to="./principal" preload="render">
                 {t('cases:case_detail.tab.principal')}
               </Link>
-              <Link disabled={!pivotObjects.length} className={tabClassName} from="/cases/s/$caseId" to="./clients">
+              <Link
+                disabled={!pivotObjects.length}
+                className={tabClassName}
+                from="/cases/s/$caseId"
+                to="./clients"
+                preload={pivotObjects.length ? 'render' : false}
+              >
                 {t('cases:manager.tab.clients_concerned')}
               </Link>
             </Tabs>

--- a/packages/app-builder/src/components/Cases/Overview/Panel/WorkflowInboxCard.tsx
+++ b/packages/app-builder/src/components/Cases/Overview/Panel/WorkflowInboxCard.tsx
@@ -46,30 +46,33 @@ export const WorkflowInboxCard = ({ inbox, settings, onToggle, disabled, default
 
         <Collapsible.Content>
           <div className="flex flex-col gap-sm px-md pb-md">
-            <div className="flex items-center gap-sm">
+            <label htmlFor="caseReviewOnCaseCreated" className="flex items-center gap-sm">
               <Switch
+                id="caseReviewOnCaseCreated"
                 checked={settings.caseReviewOnCaseCreated}
                 onCheckedChange={(checked) => onToggle('caseReviewOnCaseCreated', checked)}
                 disabled={disabled}
               />
               <span className="text-s">{t('cases:overview.workflow.case_created')}</span>
-            </div>
-            <div className="flex items-center gap-sm">
+            </label>
+            <label htmlFor="caseReviewOnEscalate" className="flex items-center gap-sm">
               <Switch
+                id="caseReviewOnEscalate"
                 checked={settings.caseReviewOnEscalate}
                 onCheckedChange={(checked) => onToggle('caseReviewOnEscalate', checked)}
                 disabled={disabled}
               />
               <span className="text-s">{t('cases:overview.workflow.case_escalated')}</span>
-            </div>
-            <div className="flex items-center gap-sm">
+            </label>
+            <label htmlFor="caseReviewManual" className="flex items-center gap-sm">
               <Switch
+                id="caseReviewManual"
                 checked={settings.caseReviewManual}
                 onCheckedChange={(checked) => onToggle('caseReviewManual', checked)}
                 disabled={disabled}
               />
               <span className="text-s">{t('cases:overview.workflow.manual_request')}</span>
-            </div>
+            </label>
           </div>
         </Collapsible.Content>
       </div>


### PR DESCRIPTION
Added preload attributes to Links in CaseManagerPageLayout for better performance.

MAR-2079: Missing padding on KYC enrichment panel
Refactored KycEnrichmentPanel to use Panel components for a cleaner layout and improved accessibility.

Updated WorkflowInboxCard to wrap Switch components in labels for better usability and accessibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the KYC enrichment panel layout with clearer sectioning, better citation display, and dedicated footer actions for closing or attaching results to a case.
  * Updated case tabs to preload content more intelligently, helping some sections open faster.
* **Bug Fixes**
  * Improved toggle controls in case workflow settings by properly linking labels to switches, making them easier to use and more accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->