### PR TITLE
fix: logo growing before sidebar MAR-2085

### DIFF
--- a/packages/app-builder/src/components/Navigation.tsx
+++ b/packages/app-builder/src/components/Navigation.tsx
@@ -40,7 +40,7 @@ export function SidebarLink({ Icon, labelTKey, to, children, className }: Sideba
       to={to}
     >
       <Icon className="size-6 shrink-0" />
-      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
+      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-400 group-hover/sidebar:delay-200">
         {t(labelTKey)}
       </span>
       {children}
@@ -62,7 +62,7 @@ export const SidebarButton = React.forwardRef<HTMLButtonElement, SidebarButtonPr
   return (
     <button ref={ref} className={sidebarLink({ className })} {...props}>
       <Icon className="size-6 shrink-0" />
-      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
+      <span className="line-clamp-1 text-start opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-400 group-hover/sidebar:delay-200">
         {t(labelTKey)}
       </span>
     </button>

--- a/packages/app-builder/src/routes/_app/_builder.tsx
+++ b/packages/app-builder/src/routes/_app/_builder.tsx
@@ -82,7 +82,7 @@ const SIDEBAR_NUDGE_CLASS = cn(
   'absolute top-sm right-sm translate-x-[50%] -translate-y-[50%] rounded-full size-2.5',
   'group-hover/sidebar:static group-hover/sidebar:translate-x-0 group-hover/sidebar:translate-y-0',
   'group-hover/sidebar:rounded-sm group-hover/sidebar:size-6',
-  'transition-all delay-300 group-hover/sidebar:delay-0 motion-reduce:delay-0 motion-reduce:duration-0',
+  'transition-all delay-400 group-hover/sidebar:delay-200 motion-reduce:delay-0 motion-reduce:duration-0',
 );
 const SIDEBAR_NUDGE_ICON_CLASS = 'size-2.5 group-hover/sidebar:size-3';
 
@@ -144,7 +144,7 @@ function Builder() {
                                 return (
                                   <div className="text-grey-disabled relative flex gap-sm p-sm">
                                     <Icon icon="123" className="size-6 shrink-0" />
-                                    <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
+                                    <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-400 group-hover/sidebar:delay-200">
                                       {t('navigation:user_scoring')}
                                     </span>
                                     <SidebarNudge kind={value} content={t('navigation:user_scoring.nudge')} />
@@ -170,7 +170,7 @@ function Builder() {
                                 return (
                                   <div className="text-grey-disabled relative flex gap-sm p-sm">
                                     <Icon icon="scan-eye" className="size-6 shrink-0" />
-                                    <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-300 group-hover/sidebar:delay-0">
+                                    <span className="text-s line-clamp-1 text-start font-medium opacity-0 transition-opacity group-hover/sidebar:opacity-100 delay-400 group-hover/sidebar:delay-200">
                                       {t('navigation:continuous_screening')}
                                     </span>
                                     <SidebarNudge kind={value} content={t('navigation:continuous_screening.nudge')} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted sidebar hover and fade timing for labels and nudge elements, creating a smoother reveal animation.
  * Updated disabled link label hover behavior to better match the revised sidebar interaction timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->