### PR TITLE
fix: rule form submit delete ast mar 2128

### DIFF
--- a/packages/app-builder/src/components/AstBuilder/styles/RemoveButton.tsx
+++ b/packages/app-builder/src/components/AstBuilder/styles/RemoveButton.tsx
@@ -6,6 +6,7 @@ import { Icon } from 'ui-icons';
 export const RemoveButton = React.forwardRef<HTMLButtonElement, ButtonV2Props>(({ className, ...props }, ref) => {
   return (
     <button
+      type="button"
       className={clsx(
         'size-fit rounded-xs border p-xs text-xs transition-colors duration-200 ease-in-out',
         'bg-surface-card text-grey-secondary border-grey-border',

--- a/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
@@ -127,19 +127,31 @@ function RuleEditForm({
   const ruleValidation = useMemo(() => findRuleValidation(scenarioValidation, rule.id), [scenarioValidation, rule.id]);
 
   const form = useForm({
-    onSubmit: ({ value, formApi }) => {
+    onSubmitMeta: { closeOnSuccess: false },
+    onSubmit: async ({ value, formApi, meta }) => {
       if (serverValidationMessages.length > 0 || !formApi.state.isValid) {
         return;
       }
 
-      return mutation.mutateAsync(value);
+      await mutation.mutateAsync(value);
+      if (meta.closeOnSuccess) {
+        panelSharp.actions.close();
+      }
     },
     validators: {
-      onSubmit: editRuleFormSchema,
-      onChange: editRuleFormSchema,
+      // onMount is required so canSubmit is false for invalid default values
+      // (TanStack keeps canSubmit true until the form is touched otherwise).
       onMount: editRuleFormSchema,
+      onChange: editRuleFormSchema,
+      onSubmit: editRuleFormSchema,
     },
-    defaultValues: rule as EditRuleForm,
+    defaultValues: {
+      name: rule.name ?? '',
+      description: rule.description ?? '',
+      ruleGroup: rule.ruleGroup,
+      scoreModifier: rule.scoreModifier,
+      formula: rule.formula,
+    } as EditRuleForm,
   });
 
   const formFormula = useStore(form.store, (state) => state.values.formula);
@@ -173,10 +185,7 @@ function RuleEditForm({
   };
 
   const handleRuleSubmit = async (closeOnSuccess: boolean) => {
-    await form.handleSubmit();
-    if (closeOnSuccess) {
-      panelSharp.actions.close();
-    }
+    await form.handleSubmit({ closeOnSuccess });
   };
   const handleRuleDelete = async () => {
     await onDelete();
@@ -192,14 +201,21 @@ function RuleEditForm({
           <div className="flex gap-sm">
             <form.Field name="name">
               {(field) => (
-                <Panel.HeaderInput
-                  ref={nameInputRef}
-                  name={field.name}
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  placeholder={t('scenarios:edit_rule.name_placeholder')}
-                  data-testid="rule_edit_panel.name_input"
-                />
+                <div className="flex flex-col gap-xs">
+                  <Panel.HeaderInput
+                    ref={nameInputRef}
+                    name={field.name}
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                    placeholder={t('scenarios:edit_rule.name_placeholder')}
+                    data-testid="rule_edit_panel.name_input"
+                    aria-invalid={field.state.meta.errors.length > 0 || undefined}
+                  />
+                  {field.state.meta.isTouched ? (
+                    <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
+                  ) : null}
+                </div>
               )}
             </form.Field>
             <form.Field
@@ -363,6 +379,7 @@ function RuleEditForm({
             {([canSubmit, isSubmitting]) => (
               <>
                 <Panel.FooterButton
+                  type="button"
                   disabled={!canSubmit}
                   isLoading={isSubmitting}
                   onClick={() => handleRuleSubmit(false)}
@@ -370,7 +387,8 @@ function RuleEditForm({
                   label={t('common:save')}
                 />
                 <Panel.FooterButton
-                  disabled={!canSubmit}
+                  type="button"
+                  disabled={!canSubmit || isSubmitting}
                   isLoading={isSubmitting}
                   onClick={() => handleRuleSubmit(true)}
                   trailingIcon="save"

--- a/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
@@ -18,7 +18,7 @@ import { useDebouncedCallbackRef } from '@marble/shared';
 import { useForm, useStore } from '@tanstack/react-form';
 import { useMutation } from '@tanstack/react-query';
 import { createServerFn } from '@tanstack/react-start';
-import { useMemo, useRef, useState } from 'react';
+import { FormEvent, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
@@ -379,10 +379,9 @@ function RuleEditForm({
             {([canSubmit, isSubmitting]) => (
               <>
                 <Panel.FooterButton
-                  type="button"
+                  type="submit"
                   disabled={!canSubmit}
                   isLoading={isSubmitting}
-                  onClick={() => handleRuleSubmit(false)}
                   variant="primary-outline"
                   label={t('common:save')}
                 />

--- a/packages/app-builder/src/components/Scenario/Rules/ScreeningRuleEditPanel.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/ScreeningRuleEditPanel.tsx
@@ -188,7 +188,8 @@ export function ScreeningRuleEditPanel({
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm({
-    onSubmit: async ({ value }) => {
+    onSubmitMeta: { closeOnSuccess: false },
+    onSubmit: async ({ value, meta }) => {
       const submitValidationOptions = {
         ignoreLegacyAggregateQuery: true,
         formQuery: value.query ?? {},
@@ -221,15 +222,24 @@ export function ScreeningRuleEditPanel({
         return;
       }
       if (form.state.isValid) {
-        mutation
-          // leave threshold undefined if it is the same as the organization threshold
-          .mutateAsync({
-            ...value,
-            threshold: value.threshold === org.sanctionThreshold ? undefined : value.threshold,
-          });
+        // leave threshold undefined if it is the same as the organization threshold
+        await mutation.mutateAsync({
+          ...value,
+          threshold: value.threshold === org.sanctionThreshold ? undefined : value.threshold,
+        });
+        if (meta.closeOnSuccess) {
+          panelSharp.actions.close();
+        }
       }
     },
+    onSubmitInvalid: () => {
+      setShowValidationSummary(true);
+    },
     validators: {
+      // onMount is required so canSubmit is false for invalid default values
+      // (TanStack keeps canSubmit true until the form is touched otherwise).
+      onMount: editScreeningFormSchema,
+      onChange: editScreeningFormSchema,
       onSubmit: editScreeningFormSchema,
     },
     defaultValues: {
@@ -242,7 +252,7 @@ export function ScreeningRuleEditPanel({
       forcedOutcome: (rule?.forcedOutcome as ScreeningOutcome) ?? 'block_and_review',
       triggerRule: rule?.triggerRule,
       entityType: rule?.entityType,
-      query: rule?.query,
+      query: rule?.query ?? {},
       counterPartyId: rule?.counterPartyId,
       preprocessing: rule?.preprocessing,
     } as EditScreeningForm,
@@ -319,10 +329,7 @@ export function ScreeningRuleEditPanel({
     cn(highlight.queryField(fieldKey) && 'rounded-sm border border-red-primary p-xs');
 
   const handleRuleSubmit = async (closeOnSuccess: boolean) => {
-    await form.handleSubmit();
-    if (closeOnSuccess) {
-      panelSharp.actions.close();
-    }
+    await form.handleSubmit({ closeOnSuccess });
   };
   const handleRuleDelete = async () => {
     await onDelete();
@@ -335,12 +342,19 @@ export function ScreeningRuleEditPanel({
           <div className="flex gap-sm">
             <form.Field name="name">
               {(field) => (
-                <Panel.HeaderInput
-                  ref={nameInputRef}
-                  name={field.name}
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
+                <div className="flex flex-col gap-xs">
+                  <Panel.HeaderInput
+                    ref={nameInputRef}
+                    name={field.name}
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                    aria-invalid={field.state.meta.errors.length > 0 || undefined}
+                  />
+                  {field.state.meta.isTouched ? (
+                    <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
+                  ) : null}
+                </div>
               )}
             </form.Field>
             <form.Field name="ruleGroup">
@@ -844,13 +858,15 @@ export function ScreeningRuleEditPanel({
             {([canSubmit, isSubmitting]) => (
               <>
                 <Panel.FooterButton
+                  type="button"
                   disabled={!canSubmit}
                   onClick={() => handleRuleSubmit(false)}
                   variant="primary-outline"
                   label={t('common:save')}
                 />
                 <Panel.FooterButton
-                  disabled={!canSubmit}
+                  type="button"
+                  disabled={!canSubmit || isSubmitting}
                   onClick={() => handleRuleSubmit(true)}
                   trailingIcon="save"
                   variant="primary"


### PR DESCRIPTION
- Delete row from AST Builder was a type="submit" which made it being triggered when the form was submitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented remove buttons from accidentally submitting surrounding forms.
  * Improved rule editing form submission and validation behavior.
  * Save actions now correctly distinguish between saving and saving while closing the panel.
  * Prevented duplicate submissions while a rule is being saved.
  * Improved validation feedback, including clearer error display and accessibility state indicators.
  * Ensured invalid initial values are recognized before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->