### PR TITLE
Scoring dry-run/backtest

### DIFF
--- a/packages/marble-api/openapis/marblecore-api.yaml
+++ b/packages/marble-api/openapis/marblecore-api.yaml
@@ -487,6 +487,8 @@ paths:
     $ref: ./marblecore-api/scoring.yml#/~1scoring~1rulesets~1{recordType}~1prepare
   /scoring/rulesets/{recordType}/commit:
     $ref: ./marblecore-api/scoring.yml#/~1scoring~1rulesets~1{recordType}~1commit
+  /scoring/rulesets/{recordType}/dry-run:
+    $ref: ./marblecore-api/scoring.yml#/~1scoring~1rulesets~1{recordType}~1dry-run
   /scoring/risk-levels/{recordType}/{recordId}:
     $ref: ./marblecore-api/scoring.yml#/~1scoring~1risk-levels~1{recordType}~1{recordId}
   /scoring/risk-levels/{recordType}/{recordId}/history:

--- a/packages/marble-api/openapis/marblecore-api/_schemas.yml
+++ b/packages/marble-api/openapis/marblecore-api/_schemas.yml
@@ -649,3 +649,5 @@ UpdateScoringRuleset:
   $ref: scoring.yml#/components/schemas/UpdateScoringRuleset
 ScoringScore:
   $ref: scoring.yml#/components/schemas/ScoringScore
+ScoringDryRun:
+  $ref: scoring.yml#/components/schemas/ScoringDryRun

--- a/packages/marble-api/openapis/marblecore-api/scoring.yml
+++ b/packages/marble-api/openapis/marblecore-api/scoring.yml
@@ -209,6 +209,57 @@
       '401':
         $ref: 'components.yml#/responses/401'
 
+/scoring/rulesets/{recordType}/dry-run:
+  post:
+    tags: [Scoring]
+    summary: Start a backtest of a ruleset draft
+    operationId: startScoringDryRun
+    parameters:
+      - name: recordType
+        description: Data model type of the scoring ruleset
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      '202':
+        description: Dry run was successfully started in the background
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoringDryRun'
+      '404':
+        $ref: 'components.yml#/responses/404'
+      '422':
+        description: Ruleset cannot be committed. Usually, it means it it not prepared.
+      '401':
+        $ref: 'components.yml#/responses/401'
+
+  get:
+    tags: [Scoring]
+    summary: Start a backtest of a ruleset draft
+    operationId: getScoringDryRun
+    parameters:
+      - name: recordType
+        description: Data model type of the scoring ruleset
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Current state of the latest dry-run
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoringDryRun'
+      '404':
+        $ref: 'components.yml#/responses/404'
+      '422':
+        description: Ruleset cannot be committed. Usually, it means it it not prepared.
+      '401':
+        $ref: 'components.yml#/responses/401'
+
 /scoring/risk-levels/{recordType}/{recordId}:
   get:
     tags: [Scoring]
@@ -539,3 +590,41 @@ components:
         stale_at:
            type: string
            format: date-time
+    ScoringDryRun:
+      type: object
+      required:
+        - id
+        - ruleset_id
+        - status
+        - record_count
+        - progress
+        - distribution
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        ruleset_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [pending, completed]
+        record_count:
+          type: integer
+        progress:
+          type: number
+          format: double
+        distribution:
+          type: array
+          items:
+            type: object
+            required: [risk_level, count]
+            properties:
+              risk_level:
+                type: integer
+              count:
+                type: integer
+        created_at:
+          type: string
+          format: date-time

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -2155,6 +2155,18 @@ export type UpdateScoringRuleset = {
         ast: NodeDto;
     }[];
 };
+export type ScoringDryRun = {
+    id: string;
+    ruleset_id: string;
+    status: "pending" | "completed";
+    record_count: number;
+    progress: number;
+    distribution: {
+        risk_level: number;
+        count: number;
+    }[];
+    created_at: string;
+};
 export type ScoringScore = {
     id: string;
     risk_level: number;
@@ -7203,6 +7215,45 @@ export function commitScoringRuleset(recordType: string, opts?: Oazapfts.Request
     }>(`/scoring/rulesets/${encodeURIComponent(recordType)}/commit`, {
         ...opts,
         method: "POST"
+    }));
+}
+/**
+ * Start a backtest of a ruleset draft
+ */
+export function startScoringDryRun(recordType: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 202;
+        data: ScoringDryRun;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    } | {
+        status: 422;
+    }>(`/scoring/rulesets/${encodeURIComponent(recordType)}/dry-run`, {
+        ...opts,
+        method: "POST"
+    }));
+}
+/**
+ * Start a backtest of a ruleset draft
+ */
+export function getScoringDryRun(recordType: string, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: ScoringDryRun;
+    } | {
+        status: 401;
+        data: string;
+    } | {
+        status: 404;
+        data: string;
+    } | {
+        status: 422;
+    }>(`/scoring/rulesets/${encodeURIComponent(recordType)}/dry-run`, {
+        ...opts
     }));
 }
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API support to start a dry run for a scoring ruleset draft.
  - Added API support to retrieve the latest dry-run status.
  - Added responses describing dry-run state, including processing and completion details.
  - Documented relevant authentication, validation, and not-found responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->