### PR TITLE
fix local tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -123,7 +123,7 @@
         "@types/js-cookie": "^3.0.6",
         "@types/qs": "^6.15.1",
         "@types/react": "18.3.24",
-        "@types/react-dom": "18.3.1",
+        "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^5.0.4",
         "jsdom": "26.0.0",
         "tailwindcss": "4.1.13",
@@ -163,7 +163,7 @@
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "18.3.24",
-        "@types/react-dom": "18.3.1",
+        "@types/react-dom": "^18.3.5",
         "jsdom": "26.0.0",
         "jsdom-testing-mocks": "^1.13.1",
         "vite": "^7.3.6",
@@ -1326,7 +1326,7 @@
 
     "@types/react": ["@types/react@18.3.24", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A=="],
 
-    "@types/react-dom": ["@types/react-dom@18.3.1", "", { "dependencies": { "@types/react": "*" } }, "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ=="],
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
     "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
@@ -2895,8 +2895,6 @@
     "svgo/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "testcontainers/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
-
-    "ui-design-system/@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
     "winston/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/packages/app-builder/package.json
+++ b/packages/app-builder/package.json
@@ -29,7 +29,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/qs": "^6.15.1",
     "@types/react": "18.3.24",
-    "@types/react-dom": "18.3.1",
+    "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^5.0.4",
     "jsdom": "26.0.0",
     "tailwindcss": "4.1.13",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "18.3.24",
-    "@types/react-dom": "18.3.1",
+    "@types/react-dom": "^18.3.5",
     "jsdom": "26.0.0",
     "jsdom-testing-mocks": "^1.13.1",
     "vite": "^7.3.6"

--- a/packages/tests/e2e/setup.ts
+++ b/packages/tests/e2e/setup.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, Network, Wait } from 'testcontainers';
+import { GenericContainer, Network, PullPolicy, Wait } from 'testcontainers';
 
 import { setupFixtures } from './fixtures';
 
@@ -25,6 +25,9 @@ async function globalSetup() {
   const firebase = await new GenericContainer(
     'europe-west1-docker.pkg.dev/marble-infra/marble/firebase-emulator:latest',
   )
+    // :latest images go stale locally otherwise — testcontainers never re-pulls
+    // an image it already has, unlike CI which pulls fresh on every run.
+    .withPullPolicy(PullPolicy.alwaysPull())
     .withNetwork(net)
     .withNetworkAliases('firebase')
     .withExposedPorts(9099)
@@ -33,6 +36,7 @@ async function globalSetup() {
     .start();
 
   await new GenericContainer('europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend')
+    .withPullPolicy(PullPolicy.alwaysPull())
     .withPlatform('linux/x86_64')
     .withNetwork(net)
     .withEnvironment({


### PR DESCRIPTION
force latest backend installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated React DOM type definitions to a newer compatible version.
  * Improved automated test environment setup to always fetch the latest Firebase emulator and backend images before running e2e tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->