### PR TITLE
Williamschlegel/mar 2121 screening with ner duplicates the search input item

### DIFF
--- a/packages/app-builder/src/components/ContinuousScreening/context/ListAndTopicDatasetConfigurationBridge.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/context/ListAndTopicDatasetConfigurationBridge.tsx
@@ -1,10 +1,11 @@
 import {
+  applyUniqueLexisNexisSectionDefault,
   getCanonicalSelectedKeys,
   ListAndTopicDatasetConfiguration,
 } from '@app-builder/components/ListAndTopicConfiguration';
 import { Spinner } from '@app-builder/components/Spinner';
 import { type AvailableFeatures, type ScreeningProviders } from '@app-builder/models/screening';
-import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
+import { type ListConfigFilters, useListConfigQuery } from '@app-builder/queries/screening/lists-config';
 import { type ReactNode, useEffect, useMemo } from 'react';
 import { Trans } from 'react-i18next';
 import { match } from 'ts-pattern';
@@ -41,7 +42,7 @@ export function ListAndTopicDatasetConfigurationBridge({
       </div>
     ))
     .otherwise(({ data }) => (
-      <ListAndTopicDatasetConfigurationBridgeInner provider={data.provider}>
+      <ListAndTopicDatasetConfigurationBridgeInner provider={data.provider} filters={data.filters}>
         {children}
       </ListAndTopicDatasetConfigurationBridgeInner>
     ));
@@ -49,9 +50,11 @@ export function ListAndTopicDatasetConfigurationBridge({
 
 function ListAndTopicDatasetConfigurationBridgeInner({
   provider,
+  filters,
   children,
 }: {
   provider: ScreeningProviders;
+  filters: ListConfigFilters;
   children: ReactNode;
 }) {
   const wizard = ContinuousScreeningConfigurationStepper.useSharp();
@@ -70,10 +73,12 @@ function ListAndTopicDatasetConfigurationBridgeInner({
   }, [listSharp, wizardMode]);
 
   useEffect(() => {
-    const currentKey = getDatasetsMapKey(listSharp.value.datasets);
-    if (currentKey === datasetsMapKey) return;
-
     const nextDatasets = { ...datasetsMap };
+    applyUniqueLexisNexisSectionDefault(nextDatasets, filters, provider);
+    const expectedKey = getDatasetsMapKey(nextDatasets);
+    const currentKey = getDatasetsMapKey(listSharp.value.datasets);
+    if (currentKey === expectedKey) return;
+
     listSharp.update((state) => {
       for (const key of Object.keys(state.datasets)) {
         delete state.datasets[key];
@@ -82,7 +87,7 @@ function ListAndTopicDatasetConfigurationBridgeInner({
         state.datasets[key] = !!nextDatasets[key];
       }
     });
-  }, [listSharp, datasetsMap, datasetsMapKey]);
+  }, [listSharp, datasetsMap, datasetsMapKey, filters, provider]);
 
   return (
     <ListAndTopicDatasetConfiguration.Provider value={listSharp}>{children}</ListAndTopicDatasetConfiguration.Provider>

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -39,7 +39,7 @@ import {
   syncSectionEnabledFromLeaves,
 } from './dataset-selection-provider-utils';
 import {
-  GlobalTopicConfig,
+  type GlobalTopicConfig,
   getAvailableGlobalTopicConfigs,
   getDatasetNames,
   getSpecialTopicLabel,

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/DatasetSelectionContent.tsx
@@ -28,19 +28,19 @@ import {
   buildDatasetKey,
   buildTopicKey,
   isDatasetKeySelected,
+  isGlobalTopicSwitchSelected,
   isSectionEnabled,
-  // isGlobalTopicSwitchSelected,
   isTopicKeySelected,
   isUniqueLexisNexisList,
   selectAllInSection,
   setDatasetKey,
-  // setGlobalTopicSwitch,
+  setGlobalTopicSwitch,
   setTopicKey,
   syncSectionEnabledFromLeaves,
 } from './dataset-selection-provider-utils';
 import {
-  // type GlobalTopicConfig,
-  // getAvailableGlobalTopicConfigs,
+  GlobalTopicConfig,
+  getAvailableGlobalTopicConfigs,
   getDatasetNames,
   getSpecialTopicLabel,
   getSpecialTopicValue,
@@ -90,18 +90,16 @@ export function DatasetSelectionContent({ useCase, onApply, onCancel }: DatasetS
 
     return match(variant)
       .with('default', () => {
-        // const availableGlobalTopicConfigs = getAvailableGlobalTopicConfigs(data);
+        const availableGlobalTopicConfigs = getAvailableGlobalTopicConfigs(data);
         return (
           <div className="flex flex-col">
-            {/*
-            TODO: uncomment when indexation is done
-            availableGlobalTopicConfigs.length > 0 && (
+            {availableGlobalTopicConfigs.length > 0 && (
               <div className="flex flex-col gap-sm px-md py-sm">
                 {availableGlobalTopicConfigs.map((config) => (
                   <GlobalTopicSwitch key={config.groupKey} config={config} />
                 ))}
               </div>
-            )*/}
+            )}
             {sections.map(([key, section]) =>
               section ? (
                 <Section
@@ -236,13 +234,11 @@ const Section = ({ sectionKey, section, isActive, onSelect, sectionCount }: Sect
   const { t } = useTranslation(['common', 'continuousScreening', 'scenarios', 'screenings']);
 
   const datasetNames = getDatasetNames(section);
-  const isEnabled = ListAndTopicDatasetConfiguration.select((state) =>
-    isSectionEnabled(state.datasets, sectionKey, state.provider, sectionCount),
-  );
   const selectedCount = ListAndTopicDatasetConfiguration.select(
     (state) => datasetNames.filter((n) => state.datasets[buildDatasetKey(sectionKey, n)]).length,
   );
   const isUniqueListForLN = isUniqueLexisNexisList(provider, sectionCount);
+  const isEnabled = ListAndTopicDatasetConfiguration.select((state) => isSectionEnabled(state.datasets, sectionKey));
 
   return match(variant)
     .with('default', () => (
@@ -318,10 +314,9 @@ const SectionPanel = ({ sectionKey, section, sectionCount }: SectionPanelProps) 
   const listConfig = ListAndTopicDatasetConfiguration.useSharp();
   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
   const provider = ListAndTopicDatasetConfiguration.select((state) => state.provider);
-  const isEnabled = ListAndTopicDatasetConfiguration.select((state) =>
-    isSectionEnabled(state.datasets, sectionKey, state.provider, sectionCount),
-  );
   const isUniqueListForLN = isUniqueLexisNexisList(provider, sectionCount);
+  const isEnabled = ListAndTopicDatasetConfiguration.select((state) => isSectionEnabled(state.datasets, sectionKey));
+
   const { t } = useTranslation(['common', 'continuousScreening', 'scenarios', 'screenings']);
   const { getLaTagLabel } = useDatasetTag();
 
@@ -1100,30 +1095,30 @@ const FilterGroupMenu = ({
   return <MenuCommand.Menu persistOnSelect>{menuTriggerAndContent}</MenuCommand.Menu>;
 };
 
-// const GlobalTopicSwitch = ({ config }: { config: GlobalTopicConfig }) => {
-//   const listSharp = ListAndTopicDatasetConfiguration.useSharp();
-//   const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
-//   const { t } = useTranslation(['screenings']);
-//   const switchId = `global-topic-${config.groupKey}`;
-//   const isSelected = ListAndTopicDatasetConfiguration.select((state) =>
-//     isGlobalTopicSwitchSelected(state.datasets, config),
-//   );
+const GlobalTopicSwitch = ({ config }: { config: GlobalTopicConfig }) => {
+  const listSharp = ListAndTopicDatasetConfiguration.useSharp();
+  const mode = ListAndTopicDatasetConfiguration.select((state) => state.mode);
+  const { t } = useTranslation(['screenings']);
+  const switchId = `global-topic-${config.groupKey}`;
+  const isSelected = ListAndTopicDatasetConfiguration.select((state) =>
+    isGlobalTopicSwitchSelected(state.datasets, config),
+  );
 
-//   return (
-//     <div className="flex items-center gap-sm">
-//       <Switch
-//         id={switchId}
-//         checked={isSelected}
-//         disabled={mode === 'view'}
-//         onCheckedChange={(checked) => {
-//           listSharp.update((state) => {
-//             setGlobalTopicSwitch(state.datasets, config, checked);
-//           });
-//         }}
-//       />
-//       <label htmlFor={switchId} className="text-s text-grey-primary cursor-pointer">
-//         {t(config.label)}
-//       </label>
-//     </div>
-//   );
-// };
+  return (
+    <div className="flex items-center gap-sm">
+      <Switch
+        id={switchId}
+        checked={isSelected}
+        disabled={mode === 'view'}
+        onCheckedChange={(checked) => {
+          listSharp.update((state) => {
+            setGlobalTopicSwitch(state.datasets, config, checked);
+          });
+        }}
+      />
+      <label htmlFor={switchId} className="text-s text-grey-primary cursor-pointer">
+        {t(config.label)}
+      </label>
+    </div>
+  );
+};

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/dataset-selection-provider-utils.ts
@@ -105,7 +105,11 @@ export function selectAllInSection(
   }
 }
 
-export function syncSharpDatasets(datasets: Record<string, boolean>, selected: string[]): void {
+export function syncSharpDatasets(
+  datasets: Record<string, boolean>,
+  selected: string[],
+  options?: { filters: ListConfigFilters; provider: ScreeningProviders },
+): void {
   const nextDatasets = makeDatasetsMap(selected);
 
   for (const key of Object.keys(datasets)) {
@@ -113,6 +117,11 @@ export function syncSharpDatasets(datasets: Record<string, boolean>, selected: s
   }
   for (const [key, isSelected] of Object.entries(nextDatasets)) {
     datasets[key] = isSelected;
+  }
+
+  // Re-apply after replace so parent syncs cannot drop the mandatory LN section flag.
+  if (options) {
+    applyUniqueLexisNexisSectionDefault(datasets, options.filters, options.provider);
   }
 }
 
@@ -151,13 +160,8 @@ export function isUniqueLexisNexisList(provider: ScreeningProviders, availableSe
   return provider === 'lexisnexis' && availableSectionCount === 1;
 }
 
-export function isSectionEnabled(
-  datasets: Record<string, boolean>,
-  sectionKey: ScreeningCategory,
-  provider: ScreeningProviders,
-  availableSectionCount: number,
-): boolean {
-  return !!datasets[sectionKey] || isUniqueLexisNexisList(provider, availableSectionCount);
+export function isSectionEnabled(datasets: Record<string, boolean>, sectionKey: ScreeningCategory): boolean {
+  return !!datasets[sectionKey];
 }
 
 /** Persists the mandatory LexisNexis section flag so UI state and wire payload stay aligned. */
@@ -175,12 +179,7 @@ export function applyUniqueLexisNexisSectionDefault(
 
 /** Strips falsy entries from the datasets map before persistence. */
 export function sanitizeTruthyDatasets(datasets: Record<string, boolean>): Record<string, boolean> {
-  // TODO: remove the liveness filter when reindexation is done
-  // global:topic:liveness:filter.alive
-  // global:topic:liveness:filter.deceased
-  const strippedDatasets = Object.fromEntries(
-    Object.entries(datasets).filter(([key, selected]) => !key.startsWith('global:topic:liveness:filter.') && selected),
-  );
+  const strippedDatasets = Object.fromEntries(Object.entries(datasets).filter(([_, selected]) => selected));
   return strippedDatasets;
 }
 

--- a/packages/app-builder/src/components/ListAndTopicConfiguration/index.ts
+++ b/packages/app-builder/src/components/ListAndTopicConfiguration/index.ts
@@ -6,6 +6,7 @@ export {
 export { DatasetSelectionContent } from './DatasetSelectionContent';
 export {
   applyAliveDeceasedDefaults,
+  applyUniqueLexisNexisSectionDefault,
   buildDatasetKey,
   buildTopicKey,
   getCanonicalSelectedKeys,

--- a/packages/app-builder/src/components/Scenario/Screening/FieldDataset.tsx
+++ b/packages/app-builder/src/components/Scenario/Screening/FieldDataset.tsx
@@ -1,5 +1,6 @@
 import { Callout } from '@app-builder/components/Callout';
 import {
+  applyUniqueLexisNexisSectionDefault,
   DatasetSelectionContent,
   getCanonicalSelectedKeys,
   ListAndTopicDatasetConfiguration,
@@ -7,7 +8,7 @@ import {
 } from '@app-builder/components/ListAndTopicConfiguration';
 import { Spinner } from '@app-builder/components/Spinner';
 import { type ScreeningProviders } from '@app-builder/models/screening';
-import { useListConfigQuery } from '@app-builder/queries/screening/lists-config';
+import { type ListConfigFilters, useListConfigQuery } from '@app-builder/queries/screening/lists-config';
 import { useSignalEffect } from '@preact/signals-react';
 import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -46,7 +47,13 @@ export const FieldDataset = ({ value, onChange, readOnly = false }: FieldDataset
             </div>
           ))
           .otherwise(({ data }) => (
-            <FieldDatasetInner provider={data.provider} value={value} onChange={onChange} readOnly={readOnly} />
+            <FieldDatasetInner
+              provider={data.provider}
+              filters={data.filters}
+              value={value}
+              onChange={onChange}
+              readOnly={readOnly}
+            />
           ))}
       </div>
     </div>
@@ -55,16 +62,22 @@ export const FieldDataset = ({ value, onChange, readOnly = false }: FieldDataset
 
 const FieldDatasetInner = ({
   provider,
+  filters,
   value,
   onChange,
   readOnly,
 }: {
   provider: ScreeningProviders;
+  filters: ListConfigFilters;
 } & FieldDatasetProps) => {
   const valueKey = useMemo(() => getDatasetsKey(value ?? []), [value]);
 
   const listSharp = ListAndTopicDatasetConfiguration.createSharp({
-    datasets: makeDatasetsMap(value ?? []),
+    datasets: (() => {
+      const initial = makeDatasetsMap(value ?? []);
+      applyUniqueLexisNexisSectionDefault(initial, filters, provider);
+      return initial;
+    })(),
     mode: readOnly ? 'view' : 'edit',
     provider,
   });
@@ -75,10 +88,12 @@ const FieldDatasetInner = ({
   lastValueKeyRef.current = valueKey;
 
   useEffect(() => {
-    const selectedKey = getDatasetsKey(getCanonicalSelectedKeys(listSharp.value.datasets));
-    if (selectedKey === valueKey) return;
-
     const nextDatasets = makeDatasetsMap(value ?? []);
+    applyUniqueLexisNexisSectionDefault(nextDatasets, filters, provider);
+    const expectedKey = getDatasetsKey(getCanonicalSelectedKeys(nextDatasets));
+    const selectedKey = getDatasetsKey(getCanonicalSelectedKeys(listSharp.value.datasets));
+    if (selectedKey === expectedKey) return;
+
     listSharp.update((state) => {
       for (const key of Object.keys(state.datasets)) {
         delete state.datasets[key];
@@ -87,7 +102,7 @@ const FieldDatasetInner = ({
         state.datasets[key] = isSelected;
       }
     });
-  }, [listSharp, value, valueKey]);
+  }, [listSharp, value, valueKey, filters, provider]);
 
   useSignalEffect(() => {
     const selectedDatasets = getCanonicalSelectedKeys(listSharp.value.datasets);

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/DatasetsPopover.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/DatasetsPopover.tsx
@@ -1,4 +1,5 @@
 import {
+  applyUniqueLexisNexisSectionDefault,
   DatasetSelectionContent,
   getCanonicalSelectedKeys,
   getSectionLeafKeys,
@@ -35,32 +36,53 @@ export const DatasetsPopover = ({ selectedDatasets, onApply, disabled }: Dataset
   const listSharp = ListAndTopicDatasetConfiguration.useSharp();
   const [open, setOpen] = useState(false);
   const tagRef = useRef<HTMLButtonElement>(null);
+  const listConfig = listConfigQuery.data;
+
+  const syncFromSelected = () => {
+    listSharp.update((state) => {
+      if (listConfig) {
+        syncSharpDatasets(state.datasets, selectedDatasets, {
+          filters: listConfig.filters,
+          provider: listConfig.provider,
+        });
+      } else {
+        syncSharpDatasets(state.datasets, selectedDatasets);
+      }
+    });
+  };
 
   const handleOpenChange = (isOpen: boolean) => {
     if (disabled) return;
     if (isOpen) {
-      listSharp.update((state) => {
-        syncSharpDatasets(state.datasets, selectedDatasets);
-      });
+      syncFromSelected();
     }
     setOpen(isOpen);
   };
 
   const handleApply = () => {
+    if (listConfig) {
+      listSharp.update((state) => {
+        applyUniqueLexisNexisSectionDefault(state.datasets, listConfig.filters, listConfig.provider);
+      });
+    }
     onApply(getCanonicalSelectedKeys(listSharp.value.datasets));
     setOpen(false);
   };
 
   const handleCancel = () => {
-    listSharp.update((state) => {
-      syncSharpDatasets(state.datasets, selectedDatasets);
-    });
+    syncFromSelected();
     setOpen(false);
   };
 
   const hasSelection = selectedDatasets.filter((d) => !d.startsWith('global')).length > 0;
 
-  const selectionMap = useMemo(() => makeDatasetsMap(selectedDatasets), [selectedDatasets]);
+  const selectionMap = useMemo(() => {
+    const map = makeDatasetsMap(selectedDatasets);
+    if (listConfig) {
+      applyUniqueLexisNexisSectionDefault(map, listConfig.filters, listConfig.provider);
+    }
+    return map;
+  }, [selectedDatasets, listConfig]);
 
   const sectionTags = useMemo(() => {
     const data = listConfigQuery.data;

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/FreeformSearchForm.tsx
@@ -1,5 +1,6 @@
 import {
   applyAliveDeceasedDefaults,
+  applyUniqueLexisNexisSectionDefault,
   getCanonicalSelectedKeys,
   ListAndTopicDatasetConfiguration,
   makeDatasetsMap,
@@ -88,12 +89,17 @@ const FreeformSearchFormInner: FunctionComponent<{ provider: ScreeningProviders 
   const [selectedDatasets, setSelectedDatasets] = useState<string[]>(() => {
     const initial: Record<string, boolean> = {};
     applyAliveDeceasedDefaults(initial, listConfig, 'manual_search');
+    applyUniqueLexisNexisSectionDefault(initial, listConfig, provider);
     return getCanonicalSelectedKeys(initial);
   });
   const selectedDatasetsKey = useMemo(() => selectedDatasets.toSorted().join(','), [selectedDatasets]);
 
   const listSharp = ListAndTopicDatasetConfiguration.createSharp({
-    datasets: makeDatasetsMap(selectedDatasets),
+    datasets: (() => {
+      const initial = makeDatasetsMap(selectedDatasets);
+      applyUniqueLexisNexisSectionDefault(initial, listConfig, provider);
+      return initial;
+    })(),
     mode: 'edit',
     variant: 'popover',
     provider,
@@ -101,12 +107,15 @@ const FreeformSearchFormInner: FunctionComponent<{ provider: ScreeningProviders 
 
   useEffect(() => {
     listSharp.update((state) => {
-      syncSharpDatasets(state.datasets, selectedDatasets);
+      syncSharpDatasets(state.datasets, selectedDatasets, { filters: listConfig, provider });
     });
-  }, [listSharp, selectedDatasetsKey, selectedDatasets]);
+  }, [listSharp, selectedDatasetsKey, selectedDatasets, listConfig, provider]);
 
   const form = useManualSearchForm({
     onSubmit: async (value) => {
+      listSharp.update((state) => {
+        applyUniqueLexisNexisSectionDefault(state.datasets, listConfig, provider);
+      });
       const datasets = getCanonicalSelectedKeys(listSharp.value.datasets);
 
       const submitValue: FreeformSearchInput = {

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/LimitPopover.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/LimitPopover.tsx
@@ -59,7 +59,14 @@ export const LimitPopover = ({
     if (isOpen) {
       setDraftLimit(committedLimit ?? DEFAULT_LIMIT);
       listSharp.update((state) => {
-        syncSharpDatasets(state.datasets, selectedDatasets);
+        if (listConfig) {
+          syncSharpDatasets(state.datasets, selectedDatasets, {
+            filters: listConfig.filters,
+            provider: listConfig.provider,
+          });
+        } else {
+          syncSharpDatasets(state.datasets, selectedDatasets);
+        }
       });
     } else {
       setDraftLimit(undefined);
@@ -70,7 +77,14 @@ export const LimitPopover = ({
   const handleCancel = () => {
     form.setFieldValue('limit', originalValue);
     listSharp.update((state) => {
-      syncSharpDatasets(state.datasets, selectedDatasets);
+      if (listConfig) {
+        syncSharpDatasets(state.datasets, selectedDatasets, {
+          filters: listConfig.filters,
+          provider: listConfig.provider,
+        });
+      } else {
+        syncSharpDatasets(state.datasets, selectedDatasets);
+      }
     });
     setDraftLimit(undefined);
     setOpen(false);

--- a/packages/app-builder/src/queries/screening/freeform-search.ts
+++ b/packages/app-builder/src/queries/screening/freeform-search.ts
@@ -22,15 +22,7 @@ export const useFreeformSearchMutation = () => {
   return useMutation({
     mutationKey: ['screening', 'freeform-search'],
     mutationFn: async (input: FreeformSearchInput): Promise<FreeformSearchResponse> => {
-      // TODO: remove this filter when reindexation is done
-      const datasets =
-        input.entityType !== 'Person'
-          ? input.datasets?.filter(
-              (dataset) =>
-                dataset !== 'global:topic:liveness:filter.alive' && dataset !== 'global:topic:liveness:filter.deceased',
-            )
-          : input.datasets;
-      return freeformSearch({ data: { ...input, datasets } }) as Promise<FreeformSearchResponse>;
+      return freeformSearch({ data: input }) as Promise<FreeformSearchResponse>;
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['screening', 'saved-searches'] });

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/home.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/home.tsx
@@ -3,6 +3,7 @@ import { Callout } from '@app-builder/components/Callout';
 import { ExternalLink } from '@app-builder/components/ExternalLink';
 import { Nudge } from '@app-builder/components/Nudge';
 import { Page } from '@app-builder/components/Page';
+import { pageLayoutGutter } from '@app-builder/components/Page/page-layout';
 import { CreateTestRun } from '@app-builder/components/Scenario/Actions/CreateTestRun';
 import { CreateDraftIteration } from '@app-builder/components/Scenario/Iteration/Actions/CreateDraft';
 import { ScenarioDescriptionEditable, ScenarioHeader } from '@app-builder/components/Scenario/ScenarioHeader';
@@ -25,13 +26,12 @@ import { useForm } from '@tanstack/react-form';
 import { useMutation } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
-import clsx from 'clsx';
 import { type ParseKeys } from 'i18next';
 import { type FeatureAccessLevelDto } from 'marble-api/generated/feature-access-api';
 import { useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
-import { Button, CtaV2ClassName, HiddenInputs, Typo } from 'ui-design-system';
+import { Button, CtaV2ClassName, cn, HiddenInputs, Typo } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { z } from 'zod/v4';
 
@@ -165,11 +165,11 @@ function ScenarioHome() {
             ) : null}
           </div>
         </section>
-        <section className="flex flex-col gap-sm">
+        <section className={cn('flex flex-col', pageLayoutGutter.gap)}>
           <Typo variant="title2" className="text-grey-primary">
             {t('scenarios:home.execution')}
           </Typo>
-          <div className="grid grid-cols-2 gap-sm">
+          <div className={cn('grid grid-cols-2', pageLayoutGutter.gap)}>
             <RealTimeSection scenarioId={currentScenario.id} liveScenarioIteration={liveScenarioIteration} />
             <BatchSection
               scenarioId={currentScenario.id}
@@ -211,7 +211,7 @@ function TestRunSection({ scenarioId, access }: { scenarioId: string; access: Fe
     <article className="flex flex-col">
       <TabHeader title={t('scenarios:home.testrun')} spinner={isExecutionOngoing} />
       <section
-        className={clsx(
+        className={cn(
           'bg-surface-card border-grey-border relative flex flex-col gap-md rounded-lg border p-md rounded-tl-none flex-1',
           isExecutionOngoing && 'border-purple-primary',
         )}
@@ -286,7 +286,7 @@ function RealTimeSection({
             />
           </span>
           <span
-            className={clsx('text-grey-primary text-s inline-flex items-center font-semibold', {
+            className={cn('text-grey-primary text-s inline-flex items-center font-semibold', {
               'whitespace-pre': isLive,
             })}
           >
@@ -314,7 +314,7 @@ function RealTimeSection({
 
 function TabHeader({ title, spinner }: { title: string; spinner: boolean }) {
   return (
-    <div className="flex items-center gap-md border-l border-t border-r bg-surface-card border-grey-border rounded-t-md py-xs px-xs w-fit">
+    <div className="flex items-center gap-md border-l border-t border-r bg-surface-card border-grey-border rounded-t-md py-xs px-sm w-fit">
       <Typo variant="subtitle1" className="text-grey-secondary">
         {title}
       </Typo>
@@ -364,7 +364,7 @@ function BatchSection({
     <article className="flex flex-col">
       <TabHeader title={t('scenarios:home.execution.batch')} spinner={isExecutionOngoing} />
       <div
-        className={clsx(
+        className={cn(
           'bg-surface-card border-grey-border relative flex flex-1 flex-col gap-md rounded-lg border p-md rounded-tl-none',
           isExecutionOngoing && 'border-purple-primary',
         )}


### PR DESCRIPTION
The default check for unique sanction in lexisnexis config was not applied correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added global topic switches to dataset selection.
  - Dataset selections now automatically apply provider-specific required section defaults.
  - Improved consistency of dataset selections across configuration screens, search forms, popovers, and submissions.

- **Bug Fixes**
  - Prevented dataset selections from becoming inconsistent when filters or providers change.
  - Corrected handling of dataset values during freeform searches and selection cancellation.

- **Style**
  - Updated screening page spacing and layout for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->