### PR TITLE
feat: display AI-generated rule description as fallback in rule list

### DIFF
--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -204,12 +204,13 @@ type ScenarioRuleRowProps = {
 
 function ScenarioRuleRow({ rule, scenario, editorMode, language, org, onEditRequest }: ScenarioRuleRowProps) {
   const { t } = useTranslation(['common', 'scenarios']);
+  const isExpandable = editorMode === 'view';
   const [open, setOpen] = useState(false);
 
   return (
     <Collapsible.Root
-      open={open}
-      onOpenChange={setOpen}
+      open={isExpandable && open}
+      onOpenChange={isExpandable ? setOpen : undefined}
       className="overflow-hidden grid grid-cols-subgrid col-span-full group/table-row hover:bg-purple-background-light cursor-pointer "
       onClick={handleRowClick}
       onKeyDown={handleRowKeyDown}

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -178,7 +178,15 @@ export function RulesPage({
                       ) : null}
                       <span>{rule.name}</span>
                     </GridCell>
-                    <GridCell>{rule.description}</GridCell>
+                    <GridCell>
+                      {rule.description ? (
+                        rule.description
+                      ) : rule.type === 'rule' && rule.aiDescription ? (
+                        <p className="border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm whitespace-pre-wrap">
+                          {rule.aiDescription}
+                        </p>
+                      ) : null}
+                    </GridCell>
                     <GridCell>{rule.ruleGroup ? <Tag>{rule.ruleGroup}</Tag> : null}</GridCell>
                     <GridCell>
                       {rule.type === 'rule' ? (

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -219,7 +219,7 @@ function RuleRow({ rule, scenario, editorMode, language, org, onEditRequest }: R
         <div
           role="link"
           tabIndex={0}
-          className="grid grid-cols-subgrid col-span-full items-center focus-visible:outline-2 -outline-offset-2 outline-purple-primary"
+          className="grid grid-cols-subgrid col-span-full items-start focus-visible:outline-2 -outline-offset-2 outline-purple-primary"
         >
           <div className="invisible">
             {editorMode === 'edit' ? (

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -180,11 +180,12 @@ export function RulesPage({
                     </GridCell>
                     <GridCell>
                       {rule.description ? (
-                        rule.description
+                        <p className="line-clamp-2">{rule.description}</p>
                       ) : rule.type === 'rule' && rule.aiDescription ? (
-                        <p className="border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm whitespace-pre-wrap">
-                          {rule.aiDescription}
-                        </p>
+                        <div className="border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm flex items-start gap-xs">
+                          <Icon icon="wand" className="size-4 shrink-0 text-purple-primary" />
+                          <p className="line-clamp-2 whitespace-pre-wrap">{rule.aiDescription}</p>
+                        </div>
                       ) : null}
                     </GridCell>
                     <GridCell>{rule.ruleGroup ? <Tag>{rule.ruleGroup}</Tag> : null}</GridCell>

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -141,7 +141,7 @@ export function RulesPage({
             <HeaderCell>{t('scenarios:rules.score_or_outcome')}</HeaderCell>
           </div>
           {list.map((rule) => (
-            <RuleRow
+            <ScenarioRuleRow
               key={`${rule.type}_${rule.id}`}
               rule={rule}
               scenario={scenario}
@@ -193,7 +193,7 @@ export function RulesPage({
   );
 }
 
-type RuleRowProps = {
+type ScenarioRuleRowProps = {
   rule: RuleOrScreening;
   scenario: Scenario;
   editorMode: NonNullable<EditorMode>;
@@ -202,7 +202,7 @@ type RuleRowProps = {
   onEditRequest: (value: { id: string; type: 'rule' | 'sanction' }) => void;
 };
 
-function RuleRow({ rule, scenario, editorMode, language, org, onEditRequest }: RuleRowProps) {
+function ScenarioRuleRow({ rule, scenario, editorMode, language, org, onEditRequest }: ScenarioRuleRowProps) {
   const { t } = useTranslation(['common', 'scenarios']);
   const [open, setOpen] = useState(false);
 
@@ -346,11 +346,7 @@ const RuleDescription = ({ rule, clamp }: { rule: RuleOrScreening; clamp?: boole
 
   if (rule.type === 'rule' && rule.aiDescription) {
     return (
-      <p
-        className={cn('border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm whitespace-pre-wrap', {
-          'line-clamp-2': clamp,
-        })}
-      >
+      <p className={cn({ 'line-clamp-2': clamp })}>
         <Icon icon="wand" className="inline size-4 align-text-bottom mr-xs text-purple-primary" />
         {rule.aiDescription}
       </p>

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -140,133 +140,17 @@ export function RulesPage({
             <HeaderCell>{t('scenarios:rules.rule_group')}</HeaderCell>
             <HeaderCell>{t('scenarios:rules.score_or_outcome')}</HeaderCell>
           </div>
-          {list.map((rule) => {
-            return (
-              <Collapsible.Root
-                key={`${rule.type}_${rule.id}`}
-                className="overflow-hidden grid grid-cols-subgrid col-span-full group/table-row hover:bg-purple-background-light cursor-pointer "
-                onClick={handleRowClick}
-                onKeyDown={handleRowKeyDown}
-                data-row
-              >
-                <Collapsible.Trigger asChild>
-                  <div
-                    role="link"
-                    tabIndex={0}
-                    className="grid grid-cols-subgrid col-span-full items-center focus-visible:outline-2 -outline-offset-2 outline-purple-primary"
-                  >
-                    <div className="invisible">
-                      {editorMode === 'edit' ? (
-                        <button
-                          data-row-button
-                          aria-label={t('scenarios:rules.edit_rule_aria_label')}
-                          onClick={() => {
-                            if (rule.id) {
-                              setCurrentEditing({ id: rule.id, type: rule.type });
-                            }
-                          }}
-                        />
-                      ) : null}
-                    </div>
-                    <GridCell
-                      className={cn({ 'grid grid-cols-[1rem_1fr] items-center gap-x-sm': editorMode === 'view' })}
-                    >
-                      {editorMode === 'view' ? (
-                        <button type="button">
-                          <Icon icon="caret-down" className="size-4" />
-                        </button>
-                      ) : null}
-                      <span>{rule.name}</span>
-                    </GridCell>
-                    <GridCell>
-                      <RuleDescription rule={rule} clamp />
-                    </GridCell>
-                    <GridCell>{rule.ruleGroup ? <Tag>{rule.ruleGroup}</Tag> : null}</GridCell>
-                    <GridCell>
-                      {rule.type === 'rule' ? (
-                        <span className={rule.scoreModifier < 0 ? 'text-green-primary' : 'text-red-primary'}>
-                          {formatNumber(rule.scoreModifier, {
-                            language,
-                            signDisplay: 'exceptZero',
-                          })}
-                        </span>
-                      ) : rule.forcedOutcome ? (
-                        <OutcomeBadge outcome={rule.forcedOutcome} size="md" />
-                      ) : null}
-                    </GridCell>
-                  </div>
-                </Collapsible.Trigger>
-                {rule.type === 'rule' ? (
-                  <Collapsible.Content asChild>
-                    <div className="col-span-full p-md grid grid-cols-[1rem_1fr] items-start gap-x-sm radix-state-open:animate-slide-down radix-state-closed:animate-slide-up">
-                      <div className="flex flex-col gap-sm max-w-3/4 col-start-2">
-                        <RuleDescription rule={rule} />
-                        <div className="border border-grey-border rounded-md px-md py-sm bg-surface-card">
-                          <RuleView scenarioId={scenario.id} ruleId={rule.id} />
-                        </div>
-                      </div>
-                    </div>
-                  </Collapsible.Content>
-                ) : (
-                  <Collapsible.Content asChild>
-                    <div className="col-span-full p-md grid grid-cols-[1rem_1fr] items-center gap-x-sm radix-state-open:animate-slide-down radix-state-closed:animate-slide-up">
-                      <div className="border border-grey-border rounded-md px-md py-sm bg-surface-card max-w-3/4 col-start-2 flex flex-col gap-sm">
-                        <div>
-                          <Trans
-                            t={t}
-                            i18nKey="scenarios:rules.screening_view.trigger_intro"
-                            values={{ triggerObject: scenario.triggerObjectType }}
-                            components={{ Tag: <Tag color="grey" /> }}
-                          />
-                        </div>
-                        <ul className="list-disc flex flex-col gap-sm pl-5">
-                          {rule.triggerRule && !isUndefinedAstNode(rule.triggerRule) ? (
-                            <li className="list-item">
-                              <div className="flex-col gap-sm">
-                                <span>{t('scenarios:rules.screening_view.trigger_condition')}</span>
-                                <AstBuilder.Provider scenarioId={scenario.id} mode="view">
-                                  <AstBuilder.Root node={rule.triggerRule} />
-                                </AstBuilder.Provider>
-                              </div>
-                            </li>
-                          ) : null}
-                          {rule.counterPartyId && isDataAccessorAstNode(rule.counterPartyId) ? (
-                            <li className="list-item">
-                              {t('scenarios:rules.screening_view.counterparty_id')}{' '}
-                              <Tag color="grey">{getDataAccessorDisplayName(rule.counterPartyId)}</Tag>
-                            </li>
-                          ) : null}
-                          {rule.entityType && rule.query ? (
-                            <ScreeningRuleQueryView
-                              entityType={rule.entityType}
-                              query={rule.query}
-                              preprocessing={rule.preprocessing}
-                            />
-                          ) : null}
-                          {rule.datasets && rule.datasets.length > 0 ? (
-                            <ScreeningDatasetsView datasets={rule.datasets} />
-                          ) : null}
-                        </ul>
-                        {rule.forcedOutcome ? (
-                          <div>
-                            <Trans
-                              t={t}
-                              i18nKey="scenarios:rules.screening_view.match_outcome"
-                              values={{ threshold: rule.threshold ?? org.sanctionThreshold }}
-                              components={{
-                                Tag: <Tag color="grey" />,
-                                Outcome: <OutcomeBadge outcome={rule.forcedOutcome} className="align-middle" />,
-                              }}
-                            />
-                          </div>
-                        ) : null}
-                      </div>
-                    </div>
-                  </Collapsible.Content>
-                )}
-              </Collapsible.Root>
-            );
-          })}
+          {list.map((rule) => (
+            <RuleRow
+              key={`${rule.type}_${rule.id}`}
+              rule={rule}
+              scenario={scenario}
+              editorMode={editorMode}
+              language={language}
+              org={org}
+              onEditRequest={setCurrentEditing}
+            />
+          ))}
         </div>
       </div>
       {editorMode === 'edit' ? (
@@ -306,6 +190,140 @@ export function RulesPage({
         </>
       ) : null}
     </div>
+  );
+}
+
+type RuleRowProps = {
+  rule: RuleOrScreening;
+  scenario: Scenario;
+  editorMode: NonNullable<EditorMode>;
+  language: ReturnType<typeof useFormatLanguage>;
+  org: ReturnType<typeof useOrganizationDetails>['org'];
+  onEditRequest: (value: { id: string; type: 'rule' | 'sanction' }) => void;
+};
+
+function RuleRow({ rule, scenario, editorMode, language, org, onEditRequest }: RuleRowProps) {
+  const { t } = useTranslation(['common', 'scenarios']);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible.Root
+      open={open}
+      onOpenChange={setOpen}
+      className="overflow-hidden grid grid-cols-subgrid col-span-full group/table-row hover:bg-purple-background-light cursor-pointer "
+      onClick={handleRowClick}
+      onKeyDown={handleRowKeyDown}
+      data-row
+    >
+      <Collapsible.Trigger asChild>
+        <div
+          role="link"
+          tabIndex={0}
+          className="grid grid-cols-subgrid col-span-full items-center focus-visible:outline-2 -outline-offset-2 outline-purple-primary"
+        >
+          <div className="invisible">
+            {editorMode === 'edit' ? (
+              <button
+                data-row-button
+                aria-label={t('scenarios:rules.edit_rule_aria_label')}
+                onClick={() => {
+                  if (rule.id) {
+                    onEditRequest({ id: rule.id, type: rule.type });
+                  }
+                }}
+              />
+            ) : null}
+          </div>
+          <GridCell className={cn({ 'grid grid-cols-[1rem_1fr] items-center gap-x-sm': editorMode === 'view' })}>
+            {editorMode === 'view' ? (
+              <button type="button">
+                <Icon icon="caret-down" className="size-4" />
+              </button>
+            ) : null}
+            <span>{rule.name}</span>
+          </GridCell>
+          <GridCell>
+            <RuleDescription rule={rule} clamp={!open} />
+          </GridCell>
+          <GridCell>{rule.ruleGroup ? <Tag>{rule.ruleGroup}</Tag> : null}</GridCell>
+          <GridCell>
+            {rule.type === 'rule' ? (
+              <span className={rule.scoreModifier < 0 ? 'text-green-primary' : 'text-red-primary'}>
+                {formatNumber(rule.scoreModifier, {
+                  language,
+                  signDisplay: 'exceptZero',
+                })}
+              </span>
+            ) : rule.forcedOutcome ? (
+              <OutcomeBadge outcome={rule.forcedOutcome} size="md" />
+            ) : null}
+          </GridCell>
+        </div>
+      </Collapsible.Trigger>
+      {rule.type === 'rule' ? (
+        <Collapsible.Content asChild>
+          <div className="col-span-full p-md grid grid-cols-[1rem_1fr] items-center gap-x-sm radix-state-open:animate-slide-down radix-state-closed:animate-slide-up">
+            <div className="border border-grey-border rounded-md px-md py-sm bg-surface-card max-w-3/4 col-start-2">
+              <RuleView scenarioId={scenario.id} ruleId={rule.id} />
+            </div>
+          </div>
+        </Collapsible.Content>
+      ) : (
+        <Collapsible.Content asChild>
+          <div className="col-span-full p-md grid grid-cols-[1rem_1fr] items-center gap-x-sm radix-state-open:animate-slide-down radix-state-closed:animate-slide-up">
+            <div className="border border-grey-border rounded-md px-md py-sm bg-surface-card max-w-3/4 col-start-2 flex flex-col gap-sm">
+              <div>
+                <Trans
+                  t={t}
+                  i18nKey="scenarios:rules.screening_view.trigger_intro"
+                  values={{ triggerObject: scenario.triggerObjectType }}
+                  components={{ Tag: <Tag color="grey" /> }}
+                />
+              </div>
+              <ul className="list-disc flex flex-col gap-sm pl-5">
+                {rule.triggerRule && !isUndefinedAstNode(rule.triggerRule) ? (
+                  <li className="list-item">
+                    <div className="flex-col gap-sm">
+                      <span>{t('scenarios:rules.screening_view.trigger_condition')}</span>
+                      <AstBuilder.Provider scenarioId={scenario.id} mode="view">
+                        <AstBuilder.Root node={rule.triggerRule} />
+                      </AstBuilder.Provider>
+                    </div>
+                  </li>
+                ) : null}
+                {rule.counterPartyId && isDataAccessorAstNode(rule.counterPartyId) ? (
+                  <li className="list-item">
+                    {t('scenarios:rules.screening_view.counterparty_id')}{' '}
+                    <Tag color="grey">{getDataAccessorDisplayName(rule.counterPartyId)}</Tag>
+                  </li>
+                ) : null}
+                {rule.entityType && rule.query ? (
+                  <ScreeningRuleQueryView
+                    entityType={rule.entityType}
+                    query={rule.query}
+                    preprocessing={rule.preprocessing}
+                  />
+                ) : null}
+                {rule.datasets && rule.datasets.length > 0 ? <ScreeningDatasetsView datasets={rule.datasets} /> : null}
+              </ul>
+              {rule.forcedOutcome ? (
+                <div>
+                  <Trans
+                    t={t}
+                    i18nKey="scenarios:rules.screening_view.match_outcome"
+                    values={{ threshold: rule.threshold ?? org.sanctionThreshold }}
+                    components={{
+                      Tag: <Tag color="grey" />,
+                      Outcome: <OutcomeBadge outcome={rule.forcedOutcome} className="align-middle" />,
+                    }}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </Collapsible.Content>
+      )}
+    </Collapsible.Root>
   );
 }
 

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -237,7 +237,7 @@ function RuleRow({ rule, scenario, editorMode, language, org, onEditRequest }: R
           <GridCell className={cn({ 'grid grid-cols-[1rem_1fr] items-center gap-x-sm': editorMode === 'view' })}>
             {editorMode === 'view' ? (
               <button type="button">
-                <Icon icon="caret-down" className="size-4" />
+                <Icon icon="caret-down" className={cn('size-4 transition-transform', { 'rotate-180': open })} />
               </button>
             ) : null}
             <span>{rule.name}</span>
@@ -346,10 +346,14 @@ const RuleDescription = ({ rule, clamp }: { rule: RuleOrScreening; clamp?: boole
 
   if (rule.type === 'rule' && rule.aiDescription) {
     return (
-      <div className="border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm flex items-start gap-xs">
-        <Icon icon="wand" className="size-4 shrink-0 text-purple-primary" />
-        <p className={cn('whitespace-pre-wrap', { 'line-clamp-2': clamp })}>{rule.aiDescription}</p>
-      </div>
+      <p
+        className={cn('border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm whitespace-pre-wrap', {
+          'line-clamp-2': clamp,
+        })}
+      >
+        <Icon icon="wand" className="inline size-4 align-text-bottom mr-xs text-purple-primary" />
+        {rule.aiDescription}
+      </p>
     );
   }
 

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -179,14 +179,7 @@ export function RulesPage({
                       <span>{rule.name}</span>
                     </GridCell>
                     <GridCell>
-                      {rule.description ? (
-                        <p className="line-clamp-2">{rule.description}</p>
-                      ) : rule.type === 'rule' && rule.aiDescription ? (
-                        <div className="border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm flex items-start gap-xs">
-                          <Icon icon="wand" className="size-4 shrink-0 text-purple-primary" />
-                          <p className="line-clamp-2 whitespace-pre-wrap">{rule.aiDescription}</p>
-                        </div>
-                      ) : null}
+                      <RuleDescription rule={rule} clamp />
                     </GridCell>
                     <GridCell>{rule.ruleGroup ? <Tag>{rule.ruleGroup}</Tag> : null}</GridCell>
                     <GridCell>
@@ -205,9 +198,12 @@ export function RulesPage({
                 </Collapsible.Trigger>
                 {rule.type === 'rule' ? (
                   <Collapsible.Content asChild>
-                    <div className="col-span-full p-md grid grid-cols-[1rem_1fr] items-center gap-x-sm radix-state-open:animate-slide-down radix-state-closed:animate-slide-up">
-                      <div className="border border-grey-border rounded-md px-md py-sm bg-surface-card max-w-3/4 col-start-2">
-                        <RuleView scenarioId={scenario.id} ruleId={rule.id} />
+                    <div className="col-span-full p-md grid grid-cols-[1rem_1fr] items-start gap-x-sm radix-state-open:animate-slide-down radix-state-closed:animate-slide-up">
+                      <div className="flex flex-col gap-sm max-w-3/4 col-start-2">
+                        <RuleDescription rule={rule} />
+                        <div className="border border-grey-border rounded-md px-md py-sm bg-surface-card">
+                          <RuleView scenarioId={scenario.id} ruleId={rule.id} />
+                        </div>
                       </div>
                     </div>
                   </Collapsible.Content>
@@ -324,6 +320,23 @@ function HeaderCell({ children, className }: { children?: React.ReactNode; class
     </GridCell>
   );
 }
+
+const RuleDescription = ({ rule, clamp }: { rule: RuleOrScreening; clamp?: boolean }) => {
+  if (rule.description) {
+    return <p className={cn({ 'line-clamp-2': clamp })}>{rule.description}</p>;
+  }
+
+  if (rule.type === 'rule' && rule.aiDescription) {
+    return (
+      <div className="border-l-purple-primary text-grey-primary text-s border-l-2 pl-sm flex items-start gap-xs">
+        <Icon icon="wand" className="size-4 shrink-0 text-purple-primary" />
+        <p className={cn('whitespace-pre-wrap', { 'line-clamp-2': clamp })}>{rule.aiDescription}</p>
+      </div>
+    );
+  }
+
+  return null;
+};
 
 const RuleView = ({ scenarioId, ruleId }: { scenarioId: string; ruleId: string }) => {
   const { t } = useTranslation(['common']);

--- a/packages/app-builder/src/models/scenario/iteration-rule.ts
+++ b/packages/app-builder/src/models/scenario/iteration-rule.ts
@@ -13,6 +13,7 @@ export interface ScenarioIterationRuleMetadata {
   displayOrder: number;
   name: string;
   description: string;
+  aiDescription: string;
   ruleGroup: string;
   scoreModifier: number;
   createdAt: string;
@@ -31,6 +32,7 @@ export function adaptScenarioIterationRuleMetadata(
     displayOrder: dto.display_order,
     name: dto.name,
     description: dto.description,
+    aiDescription: dto.ai_description,
     ruleGroup: dto.rule_group,
     scoreModifier: dto.score_modifier,
     createdAt: dto.created_at,
@@ -44,6 +46,7 @@ export function adaptScenarioIterationRule(dto: ScenarioIterationRuleDto): Scena
     displayOrder: dto.display_order,
     name: dto.name,
     description: dto.description,
+    aiDescription: dto.ai_description,
     ruleGroup: dto.rule_group,
     formula: dto.formula_ast_expression ? adaptAstNode(dto.formula_ast_expression) : null,
     scoreModifier: dto.score_modifier,

--- a/packages/marble-api/openapis/marblecore-api/scenario-iteration-rules.yml
+++ b/packages/marble-api/openapis/marblecore-api/scenario-iteration-rules.yml
@@ -236,6 +236,8 @@ components:
           type: string
         description:
           type: string
+        ai_description:
+          type: string
         rule_group:
           type: string
         score_modifier:
@@ -249,6 +251,7 @@ components:
         - display_order
         - name
         - description
+        - ai_description
         - rule_group
         - score_modifier
         - created_at

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -924,6 +924,7 @@ export type ScenarioIterationRuleMetadataDto = {
     display_order: number;
     name: string;
     description: string;
+    ai_description: string;
     rule_group: string;
     score_modifier: number;
     created_at: string;


### PR DESCRIPTION
## Summary
- Adds `ai_description` to the `ScenarioIterationRuleMetadataDto`/`ScenarioIterationRuleDto` OpenAPI schemas, mirroring the backend change in [checkmarble/marble-backend#1899](https://github.com/checkmarble/marble-backend/pull/1899), and regenerates the API client.
- Maps `aiDescription` through the rule model adapters.
- In the scenario iteration rule list, the Description column now falls back to the AI-generated description when no manual description is set, styled the same way as the AI reason in the screening match review (purple left-border text) with a wand icon inline to indicate it's AI-generated.
- Description text is clamped to 2 lines in the collapsed row; expanding the row reveals the full description in place (same Description column, not duplicated below).
- Stick the row title/tags/score to the top instead of vertically centering, since expanding the row can grow its height to fit the full description.
- The row's expand caret icon now rotates to reflect open/closed state.

## Test plan
- [x] `bun run type-check` (marble-api, app-builder)
- [x] `bun run unit-tests` (app-builder) — 43 passed
- [x] `bun run format:check`
- [x] Manually verify in the rule list UI once the backend field is deployed

## Screenshot
<img width="1534" height="1019" alt="Capture d’écran 2026-07-29 à 10 37 21" src="https://github.com/user-attachments/assets/a013daea-a0a6-4757-8d69-041d6697474c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule descriptions can now show AI-generated content when no manual description is available.
  * AI-generated descriptions are labeled with a wand icon and truncated for readability.
  * Scenario rule rows have updated expand/collapse behavior.
  * Editing is still available directly from each rule/sanction row.
* **Improvements**
  * Scenario iteration rule metadata now includes AI-generated descriptions for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->