### PR TITLE
update the decision details page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "marble-front",
+      "dependencies": {
+        "tailwindcss-grid-areas": "^0.1.1",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.5.2",
         "@vitejs/plugin-react": "4.3.4",
@@ -2513,6 +2516,8 @@
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
     "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
+
+    "tailwindcss-grid-areas": ["tailwindcss-grid-areas@0.1.1", "", { "peerDependencies": { "tailwindcss": ">=3.0.0" } }, "sha512-r1Cuhe4Z+ebz74udfHNoLy9A0hY3V+1bo/BBQCfrdNaVC8/ptrUP0CEYQAMT8Lm6/ujCHByMbs2G06Zwbzp0kg=="],
 
     "tailwindcss-radix": ["tailwindcss-radix@4.0.2", "", { "peerDependencies": { "tailwindcss": "^3.0 || ^4.0" } }, "sha512-Uoa2BUCfWKGCjQPXbj4X4Q4EWAeCsvhj0udn0IupeNcvuLbqRXvC5+bKAqsngIne5mrRUPTy/IqMXGh81YyrCA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   "type": "module",
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "tailwindcss-grid-areas": "^0.1.1"
+  }
 }

--- a/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ScreeningCaseMatches.tsx
+++ b/packages/app-builder/src/components/CaseManager/ScreeningCaseDetail/ScreeningCaseMatches.tsx
@@ -79,7 +79,7 @@ export const ScreeningCaseMatches = ({
                       <span className="font-medium">{screeningMatch.payload.caption}</span>
                       <span className="text-small text-grey-secondary">{getMatchEntityType(screeningMatch)}</span>
                       <Tag color="grey" className="shrink-0">
-                        {t('screenings:match.score', { score: screeningMatch.payload.score * 100 })}
+                        {t('screenings:match.score', { score: Math.floor(screeningMatch.payload.score * 100) })}
                       </Tag>
                       {screeningMatch.payload.properties['topics']?.map((topic) => {
                         return <TopicTag key={topic} topic={topic} className="text-small" />;

--- a/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
@@ -89,23 +89,25 @@ const SearchInput = ({
   );
 
   return (
-    <div className="flex items-center gap-sm">
-      <span>{t('screenings:search_input')}</span>
-      {searchInputList.map(({ value, type, semanticType }, i) => (
-        <div key={i} className="border-grey-border flex items-center gap-sm rounded-sm border p-sm">
-          <DatatypeIcon dataType={DatatypeToPrimitiveType(type)} />
+    <div className="grid grid-cols-[auto_1fr] gap-sm">
+      <span className="grid items-center h-[50px]">{t('screenings:search_input')}</span>
+      <div className="flex flex-wrap gap-sm">
+        {searchInputList.map(({ value, type, semanticType }, i) => (
+          <div key={i} className="border-grey-border flex items-center gap-sm rounded-sm border p-sm">
+            <DatatypeIcon dataType={DatatypeToPrimitiveType(type)} />
 
-          {semanticType === 'date_of_birth' ? (
-            <DateBirthdateComponent value={value} compact />
-          ) : semanticType === 'name' ? (
-            <StringMainComponent value={value} />
-          ) : type === 'Timestamp' ? (
-            <DateDatetimeComponent value={value} />
-          ) : (
-            value
-          )}
-        </div>
-      ))}
+            {semanticType === 'date_of_birth' ? (
+              <DateBirthdateComponent value={value} compact />
+            ) : semanticType === 'name' ? (
+              <StringMainComponent value={value} />
+            ) : type === 'Timestamp' ? (
+              <DateDatetimeComponent value={value} />
+            ) : (
+              value
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
+++ b/packages/app-builder/src/components/Decisions/ScreeningDetail.tsx
@@ -91,9 +91,12 @@ const SearchInput = ({
   return (
     <div className="grid grid-cols-[auto_1fr] gap-sm">
       <span className="grid items-center h-[50px]">{t('screenings:search_input')}</span>
-      <div className="flex flex-wrap gap-sm">
+      <div className="flex min-w-0 flex-wrap gap-sm">
         {searchInputList.map(({ value, type, semanticType }, i) => (
-          <div key={i} className="border-grey-border flex items-center gap-sm rounded-sm border p-sm">
+          <div
+            key={i}
+            className="border-grey-border flex min-w-0 items-center gap-sm break-words rounded-sm border p-sm"
+          >
             <DatatypeIcon dataType={DatatypeToPrimitiveType(type)} />
 
             {semanticType === 'date_of_birth' ? (

--- a/packages/app-builder/src/routes/_app/_builder/detection/decisions/$decisionId.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/decisions/$decisionId.tsx
@@ -13,6 +13,7 @@ import { PivotDetail } from '@app-builder/components/Decisions/PivotDetail';
 import { ScorePanel } from '@app-builder/components/Decisions/Score';
 import { ScreeningDetail } from '@app-builder/components/Decisions/ScreeningDetail';
 import { DecisionDetailTriggerObject } from '@app-builder/components/Decisions/TriggerObjectDetail';
+import { pageLayoutGutter } from '@app-builder/components/Page/page-layout';
 import { Panel } from '@app-builder/components/Panel';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
 import { DataModel, isNotFoundHttpError } from '@app-builder/models';
@@ -28,7 +29,7 @@ import { createServerFn } from '@tanstack/react-start';
 import { getRequest } from '@tanstack/react-start/server';
 import { useTranslation } from 'react-i18next';
 import * as R from 'remeda';
-import { Button } from 'ui-design-system';
+import { Button, cn } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import * as z from 'zod/v4';
 
@@ -203,31 +204,31 @@ function DecisionPage() {
           {!decision.case ? <AddToCase /> : null}
         </Page.Header>
         <Page.Container>
-          <Page.Content>
-            <div className="grid grid-cols-[2fr_1fr] gap-md lg:gap-xl">
-              <div className="flex flex-col gap-md lg:gap-xl">
-                <DecisionDetail decision={decision} />
-                <PivotDetail pivotValues={pivotValues} existingPivotDefinition={existingPivotDefinition} />
-                <RulesDetail
-                  scenarioId={decision.scenario.id}
-                  ruleExecutions={decision.rules}
-                  rules={scenarioRules}
-                  isIterationArchived={isIterationArchived}
-                />
-                {screening.map((s) => (
-                  <ScreeningDetail key={s.id} screening={s} table={table} />
-                ))}
+          <Page.Content
+            className={cn(
+              'grid grid-areas-[aside,main] xl:grid-areas-[main_aside] grid-cols-1 xl:grid-cols-[3fr_1fr]',
+              pageLayoutGutter.gap,
+            )}
+          >
+            <div className={cn('flex flex-col area-[main]', pageLayoutGutter.gap)}>
+              <DecisionDetail decision={decision} />
+              <PivotDetail pivotValues={pivotValues} existingPivotDefinition={existingPivotDefinition} />
+              <RulesDetail
+                scenarioId={decision.scenario.id}
+                ruleExecutions={decision.rules}
+                rules={scenarioRules}
+                isIterationArchived={isIterationArchived}
+              />
+              {screening.map((s) => (
+                <ScreeningDetail key={s.id} screening={s} table={table} />
+              ))}
+            </div>
+            <div className={cn('flex flex-col shrink-0 area-[aside]', pageLayoutGutter.gap)}>
+              <div className={cn('flex flex-row', pageLayoutGutter.gap)}>
+                <ScorePanel score={decision.score} />
+                <OutcomePanel outcome={decision.outcome} />
               </div>
-              <div className="flex flex-col gap-md lg:gap-xl shrink-0">
-                <div className="flex flex-col gap-md lg:flex-row lg:gap-xl">
-                  <ScorePanel score={decision.score} />
-                  <OutcomePanel outcome={decision.outcome} />
-                </div>
-                <DecisionDetailTriggerObject
-                  table={decision.triggerObjectType}
-                  triggerObject={decision.triggerObject}
-                />
-              </div>
+              <DecisionDetailTriggerObject table={decision.triggerObjectType} triggerObject={decision.triggerObject} />
             </div>
           </Page.Content>
         </Page.Container>

--- a/packages/app-builder/tailwind.config.ts
+++ b/packages/app-builder/tailwind.config.ts
@@ -1,5 +1,9 @@
+import { gridAreas } from 'tailwindcss-grid-areas';
+
 export default {
   content: ['./src/**/*.{ts,tsx,jsx,js}', '../ui-design-system/src/**/*.{ts,tsx,jsx,js}', '!.output/**', '!.nitro/**'],
+  plugins: [gridAreas],
+
   theme: {
     extend: {
       screens: {


### PR DESCRIPTION
- add the grid-area plugin to tailwind
- made the page responsive
- wrap the list of tags on multiple lines if necessary

also fix the score value (rounded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Tailwind grid-area utilities to support responsive `grid-areas` layouts.

* **Bug Fixes**
  * Match scores are now rounded down to whole-number percentage values for consistent display.

* **Style**
  * Improved the decision details page layout using shared gutter spacing and responsive grid-area structure.
  * Refreshed screening search input styling for a cleaner two-column grid and better chip wrapping/truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->