### PR TITLE
Remove --no-traffic from deployment stage.

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -104,6 +104,4 @@ jobs:
           gcloud run deploy ${{ inputs.gcloud-service }} \
             --quiet \
             --region="europe-west1" \
-            --image="$IMAGE" \
-            --service-account="${{ env.SERVICE_ACCOUNT }}" \
-            --no-traffic
+            --image="$IMAGE"


### PR DESCRIPTION
Restore proper deployment of services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * New releases now receive live traffic immediately after deployment.
  * Deployments no longer use a fixed service account or remain inactive by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->