### PR TITLE
fix: Ai rule generation component is displayed even if the org doesn't have access

### DIFF
--- a/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RuleEditPanel.tsx
@@ -340,15 +340,17 @@ function RuleEditForm({
                   </form.Field>
                 </Card>
 
-                <AiGenerateRule
-                  scenarioId={scenario.id}
-                  ruleId={rule.id}
-                  onFormulaGenerated={(ruleAst) => {
-                    form.setFieldValue('formula', ruleAst);
-                    handleFormulaChange(ruleAst);
-                    setFormulaKey((k) => k + 1);
-                  }}
-                />
+                {isAiRuleDescriptionEnabled ? (
+                  <AiGenerateRule
+                    scenarioId={scenario.id}
+                    ruleId={rule.id}
+                    onFormulaGenerated={(ruleAst) => {
+                      form.setFieldValue('formula', ruleAst);
+                      handleFormulaChange(ruleAst);
+                      setFormulaKey((k) => k + 1);
+                    }}
+                  />
+                ) : null}
 
                 <Card>
                   <div className="flex items-center gap-sm">


### PR DESCRIPTION
In the rule builder page, the AI rule builder component is not protected by the organization access feature. 
As a result, an organization without this feature will still see this component. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI-assisted rule generation is now shown only when the feature is enabled.
  * Prevented unintended formula updates and change handling when AI rule descriptions are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->