### PR TITLE
Screening rule edition page allow us to save even if the rule is not valid

### DIFF
--- a/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
@@ -394,7 +394,7 @@ function RuleEditForm({
               <>
                 <Panel.FooterButton
                   type="submit"
-                  disabled={!canSubmit}
+                  disabled={!canSubmit || isSubmitting}
                   isLoading={isSubmitting}
                   variant="primary-outline"
                   label={t('common:save')}


### PR DESCRIPTION
refactor: enhance form submission handling in RuleEditPanel and ScreeningRuleEditPanel

- Added support for closing the panel on successful form submission.
- Updated form validation to ensure proper handling of default values.
- Improved error display for form fields when touched.
- Refactored submit button states to prevent interaction during submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated rule editing forms with clearer validation feedback and field error descriptions.
  * Save actions now provide more consistent behavior: **Save** keeps the panel open, while **Save & close** closes it only after a successful submission.
  * Submit buttons now reflect validation and loading states to prevent invalid or duplicate submissions.
  * Improved accessibility by identifying invalid rule name fields for assistive technologies.
  * Enhanced screening rule editing reliability when no query criteria are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->