### PR TITLE
fix: missing a11y on SAR report modale MAR-2180

### DIFF
--- a/packages/app-builder/src/components/CaseManager/PageLayout.tsx
+++ b/packages/app-builder/src/components/CaseManager/PageLayout.tsx
@@ -251,14 +251,14 @@ function SarReportModal({ open, onOpenChange, caseId, report }: SarReportModalPr
                   onValueChange={(v) => field.handleChange(v as SuspiciousActivityReportStatus)}
                   className="flex flex-col"
                 >
-                  <div className="flex gap-md px-md items-center h-9">
+                  <label className="flex gap-md px-md items-center h-9">
                     <Radio.Item value="pending" />
                     <span className="font-medium">{t('cases:manager.sar_modal.status_pending')}</span>
-                  </div>
-                  <div className="flex gap-md px-md items-center h-9">
+                  </label>
+                  <label className="flex gap-md px-md items-center h-9">
                     <Radio.Item value="completed" />
                     <span className="font-medium">{t('cases:manager.sar_modal.status_completed')}</span>
-                  </div>
+                  </label>
                 </Radio.Root>
               )}
             </form.Field>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the status selector in SAR report dialogs so the “Pending” and “Completed” options are properly associated with their radio controls, enhancing usability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->