### PR TITLE
Improvements to graph support

### DIFF
--- a/packages/app-builder/src/components/Graph/GraphComponents.tsx
+++ b/packages/app-builder/src/components/Graph/GraphComponents.tsx
@@ -258,7 +258,6 @@ function PersonNode({ id, data }: NodeProps<PersonRfNode>) {
   const { nodeTagsVisible, nodeTagIdOverrides, addedNodeTagIds, toggleClusterExpanded, selectionMode, hoveredNodeId } =
     useCustomerGraph();
   const { t } = useTranslation(graphI18n);
-  const title = usePersonTitle(data);
   // Payload metadata is static; session edits from the settings panel replace it
   // as a whole, then bulk-tag additions merge on top of whichever list won.
   const overrideTagIds = nodeTagIdOverrides.get(id);
@@ -271,12 +270,12 @@ function PersonNode({ id, data }: NodeProps<PersonRfNode>) {
   return (
     <NodeShell
       nodeId={id}
-      label={title}
+      label={data.label}
       action={
         data.isExpandedClusterRoot
           ? {
               icon: 'unfold_less',
-              label: t('graph:node.regroup_branch', { title }),
+              label: t('graph:node.regroup_branch', { title: data.label }),
               onPress: () => toggleClusterExpanded(id),
             }
           : undefined
@@ -296,11 +295,10 @@ function PersonNode({ id, data }: NodeProps<PersonRfNode>) {
 function ClusterNode({ id, data }: NodeProps<ClusterRfNode>) {
   const { toggleClusterExpanded, selectionMode, hoveredNodeId } = useCustomerGraph();
   const { t } = useTranslation(graphI18n);
-  const title = usePersonTitle(data.root);
   const isHovered = !selectionMode && hoveredNodeId === id;
 
   return (
-    <NodeShell nodeId={id} label={title}>
+    <NodeShell nodeId={id} label={data.root.label}>
       <PersonCard data={data.root} isHovered={isHovered}>
         <div className="text-grey-primary flex items-center justify-between gap-sm text-xs">
           <div className="min-w-0 truncate">
@@ -350,14 +348,22 @@ function HypernodeNode({ id, data }: NodeProps<HypernodeRfNode>) {
   return (
     <div
       className={cn(
-        'border-grey-border bg-surface-card text-grey-primary relative flex gap-xs w-fit items-center rounded-md border p-md text-xs shadow-sm cursor-pointer transition-opacity duration-200',
-        isHovered && 'ring-2 ring-grey-primary ring-offset-2',
+        'border-grey-border bg-surface-card text-grey-primary relative flex w-fit max-w-96 items-center gap-xs rounded-full border px-sm py-xs text-xs shadow-sm cursor-pointer transition-opacity duration-200',
+        isHovered && 'ring-2 ring-orange-primary ring-offset-2',
         !highlighted && 'opacity-60',
       )}
     >
       <FourHandles />
-      <span>{t('graph:node.too_many')}</span>
-      <span className="font-medium tabular-nums">({data.count})</span>
+      <Icon icon="tip" className="size-3.5 shrink-0" />
+      <div className="min-w-0">
+        <div className="text-xs leading-none opacity-70">{data.label ?? data.objectType}</div>
+        <div className="truncate font-medium">{data.objectId}</div>
+        <p className={cn('text-2xs flex gap-xs mr-2 mt-1')}>
+          <span>
+            {t('graph:node.too_many')} (≈ {data.count})
+          </span>
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/app-builder/src/components/Graph/GraphComponents.tsx
+++ b/packages/app-builder/src/components/Graph/GraphComponents.tsx
@@ -132,7 +132,6 @@ function PersonPill({
   isHovered?: boolean;
 }) {
   const { showRiskScore, selectedObject } = useCustomerGraph();
-  const title = usePersonTitle(data);
 
   const isSelected = selectedObject?.objectType === data.objectType && selectedObject?.objectId === data.objectId;
   const isHighlighted = data.isStart || isSelected;
@@ -175,8 +174,8 @@ function PersonPill({
           </span>
         ) : null}
       </div>
-      <span className={cn('block truncate', !capped && 'max-w-48')} title={title}>
-        {title}
+      <span className={cn('block truncate', !capped && 'max-w-48')} title={data.label}>
+        {data.label}
       </span>
     </div>
   );
@@ -332,8 +331,8 @@ function PivotNode({ id, data }: NodeProps<PivotRfNode>) {
       <FourHandles />
       <Icon icon="tip" className="size-3.5 shrink-0" />
       <div className="min-w-0">
-        <div className="text-xs leading-none opacity-70">{data.rawType}</div>
-        <div className="truncate font-medium">{data.label}</div>
+        <div className="text-xs leading-none opacity-70">{data.label}</div>
+        <div className="truncate font-medium">{data.value}</div>
       </div>
     </div>
   );

--- a/packages/app-builder/src/components/Graph/GraphComponents.tsx
+++ b/packages/app-builder/src/components/Graph/GraphComponents.tsx
@@ -1,6 +1,5 @@
 import { type FtmEntityPersonOption } from '@app-builder/models/data-model';
 import { SCORING_LEVELS_COLORS } from '@app-builder/models/scoring';
-import { useObjectDetailsQuery } from '@app-builder/queries/data/get-object-details';
 import { useScoringSettingsQuery } from '@app-builder/queries/scoring/get-scoring-settings';
 import {
   BaseEdge,
@@ -28,7 +27,6 @@ import {
   type PivotRfNode,
 } from './graph-rf-types';
 import { ObjectTagLine, useTagsByIds } from './ObjectTags';
-import { resolveTitle } from './resolve-object-title';
 
 /**
  * A node stays fully opaque when nothing is hovered, when it is the hovered
@@ -110,12 +108,6 @@ function subEntityIcon(subEntity: FtmEntityPersonOption): IconName {
     default:
       return 'person';
   }
-}
-
-/** Resolved object title, falling back to the raw id while the details load. */
-function usePersonTitle(data: PersonRfData): string {
-  const detailsQuery = useObjectDetailsQuery(data.objectType, data.objectId);
-  return detailsQuery.data?.data != null ? resolveTitle(detailsQuery.data.data, data.objectId) : data.label;
 }
 
 /**

--- a/packages/app-builder/src/components/Graph/GraphImpl.tsx
+++ b/packages/app-builder/src/components/Graph/GraphImpl.tsx
@@ -1,7 +1,7 @@
 import { AutoLayoutControlButton } from '@app-builder/components/ReactFlow';
 import { useTheme } from '@app-builder/contexts/ThemeContext';
 import { type DataModel } from '@app-builder/models/data-model';
-import { type GraphData } from '@app-builder/models/graph';
+import { type GraphData, GraphNodeData } from '@app-builder/models/graph';
 import { ControlButton, Controls, EdgeMouseHandler, type NodeMouseHandler, ReactFlow } from '@xyflow/react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/packages/app-builder/src/components/Graph/GraphImpl.tsx
+++ b/packages/app-builder/src/components/Graph/GraphImpl.tsx
@@ -30,6 +30,16 @@ function sameRefs(a: GraphObjectRef[], b: GraphObjectRef[]): boolean {
   );
 }
 
+function personRefFromRfNode(node: Extract<GraphRfNode, { type: 'person' }>): GraphObjectRef {
+  return { objectType: node.data.objectType, objectId: node.data.objectId, label: node.data.label };
+}
+
+function personRefFromGraphData(nodes: GraphNodeData[], key: string): GraphObjectRef {
+  const ref = parseNodeKey(key);
+  const node = nodes.find((n) => n.type === ref.objectType && n.id === ref.objectId);
+  return { ...ref, label: node?.metadata?.label };
+}
+
 export function GraphImpl({ data, dataModel }: GraphImplProps) {
   const { t } = useTranslation(graphI18n);
   const theme = useTheme();
@@ -82,7 +92,7 @@ export function GraphImpl({ data, dataModel }: GraphImplProps) {
       }
       return nodes
         .filter((n): n is Extract<GraphRfNode, { type: 'person' }> => n.type === 'person' && neighborIds.has(n.id))
-        .map((n) => ({ objectType: n.data.objectType, objectId: n.data.objectId }));
+        .map(personRefFromRfNode);
     },
     [edges, nodes],
   );
@@ -108,6 +118,7 @@ export function GraphImpl({ data, dataModel }: GraphImplProps) {
           nodeType: 'person',
           objectType: node.data.objectType,
           objectId: node.data.objectId,
+          label: node.data.label,
           persons: connectedPersonsForNode(node.id),
         });
         return;
@@ -118,10 +129,10 @@ export function GraphImpl({ data, dataModel }: GraphImplProps) {
           nodeType: 'cluster',
           objectType: node.data.root.objectType,
           objectId: node.data.root.objectId,
+          label: node.data.root.label,
           nodeCount: node.data.nodeCount,
           internalEdgeCount: node.data.internalEdgeCount,
-          // Members are never pivots, so every id parses as a person ref.
-          persons: node.data.memberIds.map(parseNodeKey),
+          persons: node.data.memberIds.map((memberId) => personRefFromGraphData(data.nodes, memberId)),
         });
         return;
       }
@@ -144,7 +155,7 @@ export function GraphImpl({ data, dataModel }: GraphImplProps) {
         persons: connectedPersonsForNode(node.id),
       });
     },
-    [connectedPersonsForNode, setSelectedObject],
+    [connectedPersonsForNode, data.nodes, setSelectedObject],
   );
 
   const onNodeMouseEnter = useCallback<NodeMouseHandler<GraphRfNode>>(

--- a/packages/app-builder/src/components/Graph/GraphImpl.tsx
+++ b/packages/app-builder/src/components/Graph/GraphImpl.tsx
@@ -139,8 +139,8 @@ export function GraphImpl({ data, dataModel }: GraphImplProps) {
 
       setSelectedObject({
         nodeType: 'pivot',
-        objectType: node.data.rawType,
-        objectId: node.data.label,
+        objectType: node.data.label ?? '',
+        objectId: node.data.value,
         persons: connectedPersonsForNode(node.id),
       });
     },

--- a/packages/app-builder/src/components/Graph/GraphSettingsPanel.tsx
+++ b/packages/app-builder/src/components/Graph/GraphSettingsPanel.tsx
@@ -101,14 +101,10 @@ function asBoolean(value: CheckedState): boolean {
   return value === true;
 }
 
-function DetailCardSkeleton() {
+function DetailCardSkeleton({ showTags }: { showTags: boolean }) {
   return (
     <div className="flex flex-col gap-sm">
-      <div className="flex flex-wrap items-center gap-sm">
-        <div className="bg-grey-border h-4 w-28 animate-pulse rounded-md" />
-        <div className="bg-grey-border h-5 w-24 animate-pulse rounded-full" />
-      </div>
-      <ObjectTagLineSkeleton />
+      {showTags ? <ObjectTagLineSkeleton /> : null}
       <div className="flex flex-col gap-xs">
         <div className="bg-grey-border h-6 w-full animate-pulse rounded-sm" />
         <div className="bg-grey-border h-6 w-full animate-pulse rounded-sm" />
@@ -212,10 +208,7 @@ function ObjectTags({ objectType, objectId }: GraphObjectRef) {
 
 function PersonRow({ person, showTags }: { person: GraphObjectRef; showTags: boolean }) {
   const { selectionMode, setHoveredNodeId, setSelectedObject } = useCustomerGraph();
-  const detailsQuery = useObjectDetailsQuery(person.objectType, person.objectId);
-  const title = match(detailsQuery)
-    .with({ isSuccess: true }, ({ data }) => resolveTitle(data.data, person.objectId))
-    .otherwise(() => person.objectId);
+  const title = resolveTitle(person.label, person.objectId);
   const id = nodeKey(person.objectType, person.objectId);
 
   return (
@@ -390,18 +383,17 @@ export function GraphSettingsPanel() {
           match(selectedObject)
             .with({ nodeType: 'person' }, (person) => (
               <>
+                <div className="flex flex-wrap items-center gap-sm">
+                  <span className="text-purple-primary text-sm font-semibold">
+                    {resolveTitle(person.label, person.objectId)}
+                  </span>
+                  <ObjectRiskBadge objectType={objectType} objectId={objectId} />
+                </div>
                 {match(detailsQuery)
                   .with({ isError: true }, () => <QueryError onRetry={() => detailsQuery.refetch()} />)
-                  .with({ isPending: true }, () => <DetailCardSkeleton />)
+                  .with({ isPending: true }, () => <DetailCardSkeleton showTags={showTags} />)
                   .with({ isSuccess: true }, ({ data: objectDetails }) => (
                     <>
-                      <div className="flex flex-wrap items-center gap-sm">
-                        <span className="text-purple-primary text-sm font-semibold">
-                          {resolveTitle(objectDetails.data, objectId)}
-                        </span>
-                        <ObjectRiskBadge objectType={objectType} objectId={objectId} />
-                      </div>
-
                       {showTags ? (
                         <ClientObjectTagList
                           tableName={objectType}

--- a/packages/app-builder/src/components/Graph/SessionGraphCanvas.tsx
+++ b/packages/app-builder/src/components/Graph/SessionGraphCanvas.tsx
@@ -28,6 +28,10 @@ export function SessionGraphCanvas({ placeholder }: { placeholder: ReactNode }) 
 
   if (!graphData) return placeholder;
 
+  const startNode = graphData.nodes.find(
+    (node) => node.type === graphData.start.type && node.id === graphData.start.id,
+  );
+
   return (
     <CustomerGraphProvider
       key={graphGeneration}
@@ -36,6 +40,7 @@ export function SessionGraphCanvas({ placeholder }: { placeholder: ReactNode }) 
         nodeType: 'person',
         objectType: graphData.start.type,
         objectId: graphData.start.id,
+        label: startNode?.metadata?.label,
         persons: [],
       }}
     >

--- a/packages/app-builder/src/components/Graph/graph-keys.ts
+++ b/packages/app-builder/src/components/Graph/graph-keys.ts
@@ -7,6 +7,8 @@
 export type GraphObjectRef = {
   objectType: string;
   objectId: string;
+  /** Graph node metadata label. */
+  label?: string;
 };
 
 export function nodeKey(objectType: string, objectId: string): string {

--- a/packages/app-builder/src/components/Graph/graph-layout.spec.ts
+++ b/packages/app-builder/src/components/Graph/graph-layout.spec.ts
@@ -19,7 +19,7 @@ function personNode(id: string, isStart = false): GraphRfNode {
 }
 
 function pivotNode(id: string): GraphRfNode {
-  return { id, position: { x: 0, y: 0 }, type: 'pivot', data: { label: id, rawType: 'same_ip' } };
+  return { id, position: { x: 0, y: 0 }, type: 'pivot', data: { value: id, label: 'same_ip' } };
 }
 
 function linkEdge(source: string, target: string): GraphRfEdge {

--- a/packages/app-builder/src/components/Graph/graph-rf-types.ts
+++ b/packages/app-builder/src/components/Graph/graph-rf-types.ts
@@ -16,11 +16,12 @@ export type PersonRfData = {
 };
 
 export type PivotRfData = {
-  label: string;
-  rawType: string;
+  label?: string;
+  value: string;
 };
 
 export type HypernodeRfData = {
+  label?: string;
   count: number;
   objectType: string;
   objectId: string;

--- a/packages/app-builder/src/components/Graph/resolve-object-title.ts
+++ b/packages/app-builder/src/components/Graph/resolve-object-title.ts
@@ -1,13 +1,12 @@
-import { type DataModelObjectValue } from '@app-builder/models/data-model';
+import { type GraphEdgeData } from '@app-builder/models/graph';
 
-const TITLE_FIELD_CANDIDATES = ['name', 'full_name', 'company_name', 'display_name', 'label'] as const;
-
-export function resolveTitle(data: Record<string, DataModelObjectValue>, objectId: string): string {
-  for (const key of TITLE_FIELD_CANDIDATES) {
-    const value = data[key];
-    if (typeof value === 'string' && value.trim()) return value;
-  }
-  const objectIdValue = data['object_id'];
-  if (typeof objectIdValue === 'string' && objectIdValue.trim()) return objectIdValue;
+export function resolveTitle(label: string | undefined, objectId: string) {
+  const trimmed = label?.trim();
+  if (trimmed && trimmed !== '-') return trimmed;
   return objectId;
+}
+
+/** Placeholder: edge metadata will produce the displayed label. */
+export function resolveEdgeLabel(_edge: GraphEdgeData): string | undefined {
+  return undefined;
 }

--- a/packages/app-builder/src/components/Graph/use-laid-out-graph.ts
+++ b/packages/app-builder/src/components/Graph/use-laid-out-graph.ts
@@ -46,7 +46,7 @@ function isNodeVisible(node: GraphRfNode, filters: VisibilityFilters): boolean {
 
   if (node.type === 'pivot') {
     if (filters.hiddenNodeIds.has(node.id)) return false;
-    return allowsPivot(filters.relationFilter, node.data.rawType);
+    return allowsPivot(filters.relationFilter, node.data.label ?? '');
   }
 
   // Hypernodes and clusters are not relation-filtered.

--- a/packages/app-builder/src/components/Graph/utils.ts
+++ b/packages/app-builder/src/components/Graph/utils.ts
@@ -3,6 +3,7 @@ import { match } from 'ts-pattern';
 import { type GraphTypeHelpers } from './data-model-map';
 import { nodeKey } from './graph-keys';
 import { type GraphRfEdge, type GraphRfNode } from './graph-rf-types';
+import { resolveEdgeLabel, resolveTitle } from './resolve-object-title';
 
 export type FlatFlowElements = {
   nodes: GraphRfNode[];
@@ -83,7 +84,7 @@ export function toFlatFlowElements(data: GraphData, typeHelpers: GraphTypeHelper
           position,
           type: 'person',
           data: {
-            label: node.metadata?.label ?? '-',
+            label: resolveTitle(node.metadata?.label, node.id),
             subEntity: typeHelpers.getPersonSubEntity(node.type),
             isStart: key === startKey,
             objectType: node.type,
@@ -103,7 +104,8 @@ export function toFlatFlowElements(data: GraphData, typeHelpers: GraphTypeHelper
     const toKey = nodeKey(edge.to.type, edge.to.id);
     if (!keptKeys.has(fromKey) || !keptKeys.has(toKey)) continue;
 
-    const edgeId = `${fromKey}->${toKey}:${edge.label}`;
+    const throughKey = edge.through.join(',');
+    const edgeId = `${fromKey}->${toKey}:${throughKey}`;
     if (seenEdges.has(edgeId)) continue;
     seenEdges.add(edgeId);
 
@@ -117,7 +119,7 @@ export function toFlatFlowElements(data: GraphData, typeHelpers: GraphTypeHelper
       target: toKey,
       type: touchesHypernode ? 'hypernode' : isMatch ? 'match' : 'link',
       animated: touchesHypernode || isMatch,
-      label: edge.label,
+      label: resolveEdgeLabel(edge),
       data: { kind: edge.kind },
     });
   }

--- a/packages/app-builder/src/components/Graph/utils.ts
+++ b/packages/app-builder/src/components/Graph/utils.ts
@@ -65,26 +65,31 @@ export function toFlatFlowElements(data: GraphData, typeHelpers: GraphTypeHelper
           id: key,
           position,
           type: 'hypernode',
-          data: { count: hypernode.hypernodeCount, objectType: node.type, objectId: node.id },
+          data: {
+            count: hypernode.hypernodeCount,
+            objectType: node.type,
+            objectId: node.id,
+            label: node.metadata?.label,
+          },
         }))
         .with({ kind: 'connector' }, () => ({
           id: key,
           position,
           type: 'pivot',
-          data: { label: node.id, rawType: node.type },
+          data: { value: node.id, label: node.metadata?.label },
         }))
         .with({ kind: 'record' }, (record) => ({
           id: key,
           position,
           type: 'person',
           data: {
-            label: node.id,
+            label: node.metadata?.label ?? '-',
             subEntity: typeHelpers.getPersonSubEntity(node.type),
             isStart: key === startKey,
             objectType: node.type,
             objectId: node.id,
-            riskLevel: record.metadata.riskLevel,
-            tagIds: record.metadata.tagIds,
+            riskLevel: record.metadata?.riskLevel,
+            tagIds: record.metadata?.tagIds ?? [],
           },
         }))
         .exhaustive(),

--- a/packages/app-builder/src/locales/ar/graph.json
+++ b/packages/app-builder/src/locales/ar/graph.json
@@ -22,7 +22,7 @@
   "node.expand_other": "توسيع {{count}} عقد",
   "node.regroup_branch": "إعادة تجميع الفرع {{title}}",
   "node.select": "تحديد {{label}}",
-  "node.too_many": "عدد كبير جدًا من العقد للعرض",
+  "node.too_many": "مخطط مجتزأ بسبب كيان فائق الترابط",
   "panel.connected_nodes": "العقد المتصلة",
   "panel.grouped_branch": "فرع مجمّع",
   "panel.hypernode": "عقدة فائقة",

--- a/packages/app-builder/src/locales/en/graph.json
+++ b/packages/app-builder/src/locales/en/graph.json
@@ -22,7 +22,7 @@
   "node.expand_other": "Expand {{count}} nodes",
   "node.regroup_branch": "Regroup branch {{title}}",
   "node.select": "Select {{label}}",
-  "node.too_many": "Too many nodes to display",
+  "node.too_many": "Graph truncated due to hyperconnected entity",
   "panel.connected_nodes": "Connected nodes",
   "panel.grouped_branch": "Grouped branch",
   "panel.hypernode": "Hypernode",

--- a/packages/app-builder/src/locales/fr/graph.json
+++ b/packages/app-builder/src/locales/fr/graph.json
@@ -22,7 +22,7 @@
   "node.expand_other": "Déployer {{count}} nœuds",
   "node.regroup_branch": "Regrouper la branche {{title}}",
   "node.select": "Sélectionner {{label}}",
-  "node.too_many": "Trop de nœuds à afficher",
+  "node.too_many": "Graphe tronqué dû à une entité hyperconnectée",
   "panel.connected_nodes": "Nœuds connectés",
   "panel.grouped_branch": "Branche regroupée",
   "panel.hypernode": "Hypernœud",

--- a/packages/app-builder/src/models/graph.ts
+++ b/packages/app-builder/src/models/graph.ts
@@ -14,6 +14,7 @@ export type GraphNodeRef = {
 
 /** Per-node annotations returned with the graph payload (structural/record nodes). */
 export type GraphNodeMetadata = {
+  label?: string;
   riskLevel?: number;
   tagIds: string[];
 };
@@ -24,9 +25,9 @@ export type GraphNodeMetadata = {
  */
 export type GraphNodeData = GraphNodeRef &
   (
-    | { kind: 'record'; metadata: GraphNodeMetadata }
-    | { kind: 'connector' }
-    | { kind: 'hypernode'; hypernodeCount: number }
+    | { kind: 'record'; metadata?: GraphNodeMetadata }
+    | { kind: 'connector'; metadata?: GraphNodeMetadata }
+    | { kind: 'hypernode'; hypernodeCount: number; metadata?: GraphNodeMetadata }
   );
 
 export type GraphEdgeData = {
@@ -69,6 +70,7 @@ function adaptGraphNodeRef(dto: GraphNodeRefDto): GraphNodeRef {
 function adaptGraphNodeMetadata(dto: GraphNodeDto): GraphNodeMetadata {
   const rawTags = dto.metadata?.tags;
   return {
+    label: dto.metadata?.label,
     riskLevel: dto.metadata?.risk_level,
     tagIds: Array.isArray(rawTags) ? rawTags.map(String).filter(Boolean) : [],
   };
@@ -77,10 +79,10 @@ function adaptGraphNodeMetadata(dto: GraphNodeDto): GraphNodeMetadata {
 function adaptGraphNode(dto: GraphNodeDto): GraphNodeData {
   const ref = adaptGraphNodeRef(dto);
   if (dto.hypernode_count != null) {
-    return { ...ref, kind: 'hypernode', hypernodeCount: dto.hypernode_count };
+    return { ...ref, kind: 'hypernode', hypernodeCount: dto.hypernode_count, metadata: adaptGraphNodeMetadata(dto) };
   }
   if (dto.connector === true) {
-    return { ...ref, kind: 'connector' };
+    return { ...ref, kind: 'connector', metadata: adaptGraphNodeMetadata(dto) };
   }
   return { ...ref, kind: 'record', metadata: adaptGraphNodeMetadata(dto) };
 }

--- a/packages/app-builder/src/models/graph.ts
+++ b/packages/app-builder/src/models/graph.ts
@@ -34,7 +34,7 @@ export type GraphEdgeData = {
   from: GraphNodeRef;
   to: GraphNodeRef;
   kind: string;
-  label: string;
+  through: string[];
   field?: string;
   value?: string;
 };
@@ -92,7 +92,7 @@ function adaptGraphEdge(dto: GraphEdgeDto): GraphEdgeData {
     from: adaptGraphNodeRef(dto.from),
     to: adaptGraphNodeRef(dto.to),
     kind: dto.kind,
-    label: dto.label,
+    through: dto.through ?? [],
     field: dto.field,
     value: dto.value,
   };

--- a/packages/marble-api/openapis/marblecore-api/graph.yml
+++ b/packages/marble-api/openapis/marblecore-api/graph.yml
@@ -132,6 +132,7 @@ components:
       type: object
       required:
         - id
+        - group_id
         - label
         - left_type
         - left_field
@@ -140,6 +141,9 @@ components:
         - created_at
       properties:
         id:
+          type: string
+          format: uuid
+        group_id:
           type: string
           format: uuid
         label:
@@ -165,6 +169,9 @@ components:
         - right_type
         - right_field
       properties:
+        group_id:
+          type: string
+          format: uuid
         label:
           type: string
         left_type:
@@ -232,7 +239,6 @@ components:
                     type: string
                     format: uuid
 
-
     GraphEdge:
       type: object
       required:
@@ -243,12 +249,14 @@ components:
       properties:
         kind:
           type: string
-        label:
-          type: string
         from:
           $ref: "#/components/schemas/GraphNodeRef"
         to:
           $ref: "#/components/schemas/GraphNodeRef"
+        through:
+          type: array
+          items:
+            type: string
         field:
           type: string
         value:

--- a/packages/marble-api/openapis/marblecore-api/graph.yml
+++ b/packages/marble-api/openapis/marblecore-api/graph.yml
@@ -222,6 +222,8 @@ components:
             metadata:
               type: object
               properties:
+                label:
+                  type: string
                 risk_level:
                   type: integer
                 tags:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -2151,6 +2151,7 @@ export type ScoringScore = {
 };
 export type GraphRelation = {
     id: string;
+    group_id: string;
     label: string;
     left_type: string;
     left_field: string;
@@ -2159,6 +2160,7 @@ export type GraphRelation = {
     created_at: string;
 };
 export type CreateGraphRelation = {
+    group_id?: string;
     label: string;
     left_type: string;
     left_field: string;
@@ -2183,9 +2185,9 @@ export type GraphNode = GraphNodeRef & {
 };
 export type GraphEdge = {
     kind: string;
-    label: string;
     "from": GraphNodeRef;
     to: GraphNodeRef;
+    through?: string[];
     field?: string;
     value?: string;
 };

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -2176,6 +2176,7 @@ export type GraphNode = GraphNodeRef & {
     connector_kind?: "match" | "link";
     hypernode_count?: number;
     metadata?: {
+        label?: string;
         risk_level?: number;
         tags?: string[];
     };


### PR DESCRIPTION
- Entity caption now returned as a node metadata (`label`)
- Hypernode rendered with data
- Relation configs are now set with a `group_id` grouping key
- New edge metadata (`through` adds a path of tables + `field` + `value`) 