### PR TITLE
Add comments feature to MatchCard component

### DIFF
--- a/packages/app-builder/src/components/CaseManager/ContinuousScreening/MatchCard.tsx
+++ b/packages/app-builder/src/components/CaseManager/ContinuousScreening/MatchCard.tsx
@@ -1,3 +1,4 @@
+import { CommentLine } from '@app-builder/components/Screenings/MatchCard/CommentLine';
 import { MatchDetails } from '@app-builder/components/Screenings/MatchDetails';
 import { TopicTag } from '@app-builder/components/Screenings/TopicTag';
 import { Case } from '@app-builder/models/cases';
@@ -54,6 +55,9 @@ export function MatchCard({ caseDetail, screening, screeningMatch }: MatchCardPr
                     return <TopicTag key={topic} topic={topic} className="text-small" />;
                   })}
                 </div>
+                {screeningMatch.comments.map((comment) => {
+                  return <CommentLine key={comment.id} comment={comment} />;
+                })}
               </div>
             </div>
           </Collapsible.Trigger>

--- a/packages/app-builder/src/components/Screenings/MatchCard/CommentLine.tsx
+++ b/packages/app-builder/src/components/Screenings/MatchCard/CommentLine.tsx
@@ -1,10 +1,10 @@
-import { ScreeningMatch } from '@app-builder/models/screening';
+import type { ScreeningMatchComment } from '@app-builder/models/screening';
 import { useOrganizationUsers } from '@app-builder/services/organization/organization-users';
 import { getFullName } from '@app-builder/services/user';
 import { useFormatDateTime } from '@app-builder/utils/format';
 import { Avatar } from 'ui-design-system';
 
-export const CommentLine = ({ comment }: { comment: ScreeningMatch['comments'][number] }) => {
+export const CommentLine = ({ comment }: { comment: ScreeningMatchComment }) => {
   const formatDateTime = useFormatDateTime();
   const { getOrgUserById } = useOrganizationUsers();
   const user = getOrgUserById(comment.authorId);

--- a/packages/app-builder/src/models/continuous-screening.ts
+++ b/packages/app-builder/src/models/continuous-screening.ts
@@ -23,11 +23,13 @@ import {
 } from 'marble-api';
 import * as R from 'remeda';
 import {
+  adaptScreeningMatchComments,
   adaptScreeningMatchPayload,
   isKnownEntitySchema,
   matchEntitySchemas,
-  OpenSanctionEntitySchema,
-  ScreeningMatchPayload,
+  type OpenSanctionEntitySchema,
+  type ScreeningMatchComment,
+  type ScreeningMatchPayload,
 } from './screening';
 import { createScreeningFilters, getDatasetFromFilters } from './screening-config';
 
@@ -358,6 +360,7 @@ export type ContinuousScreeningMatchBase = {
   continuousScreeningId: string;
   status: ContinuousScreeningMatchBaseDto['status'];
   payload: ContinuousScreeningMatchPayload;
+  comments: ScreeningMatchComment[];
 };
 
 export type ContinuousScreeningMatchScreeningEntity = ContinuousScreeningMatchBase & {
@@ -417,20 +420,27 @@ export function adaptContinuousScreeningRequest(dto: ContinuousScreeningRequestD
   };
 }
 
-export function adaptContinuousScreeningMatchMarble(
-  dto: ContinuousScreeningMatchMarbleDto,
-): ContinuousScreeningMatchMarble {
+function adaptContinuousScreeningMatchBase(dto: ContinuousScreeningMatchBaseDto): ContinuousScreeningMatchBase {
   return {
     id: dto.id,
     continuousScreeningId: dto.continuous_screening_id,
     status: dto.status,
-    objectType: dto.object_type,
-    objectId: dto.object_id,
     payload: {
       ...adaptScreeningMatchPayload(dto.payload),
       target: dto.payload.target,
       datasets: dto.payload.datasets,
     },
+    comments: adaptScreeningMatchComments(dto.comments),
+  };
+}
+
+export function adaptContinuousScreeningMatchMarble(
+  dto: ContinuousScreeningMatchMarbleDto,
+): ContinuousScreeningMatchMarble {
+  return {
+    ...adaptContinuousScreeningMatchBase(dto),
+    objectType: dto.object_type,
+    objectId: dto.object_id,
   };
 }
 
@@ -438,15 +448,8 @@ export function adaptContinuousScreeningMatchScreeningEntity(
   dto: ContinuousScreeningMatchScreeningEntityDto,
 ): ContinuousScreeningMatchScreeningEntity {
   return {
-    id: dto.id,
-    continuousScreeningId: dto.continuous_screening_id,
-    status: dto.status,
+    ...adaptContinuousScreeningMatchBase(dto),
     opensanctionEntityId: dto.opensanction_entity_id,
-    payload: {
-      ...adaptScreeningMatchPayload(dto.payload),
-      target: dto.payload.target,
-      datasets: dto.payload.datasets,
-    },
   };
 }
 

--- a/packages/app-builder/src/models/screening.ts
+++ b/packages/app-builder/src/models/screening.ts
@@ -196,6 +196,13 @@ export function adaptScreeningMatchPayload(dto: ScreeningMatchPayloadDto): Scree
   };
 }
 
+export type ScreeningMatchComment = {
+  id: string;
+  authorId: string;
+  comment: string;
+  createdAt: string;
+};
+
 export type ScreeningMatch = {
   id: string;
   entityId: string;
@@ -204,13 +211,17 @@ export type ScreeningMatch = {
   enriched: boolean;
   // datasets: unknown[];
   payload: ScreeningMatchPayload;
-  comments: {
-    id: string;
-    authorId: string;
-    comment: string;
-    createdAt: string;
-  }[];
+  comments: ScreeningMatchComment[];
 };
+
+export function adaptScreeningMatchComments(comments: ScreeningMatchDto['comments']): ScreeningMatchComment[] {
+  return R.map(comments, (comment) => ({
+    id: comment.id,
+    authorId: comment.author_id,
+    comment: comment.comment,
+    createdAt: comment.created_at,
+  }));
+}
 
 export function adaptScreeningMatch(dto: ScreeningMatchDto): ScreeningMatch {
   return {
@@ -220,12 +231,7 @@ export function adaptScreeningMatch(dto: ScreeningMatchDto): ScreeningMatch {
     status: dto.status,
     enriched: dto.enriched,
     payload: adaptScreeningMatchPayload(dto.payload),
-    comments: R.map(dto.comments, (comment) => ({
-      id: comment.id,
-      authorId: comment.author_id,
-      comment: comment.comment,
-      createdAt: comment.created_at,
-    })),
+    comments: adaptScreeningMatchComments(dto.comments),
   };
 }
 

--- a/packages/marble-api/openapis/marblecore-api/continuous-screenings.yml
+++ b/packages/marble-api/openapis/marblecore-api/continuous-screenings.yml
@@ -892,6 +892,7 @@ components:
         - continuous_screening_id
         - status
         - payload
+        - comments
         - created_at
         - updated_at
       properties:
@@ -913,6 +914,27 @@ components:
         reviewed_by:
           type: string
           format: uuid
+        comments:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - author_id
+              - comment
+              - created_at
+            properties:
+              id:
+                type: string
+                format: uuid
+              author_id:
+                type: string
+                format: uuid
+              comment:
+                type: string
+              created_at:
+                type: string
+                format: date-time
         created_at:
           type: string
           format: date-time

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -263,6 +263,12 @@ export type ContinuousScreeningMatchBaseDto = {
     status: "pending" | "confirmed_hit" | "no_hit" | "skipped";
     payload: ContinuousScreeningMatchPayloadDto;
     reviewed_by?: string;
+    comments: {
+        id: string;
+        author_id: string;
+        comment: string;
+        created_at: string;
+    }[];
     created_at: string;
     updated_at: string;
 };


### PR DESCRIPTION
update openapi with the comments already sent by the `/cases/:caseid` route

<img width="2128" height="398" alt="Screenshot 2026-08-27 at 16 17 46" src="https://github.com/user-attachments/assets/1f9ef2a8-f17d-41c7-9a35-3786f60ba4cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Continuous screening match cards now display associated comments beneath their topic tags.
  - Match comments include the author, comment text, identifier, and creation date.
  - Screening match data now consistently includes comments across supported screening results.

- **Documentation**
  - Updated screening data definitions to describe the comments included with continuous screening matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->