### PR TITLE
API specification for graph exploration.

### DIFF
--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -471,7 +471,7 @@ paths:
   /analytics/available-filters:
     $ref: ./marblecore-api/analytics.yml#/~1analytics~1available-filters
 
- # SCORING
+# SCORING
 
   /scoring/settings:
     $ref: ./marblecore-api/scoring.yml#/~1scoring~1settings
@@ -491,6 +491,15 @@ paths:
     $ref: ./marblecore-api/scoring.yml#/~1scoring~1risk-levels~1{recordType}~1{recordId}~1history
   /scoring/distribution/{recordType}:
     $ref: ./marblecore-api/scoring.yml#/~1scoring~1distribution~1{recordType}
+
+# GRAPH EXPLORATION
+
+  /graph/relations:
+    $ref: ./marblecore-api/graph.yml#/~1graph~1relations
+  /graph/relations/{relationId}:
+    $ref: ./marblecore-api/graph.yml#/~1graph~1relations~1{relationId}
+  /graph/{recordType}/{recordId}:
+    $ref: ./marblecore-api/graph.yml#/~1graph~1{recordType}~1{recordId}
 
 components:
   securitySchemes:

--- a/packages/marble-api/openapis/marblecore-api/_schemas.yml
+++ b/packages/marble-api/openapis/marblecore-api/_schemas.yml
@@ -647,3 +647,18 @@ UpdateScoringRuleset:
   $ref: scoring.yml#/components/schemas/UpdateScoringRuleset
 ScoringScore:
   $ref: scoring.yml#/components/schemas/ScoringScore
+
+# GRAPH EXPLORATION
+
+GraphRelation:
+  $ref: graph.yml#/components/schemas/GraphRelation
+CreateGraphRelation:
+  $ref: graph.yml#/components/schemas/CreateGraphRelation
+Graph:
+  $ref: graph.yml#/components/schemas/Graph
+GraphNodeRef:
+  $ref: graph.yml#/components/schemas/GraphNodeRef
+GraphNode:
+  $ref: graph.yml#/components/schemas/GraphNode
+GraphEdge:
+  $ref: graph.yml#/components/schemas/GraphEdge

--- a/packages/marble-api/openapis/marblecore-api/graph.yml
+++ b/packages/marble-api/openapis/marblecore-api/graph.yml
@@ -1,0 +1,219 @@
+/graph/relations:
+  get:
+    tags:
+      - Graph exploration
+    summary: List same-field relations configurations
+    operationId: listGraphRelations
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: List of same-field relation configurations
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/GraphRelation"
+      "401":
+        $ref: "components.yml#/responses/401"
+      "403":
+        $ref: "components.yml#/responses/403"
+
+  post:
+    tags:
+      - Graph exploration
+    summary: Create a same-field relation configuration
+    operationId: createGraphRelation
+    security:
+      - bearerAuth: []
+    requestBody:
+      description: Graph relation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateGraphRelation'
+      required: true
+    responses:
+      "201":
+        description: Configuration created
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GraphRelation"
+      "401":
+        $ref: "components.yml#/responses/401"
+      "403":
+        $ref: "components.yml#/responses/403"
+
+/graph/relations/{relationId}:
+  delete:
+    tags:
+      - Graph exploration
+    summary: Delete a same-field relation configuration
+    operationId: deleteGraphRelation
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: relationId
+        description: ID of the configuration
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      "204":
+        description: Configuration was deleted
+      "401":
+        $ref: "components.yml#/responses/401"
+      "403":
+        $ref: "components.yml#/responses/403"
+
+/graph/{recordType}/{recordId}:
+  get:
+    tags:
+      - Graph exploration
+    summary: Generate the relationship graph from a starting record
+    operationId: generateRelationshipGraph
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: recordType
+        description: Record table name
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: recordId
+        description: Record ID
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      "200":
+        description: Relationship graph
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Graph"
+      "401":
+        $ref: "components.yml#/responses/401"
+      "403":
+        $ref: "components.yml#/responses/403"
+
+components:
+  schemas:
+    GraphRelation:
+      type: object
+      required:
+        - id
+        - label
+        - left_type
+        - left_field
+        - right_type
+        - right_field
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        label:
+          type: string
+        left_type:
+          type: string
+        left_field:
+          type: string
+        right_type:
+          type: string
+        right_field:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
+    CreateGraphRelation:
+      type: object
+      required:
+        - label
+        - left_type
+        - left_field
+        - right_type
+        - right_field
+      properties:
+        label:
+          type: string
+        left_type:
+          type: string
+        left_field:
+          type: string
+        right_type:
+          type: string
+        right_field:
+          type: string
+
+    Graph:
+      type: object
+      required:
+        - start
+        - nodes
+        - edges
+      properties:
+        start:
+          $ref: "#/components/schemas/GraphNodeRef"
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/GraphNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/GraphEdge"
+
+    GraphNodeRef:
+      type: object
+      required: [type, id]
+      properties:
+        type:
+          type: string
+        id:
+          type: string
+
+    GraphNode:
+      allOf:
+        - $ref: "#/components/schemas/GraphNodeRef"
+        - type: object
+          properties:
+            type:
+              type: string
+            id:
+              type: string
+            connector:
+              type: boolean
+            connector_kind:
+              type: string
+              enum: [match, link]
+            hypernode_count:
+              type: integer
+
+    GraphEdge:
+      type: object
+      required:
+        - kind
+        - label
+        - from
+        - to
+      properties:
+        kind:
+          type: string
+        label:
+          type: string
+        from:
+          $ref: "#/components/schemas/GraphNodeRef"
+        to:
+          $ref: "#/components/schemas/GraphNodeRef"
+        field:
+          type: string
+        value:
+          type: string

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -2143,6 +2143,46 @@ export type ScoringScore = {
     ruleset_id?: string;
     evaluations?: NodeEvaluationDto[];
 };
+export type GraphRelation = {
+    id: string;
+    label: string;
+    left_type: string;
+    left_field: string;
+    right_type: string;
+    right_field: string;
+    created_at: string;
+};
+export type CreateGraphRelation = {
+    label: string;
+    left_type: string;
+    left_field: string;
+    right_type: string;
+    right_field: string;
+};
+export type GraphNodeRef = {
+    "type": string;
+    id: string;
+};
+export type GraphNode = GraphNodeRef & {
+    "type"?: string;
+    id?: string;
+    connector?: boolean;
+    connector_kind?: "match" | "link";
+    hypernode_count?: number;
+};
+export type GraphEdge = {
+    kind: string;
+    label: string;
+    "from": GraphNodeRef;
+    to: GraphNodeRef;
+    field?: string;
+    value?: string;
+};
+export type Graph = {
+    start: GraphNodeRef;
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+};
 /**
  * Get searchable tables
  */
@@ -7224,6 +7264,76 @@ export function getScoreDistribution(recordType: string, opts?: Oazapfts.Request
         status: 404;
         data: string;
     }>(`/scoring/distribution/${encodeURIComponent(recordType)}`, {
+        ...opts
+    }));
+}
+/**
+ * List same-field relations configurations
+ */
+export function listGraphRelations(opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: GraphRelation[];
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    }>("/graph/relations", {
+        ...opts
+    }));
+}
+/**
+ * Create a same-field relation configuration
+ */
+export function createGraphRelation(createGraphRelation: CreateGraphRelation, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 201;
+        data: GraphRelation;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    }>("/graph/relations", oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: createGraphRelation
+    })));
+}
+/**
+ * Delete a same-field relation configuration
+ */
+export function deleteGraphRelation(relationId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 204;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    }>(`/graph/relations/${encodeURIComponent(relationId)}`, {
+        ...opts,
+        method: "DELETE"
+    }));
+}
+/**
+ * Generate the relationship graph from a starting record
+ */
+export function generateRelationshipGraph(recordType: string, recordId: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: Graph;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 403;
+        data: string;
+    }>(`/graph/${encodeURIComponent(recordType)}/${encodeURIComponent(recordId)}`, {
         ...opts
     }));
 }


### PR DESCRIPTION
Works with WIP backend branch [`graph-walking-v2`](https://github.com/checkmarble/marble-backend/tree/feat/graph-walking-v2).

Important: graph explorationr relies on an adjacency table being generated, you can trigger that with `go run . -worker -worker-only graph_build -worker-args '{"org_id":"<orgid>"}'`. This must be run whenever:
 - The data changes (objects added or modified)
 - The data model changes in a way that impacts the graph (tables or links changed).
 - Same-field relation configs are modified