### PR TITLE
fix: outdated modal design

### DIFF
--- a/packages/app-builder/src/components/VersionUpdate/VersionUpdateModal.tsx
+++ b/packages/app-builder/src/components/VersionUpdate/VersionUpdateModal.tsx
@@ -23,12 +23,10 @@ export const VersionUpdateModal: FunctionComponent<VersionUpdateModalProps> = ({
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange}>
       <Modal.Content size="xlarge" fixedHeight className="max-h-[80vh] flex flex-col">
-        <div className="flex items-center gap-sm border-b border-grey-border p-md">
+        <Modal.Title className="flex items-center gap-sm border-b border-grey-border text-l font-semibold text-start">
           <Icon icon="speakerphone" className="size-8 shrink-0 text-purple-primary" />
-          <Modal.Title className="text-l font-semibold text-left">
-            {t('common:version_update.title', { version })}
-          </Modal.Title>
-        </div>
+          {t('common:version_update.title', { version })}
+        </Modal.Title>
 
         <div className="flex-1 overflow-y-auto p-md">
           <ReleaseMarkdown>{releaseNotes}</ReleaseMarkdown>
@@ -36,7 +34,6 @@ export const VersionUpdateModal: FunctionComponent<VersionUpdateModalProps> = ({
 
         <Modal.Footer>
           <Modal.FooterButton isCloseButton label={t('common:understand')} onClick={() => onOpenChange(false)} />
-          {t('common:understand')}
           <Modal.FooterButton
             label={t('common:version_update.view_release')}
             onClick={() => window.open(releaseUrl, '_blank', 'noopener,noreferrer')}

--- a/packages/ui-design-system/src/Markdown/ReleaseMarkdown.tsx
+++ b/packages/ui-design-system/src/Markdown/ReleaseMarkdown.tsx
@@ -86,5 +86,12 @@ interface ReleaseMarkdownProps {
 
 export function ReleaseMarkdown({ children }: ReleaseMarkdownProps) {
   const processedMarkdown = preprocessGitHubCallouts(children);
-  return <Markdown components={releaseMarkdownComponents}>{processedMarkdown}</Markdown>;
+  return (
+    // Use `ltr` to force the content to be align at the left, even in arabic language.
+    // text-left is not enough because the list point is still on the right side in rtl languages.
+    // The release content is always in english
+    <div dir="ltr">
+      <Markdown components={releaseMarkdownComponents}>{processedMarkdown}</Markdown>
+    </div>
+  );
 }


### PR DESCRIPTION
Before: 
<img width="1724" height="1023" alt="Capture d’écran 2026-07-27 à 13 55 41" src="https://github.com/user-attachments/assets/34e34b15-228e-4a1c-9b0b-3baeab5176d0" />


After: 
<img width="1728" height="1023" alt="Capture d’écran 2026-07-27 à 13 54 16" src="https://github.com/user-attachments/assets/9698b489-205c-476a-9b45-281df88a9fe2" />

After: arabic
<img width="1731" height="1022" alt="Capture d’écran 2026-07-27 à 14 31 14" src="https://github.com/user-attachments/assets/d6179e20-0849-4dff-a9d5-fd282de33cbb" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the version update modal’s layout and styling.
  * Simplified the modal footer by removing redundant text.
  * Ensured release notes consistently display in a left-to-right layout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->