### PR TITLE
remove unsupported --no-traffic flag in gcloud deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -102,5 +102,4 @@ jobs:
             --quiet \
             --region="europe-west1" \
             --image="$IMAGE" \
-            --service-account="${{ env.SERVICE_ACCOUNT }}" \
-            --no-traffic
+            --service-account="${{ env.SERVICE_ACCOUNT }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - New Cloud Run deployments now receive live traffic immediately, ensuring the latest release is available as soon as deployment completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->