### PR TITLE
feat: poll scheduled executions while pending or processing

### DIFF
--- a/packages/app-builder/src/models/decision.spec.ts
+++ b/packages/app-builder/src/models/decision.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { hasInProgressScheduledExecution, isScheduledExecutionInProgress } from './decision';
+
+describe('isScheduledExecutionInProgress', () => {
+  it('treats pending as in progress', () => {
+    expect(isScheduledExecutionInProgress('pending')).toBe(true);
+  });
+
+  it('treats processing as in progress', () => {
+    expect(isScheduledExecutionInProgress('processing')).toBe(true);
+  });
+
+  it('treats success as not in progress', () => {
+    expect(isScheduledExecutionInProgress('success')).toBe(false);
+  });
+
+  it('treats failure as not in progress', () => {
+    expect(isScheduledExecutionInProgress('failure')).toBe(false);
+  });
+
+  it('treats partial_failure as not in progress', () => {
+    expect(isScheduledExecutionInProgress('partial_failure')).toBe(false);
+  });
+});
+
+describe('hasInProgressScheduledExecution', () => {
+  it('is true if any row is in progress', () => {
+    expect(hasInProgressScheduledExecution([{ status: 'success' }, { status: 'pending' }])).toBe(true);
+    expect(hasInProgressScheduledExecution([{ status: 'processing' }])).toBe(true);
+  });
+
+  it('is false for an empty list', () => {
+    expect(hasInProgressScheduledExecution([])).toBe(false);
+  });
+
+  it('is false when every row is terminal', () => {
+    expect(
+      hasInProgressScheduledExecution([{ status: 'success' }, { status: 'failure' }, { status: 'partial_failure' }]),
+    ).toBe(false);
+  });
+});

--- a/packages/app-builder/src/models/decision.ts
+++ b/packages/app-builder/src/models/decision.ts
@@ -57,6 +57,22 @@ export interface ScheduledExecution {
   finishedAt: string | null;
 }
 
+export const scheduledExecutionInProgressByStatus = {
+  pending: true,
+  processing: true,
+  success: false,
+  failure: false,
+  partial_failure: false,
+} as const satisfies Record<ScheduledExecution['status'], boolean>;
+
+export function isScheduledExecutionInProgress(status: ScheduledExecution['status']) {
+  return scheduledExecutionInProgressByStatus[status];
+}
+
+export function hasInProgressScheduledExecution(executions: readonly Pick<ScheduledExecution, 'status'>[]) {
+  return executions.some((execution) => isScheduledExecutionInProgress(execution.status));
+}
+
 export function adaptScheduledExecution(dto: ScheduledExecutionDto): ScheduledExecution {
   return {
     id: dto.id,

--- a/packages/app-builder/src/queries/decisions/list-scheduled-executions.spec.ts
+++ b/packages/app-builder/src/queries/decisions/list-scheduled-executions.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getScheduledExecutionsRefetchInterval,
+  SCHEDULED_EXECUTIONS_REFETCH_INTERVAL_MS,
+} from './list-scheduled-executions';
+
+describe('getScheduledExecutionsRefetchInterval', () => {
+  it('returns 1000 when any execution is pending', () => {
+    expect(getScheduledExecutionsRefetchInterval([{ status: 'pending' }])).toBe(
+      SCHEDULED_EXECUTIONS_REFETCH_INTERVAL_MS,
+    );
+  });
+
+  it('returns 1000 when any execution is processing', () => {
+    expect(getScheduledExecutionsRefetchInterval([{ status: 'success' }, { status: 'processing' }])).toBe(
+      SCHEDULED_EXECUTIONS_REFETCH_INTERVAL_MS,
+    );
+  });
+
+  it('returns false when every execution is terminal', () => {
+    expect(
+      getScheduledExecutionsRefetchInterval([
+        { status: 'success' },
+        { status: 'failure' },
+        { status: 'partial_failure' },
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false for an empty list', () => {
+    expect(getScheduledExecutionsRefetchInterval([])).toBe(false);
+  });
+});

--- a/packages/app-builder/src/queries/decisions/list-scheduled-executions.ts
+++ b/packages/app-builder/src/queries/decisions/list-scheduled-executions.ts
@@ -1,13 +1,39 @@
-import { ScheduledExecution } from '@app-builder/models/decision';
+import { hasInProgressScheduledExecution, type ScheduledExecution } from '@app-builder/models/decision';
 import { listScheduledExecutionsFn } from '@app-builder/server-fns/decisions';
-import { useQuery } from '@tanstack/react-query';
+import { type Query, useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
 
-export const useListScheduleExecutions = () => {
-  const listScheduledExecutions = useServerFn(listScheduledExecutionsFn);
+type ListScheduledExecutionsResult = { scheduledExecutions: ScheduledExecution[] };
 
+type ListScheduledExecutionsQuery = Query<
+  ListScheduledExecutionsResult,
+  Error,
+  ListScheduledExecutionsResult,
+  (string | { scenarioId?: string })[]
+>;
+
+export const SCHEDULED_EXECUTIONS_REFETCH_INTERVAL_MS = 1_000;
+
+export function getScheduledExecutionsRefetchInterval(
+  executions: readonly Pick<ScheduledExecution, 'status'>[],
+): number | false {
+  return hasInProgressScheduledExecution(executions) ? SCHEDULED_EXECUTIONS_REFETCH_INTERVAL_MS : false;
+}
+
+export function useListScheduleExecutions({
+  scenarioId,
+  initialData,
+  refetchInterval,
+}: {
+  scenarioId?: string;
+  initialData?: { scheduledExecutions: ScheduledExecution[] };
+  refetchInterval?: number | false | ((query: ListScheduledExecutionsQuery) => number | false | undefined);
+} = {}) {
+  const listScheduledExecutions = useServerFn(listScheduledExecutionsFn);
   return useQuery({
-    queryKey: ['decisions', 'list-scheduled-executions'],
-    queryFn: async () => listScheduledExecutions() as Promise<{ scheduledExecutions: ScheduledExecution[] }>,
+    queryKey: ['decisions', 'list-scheduled-executions', { scenarioId }],
+    queryFn: () => listScheduledExecutions({ data: { scenarioId } }),
+    initialData,
+    refetchInterval,
   });
-};
+}

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/home.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/home.tsx
@@ -13,7 +13,7 @@ import { WorkflowNudge } from '@app-builder/components/Workflows/Nudge';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useDetectionScenarioData } from '@app-builder/hooks/routes-layout-data';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
-import { type ScheduledExecution } from '@app-builder/models/decision';
+import { hasInProgressScheduledExecution, type ScheduledExecution } from '@app-builder/models/decision';
 import { type Scenario } from '@app-builder/models/scenario';
 import { type ScenarioIterationSummaryWithType } from '@app-builder/models/scenario/iteration';
 import { useListRulesQuery } from '@app-builder/queries/Workflows';
@@ -355,9 +355,7 @@ function BatchSection({
     }
   }, [language, schedule]);
 
-  const isExecutionOngoing = scheduledExecutions.some((execution) =>
-    ['pending', 'processing'].includes(execution.status),
-  );
+  const isExecutionOngoing = hasInProgressScheduledExecution(scheduledExecutions);
 
   return (
     <article className="flex flex-col">

--- a/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/scheduled-executions.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/detection/scenarios/$scenarioId/scheduled-executions.tsx
@@ -3,6 +3,10 @@ import { BreadCrumbLink, type BreadCrumbProps, BreadCrumbs } from '@app-builder/
 import { ScheduledExecutionsList } from '@app-builder/components/Scenario/ScheduledExecutionsList';
 import { useDetectionScenarioData } from '@app-builder/hooks/routes-layout-data';
 import { authMiddleware } from '@app-builder/middlewares/auth-middleware';
+import {
+  getScheduledExecutionsRefetchInterval,
+  useListScheduleExecutions,
+} from '@app-builder/queries/decisions/list-scheduled-executions';
 import { fromParams, fromUUIDtoSUUID } from '@app-builder/utils/short-uuid';
 import * as Sentry from '@sentry/react';
 import { createFileRoute } from '@tanstack/react-router';
@@ -18,7 +22,7 @@ const scheduledExecutionsLoader = createServerFn()
 
     const scheduledExecutions = await context.authInfo.decision.listScheduledExecutions({ scenarioId });
 
-    return { scheduledExecutions };
+    return { scenarioId, scheduledExecutions };
   });
 
 export const Route = createFileRoute('/_app/_builder/detection/scenarios/$scenarioId/scheduled-executions')({
@@ -50,7 +54,13 @@ export const Route = createFileRoute('/_app/_builder/detection/scenarios/$scenar
 
 function ScheduledExecutions() {
   const { t } = useTranslation(scenarioI18n);
-  const { scheduledExecutions } = Route.useLoaderData();
+  const { scenarioId, scheduledExecutions } = Route.useLoaderData();
+  const scheduledExecutionsQuery = useListScheduleExecutions({
+    scenarioId,
+    initialData: { scheduledExecutions },
+    refetchInterval: (query) => getScheduledExecutionsRefetchInterval(query.state.data?.scheduledExecutions ?? []),
+  });
+  const currentScheduledExecutions = scheduledExecutionsQuery.data?.scheduledExecutions ?? scheduledExecutions;
 
   return (
     <Page.Main>
@@ -61,10 +71,10 @@ function ScheduledExecutions() {
       <Page.Content width="form">
         <Typo variant="title1" className="text-grey-primary text-m">
           {t('scenarios:home.execution.batch.scheduled_execution', {
-            count: scheduledExecutions.length,
+            count: currentScheduledExecutions.length,
           })}
         </Typo>
-        <ScheduledExecutionsList scheduledExecutions={scheduledExecutions} />
+        <ScheduledExecutionsList scheduledExecutions={currentScheduledExecutions} />
       </Page.Content>
     </Page.Main>
   );

--- a/packages/app-builder/src/server-fns/decisions.ts
+++ b/packages/app-builder/src/server-fns/decisions.ts
@@ -12,7 +12,10 @@ export const getDecisionFn = createServerFn({ method: 'GET' })
 
 export const listScheduledExecutionsFn = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
-  .handler(async ({ context }) => {
-    const scheduledExecutions = await context.authInfo.decision.listScheduledExecutions();
+  .validator(z.object({ scenarioId: z.string().optional() }).optional())
+  .handler(async ({ context, data }) => {
+    const scheduledExecutions = await context.authInfo.decision.listScheduledExecutions({
+      scenarioId: data?.scenarioId,
+    });
     return { scheduledExecutions };
   });


### PR DESCRIPTION
## What changed

The scenario scheduled-executions page used to freeze on the SSR loader snapshot. While any row is `pending` or `processing`, the page now refetches every second through TanStack Query and stops once every row is terminal.

`ScheduledExecutionsList` stays presentational. The route seeds `useListScheduleExecutions` from loader `initialData` and owns the poll policy. In-progress status lives in a total map on `ScheduledExecution`, so a new status fails the build until someone decides whether it should keep polling.

## Why this shape

Matches the existing ObservabilityPage pattern. The decisions filter keeps calling `useListScheduleExecutions()` with no args on a separate cache key (`scenarioId` is optional on the server fn and query key).

## How to check

1. Open a scenario that has a batch run in `pending` or `processing`.
2. On `/detection/scenarios/:id/scheduled-executions`, confirm counts and status update about once a second.
3. When the run finishes, confirm network polling stops.
4. Confirm the decisions scheduled-execution filter still loads without continuous polling.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled execution lists now refresh automatically while executions are pending or processing.
  * Execution lists can be filtered by scenario.
  * Scheduled execution counts and statuses update in near real time.

* **Bug Fixes**
  * Improved status handling for in-progress and completed scheduled executions.

* **Tests**
  * Added coverage for execution status detection and automatic refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->