### PR TITLE
fix score value

### DIFF
--- a/packages/app-builder/src/components/CaseManager/ContinuousScreening/MatchCard.tsx
+++ b/packages/app-builder/src/components/CaseManager/ContinuousScreening/MatchCard.tsx
@@ -47,7 +47,7 @@ export function MatchCard({ caseDetail, screening, screeningMatch }: MatchCardPr
                   </span>
                   <div className="bg-grey-border rounded-full size-1.5" />
                   <Tag color="grey" className="shrink-0">
-                    {t('screenings:match.score', { score: screeningMatch.payload.score * 100 })}
+                    {t('screenings:match.score', { score: Math.round(screeningMatch.payload.score * 100) })}
                   </Tag>
                 </div>
                 <div className="flex flex-row flex-wrap gap-xs">


### PR DESCRIPTION
## before

<img width="513" height="82" alt="Screenshot 2026-08-31 at 13 22 57" src="https://github.com/user-attachments/assets/6b12d76f-38ce-481a-bccc-c27a3753f45a" />

## after

<img width="397" height="87" alt="Screenshot 2026-08-31 at 13 23 16" src="https://github.com/user-attachments/assets/f3772274-4c91-4f6c-b7f5-a59731ffab60" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Match scores in continuous screening cards are now rounded to the nearest whole number for clearer, more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->