### PR TITLE
fix issues with MFA setup

### DIFF
--- a/packages/app-builder/src/components/Auth/MfaChallenge.tsx
+++ b/packages/app-builder/src/components/Auth/MfaChallenge.tsx
@@ -95,6 +95,7 @@ function MfaTotpChallenge({
           id="mfa-totp-code"
           inputMode="numeric"
           autoComplete="one-time-code"
+          enablePasswordManagers
           maxLength={6}
           className="w-full"
           value={code}

--- a/packages/app-builder/src/components/Settings/TwoFactorAuth/ReauthPanel.tsx
+++ b/packages/app-builder/src/components/Settings/TwoFactorAuth/ReauthPanel.tsx
@@ -124,6 +124,7 @@ export function ReauthPanel({ onReauthenticated }: { onReauthenticated: () => vo
             id="reauth-mfa-code"
             inputMode="numeric"
             autoComplete="one-time-code"
+            enablePasswordManagers
             maxLength={6}
             value={mfaCode}
             onChange={(e) => setMfaCode(e.currentTarget.value.replace(/\D/g, ''))}
@@ -165,6 +166,7 @@ export function ReauthPanel({ onReauthenticated }: { onReauthenticated: () => vo
             id="reauth-password"
             type="password"
             autoComplete="current-password"
+            enablePasswordManagers
             startAdornment="lock"
             value={password}
             onChange={(e) => setPassword(e.currentTarget.value)}

--- a/packages/app-builder/src/components/Settings/TwoFactorAuth/TwoFactorAuthSettings.tsx
+++ b/packages/app-builder/src/components/Settings/TwoFactorAuth/TwoFactorAuthSettings.tsx
@@ -97,9 +97,11 @@ export function TwoFactorAuthSettings() {
         <span className="text-xs text-grey-secondary">{t('account:mfa.status.disabled')}</span>
       )}
 
-      <div className="flex flex-col gap-sm">
-        <EnrollTotpModal onEnrolled={() => queryClient.invalidateQueries({ queryKey: enrolledFactorsQueryKey })} />
-      </div>
+      {factors.length === 0 ? (
+        <div className="flex flex-col gap-sm">
+          <EnrollTotpModal onEnrolled={() => queryClient.invalidateQueries({ queryKey: enrolledFactorsQueryKey })} />
+        </div>
+      ) : null}
 
       <Modal.Root
         open={reauthForRemoval !== null}
@@ -241,6 +243,7 @@ function EnrollTotpModal({ onEnrolled }: { onEnrolled: () => void }) {
                       id="totp-enroll-code"
                       inputMode="numeric"
                       autoComplete="one-time-code"
+                      enablePasswordManagers
                       maxLength={6}
                       value={code}
                       onChange={(e) => setCode(e.currentTarget.value.replace(/\D/g, ''))}


### PR DESCRIPTION
Fixes https://linear.app/marble-eu/issue/MAR-2104/mfa-fields-disable-password-managers, https://linear.app/marble-eu/issue/MAR-2107/enrolling-a-second-mfa-device-results-in-opaque-error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TOTP and password fields now support password manager interactions during sign-in, reauthentication, and two-factor setup.
  * Two-factor enrollment is shown only when no authenticator method is currently enrolled.

* **Bug Fixes**
  * Improved the two-factor authentication setup experience by preventing unnecessary enrollment prompts for users who already have an enrolled method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->