### PR TITLE
Approve or Decline pop up show a warning message even if all screening has been reviewed

### DIFF
--- a/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
+++ b/packages/app-builder/src/components/CaseManager/DecisionPanel/DecisionPanel.tsx
@@ -77,7 +77,7 @@ export function DecisionPanel({
               <ScoreModifier score={decision.score} />
             </div>
             {isPendingReview ? (
-              <ReviewDecisionModal defaultOpened={withReviewOpened} decisionId={decision.id} screening={screenings[0]}>
+              <ReviewDecisionModal defaultOpened={withReviewOpened} decisionId={decision.id} screenings={screenings}>
                 <Button variant="primary" size="small">
                   {t('cases:decisions.approve_or_decline')}
                 </Button>

--- a/packages/app-builder/src/components/Decisions/ReviewDecisionModal.tsx
+++ b/packages/app-builder/src/components/Decisions/ReviewDecisionModal.tsx
@@ -12,19 +12,20 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { cn, Modal, TextArea } from 'ui-design-system';
+import { Callout } from '../Callout';
 import { FormErrorOrDescription } from '../Form/Tanstack/FormErrorOrDescription';
 import { LoadingIcon } from '../Spinner';
 import { ReviewStatusTag } from './ReviewStatusTag';
 
 export function ReviewDecisionModal({
   decisionId,
-  screening,
+  screenings,
   children,
   defaultOpened,
 }: {
   children: React.ReactElement;
   decisionId: string;
-  screening: { status: ScreeningStatus } | undefined;
+  screenings: Array<{ status: ScreeningStatus }> | undefined;
   defaultOpened: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpened);
@@ -33,7 +34,7 @@ export function ReviewDecisionModal({
     <Modal.Root open={open} onOpenChange={setOpen}>
       <Modal.Trigger asChild>{children}</Modal.Trigger>
       <Modal.Content>
-        <ReviewDecisionContent setOpen={setOpen} decisionId={decisionId} screening={screening} />
+        <ReviewDecisionContent setOpen={setOpen} decisionId={decisionId} screenings={screenings} />
       </Modal.Content>
     </Modal.Root>
   );
@@ -41,15 +42,16 @@ export function ReviewDecisionModal({
 
 function ReviewDecisionContent({
   decisionId,
-  screening,
+  screenings,
   setOpen,
 }: {
   decisionId: string;
-  screening: { status: ScreeningStatus } | undefined;
+  screenings: Array<{ status: ScreeningStatus }> | undefined;
   setOpen: (open: boolean) => void;
 }) {
   const { t } = useTranslation(['common', 'cases']);
   const reviewDecisionMutation = useReviewDecisionMutation();
+  const hasScreeningsUnconfirmed = screenings?.some((screening) => ['in_review', 'pending'].includes(screening.status));
 
   const form = useForm({
     defaultValues: {
@@ -108,30 +110,29 @@ function ReviewDecisionContent({
             <div className="flex flex-col gap-sm">
               {nonPendingReviewStatuses.map((reviewStatus) => {
                 const isSelected = field.state.value === reviewStatus;
-                const hasScreeningWarning = screening && screening.status !== 'no_hit' && reviewStatus === 'approve';
 
                 return (
-                  <label key={reviewStatus} className="flex cursor-pointer items-center gap-sm">
-                    <input
-                      type="radio"
-                      name="reviewStatus"
-                      value={reviewStatus}
-                      checked={isSelected}
-                      onChange={() => field.handleChange(reviewStatus)}
-                      className={cn(
-                        'size-4 shrink-0 appearance-none rounded-full border',
-                        isSelected ? 'border-[5px] border-purple-primary' : 'border border-purple-primary bg-white',
-                      )}
-                    />
-                    <div className="flex flex-col gap-2xs">
+                  <div className="flex flex-col gap-2xs">
+                    <label key={reviewStatus} className="flex cursor-pointer items-center gap-sm">
+                      <input
+                        type="radio"
+                        name="reviewStatus"
+                        value={reviewStatus}
+                        checked={isSelected}
+                        onChange={() => field.handleChange(reviewStatus)}
+                        className={cn(
+                          'size-4 shrink-0 appearance-none rounded-full border',
+                          isSelected ? 'border-[5px] border-purple-primary' : 'border border-purple-primary bg-white',
+                        )}
+                      />
                       <ReviewStatusTag size="small" className="w-fit" reviewStatus={reviewStatus} />
-                      {hasScreeningWarning ? (
-                        <span className="text-red-hover text-xs">
-                          {t('cases:case_detail.review_decision.warning_approve')}
-                        </span>
-                      ) : null}
-                    </div>
-                  </label>
+                    </label>
+                    {hasScreeningsUnconfirmed && reviewStatus === 'approve' ? (
+                      <Callout icon="warning" iconColor="orange" color="orange" className="text-orange-primary text-xs">
+                        {t('cases:case_detail.review_decision.warning_approve')}
+                      </Callout>
+                    ) : null}
+                  </div>
                 );
               })}
               <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />

--- a/packages/app-builder/src/components/Decisions/ReviewDecisionModal.tsx
+++ b/packages/app-builder/src/components/Decisions/ReviewDecisionModal.tsx
@@ -112,8 +112,8 @@ function ReviewDecisionContent({
                 const isSelected = field.state.value === reviewStatus;
 
                 return (
-                  <div className="flex flex-col gap-2xs">
-                    <label key={reviewStatus} className="flex cursor-pointer items-center gap-sm">
+                  <div key={reviewStatus} className="flex flex-col gap-2xs">
+                    <label className="flex cursor-pointer items-center gap-sm">
                       <input
                         type="radio"
                         name="reviewStatus"


### PR DESCRIPTION
refactor: update ReviewDecisionModal to accept multiple screenings and improve warning display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Review decisions now use the status of all screenings, not just the first one.
  - When approving with unconfirmed screenings, the UI now shows an orange warning callout to guide reviewers.
  - Review option rendering has been updated so status messaging and warnings are presented more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->