### PR TITLE
Williamschlegel/mar 2241 dry run batch test on user scoring

### DIFF
--- a/.claude/hooks/stop-check.sh
+++ b/.claude/hooks/stop-check.sh
@@ -33,10 +33,10 @@ if [ -z "$ALL_MODIFIED" ]; then
   exit 0
 fi
 
-# Run Biome format on all modified files (silently fix formatting)
+# Format and apply assist (including named-import sort) so the result matches `biome check`.
 for file in $ALL_MODIFIED; do
   if [ -f "$file" ]; then
-    "$PROJECT_DIR"/node_modules/.bin/biome format --write "$file" 2>/dev/null || true
+    "$PROJECT_DIR"/node_modules/.bin/biome check --write --linter-enabled=false "$file" 2>/dev/null || true
   fi
 done
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,17 @@
   "i18n-ally-next.namespace": true,
   "i18n-ally-next.pathMatcher": "{locale}/{namespaces}.json",
   "editor.codeActionsOnSave": {
+    "source.organizeImports": "never",
     "source.fixAll.biome": "explicit",
     "source.organizeImports.biome": "explicit",
     "source.removeUnusedImports": "explicit"
+  },
+  "js/ts.preferences.organizeImports": {
+    "caseSensitivity": "caseSensitive",
+    "caseFirst": "upper",
+    "unicodeCollation": "unicode",
+    "numericCollation": true,
+    "typeOrder": "inline"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "biomejs.biome",

--- a/biome.json
+++ b/biome.json
@@ -120,7 +120,17 @@
   },
   "assist": {
     "enabled": true,
-    "actions": { "source": { "organizeImports": "on", "useSortedKeys": "off" } }
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "identifierOrder": "natural"
+          }
+        },
+        "useSortedKeys": "off"
+      }
+    }
   },
   "overrides": [
     {

--- a/packages/app-builder/src/components/CaseManager/CaseEvents.tsx
+++ b/packages/app-builder/src/components/CaseManager/CaseEvents.tsx
@@ -125,7 +125,8 @@ export function CaseEvents({ events, includeEventTypes, excludeEventTypes, dueAt
                 <span className="truncate">
                   {step.kind === 'event'
                     ? t(`cases:case_detail.history.event_type.${step.eventType}`)
-                    : t('cases:manager.timeline.due')}{' '}
+                    : t('cases:manager.timeline.due')}
+                  &nbsp;
                   {relativeLabel}
                 </span>
               </div>

--- a/packages/app-builder/src/components/Cases/Analytics/AlertMetricsChart.tsx
+++ b/packages/app-builder/src/components/Cases/Analytics/AlertMetricsChart.tsx
@@ -134,7 +134,8 @@ export function AlertMetricsChart({ alertCountByPeriod, falsePositiveRateByPerio
                       </span>
                     </div>
                     <span className="text-xs text-grey-secondary">
-                      {formatChartNumber(data.fpCount, language)} / {formatChartNumber(data.closedCount, language)}{' '}
+                      {formatChartNumber(data.fpCount, language)}&nbsp;/&nbsp;
+                      {formatChartNumber(data.closedCount, language)}&nbsp;
                       {t('cases:analytics.alerts.closed')}
                     </span>
                   </div>

--- a/packages/app-builder/src/components/ClientDetail/SearchForm.tsx
+++ b/packages/app-builder/src/components/ClientDetail/SearchForm.tsx
@@ -56,7 +56,8 @@ export const SearchForm = ({ table }: SearchFormProps) => {
         </span>
         {!table.ready ? (
           <span className="text-grey-text text-small flex items-center gap-xs">
-            <Icon icon="warning" className="size-4 text-yellow-primary" />{' '}
+            <Icon icon="warning" className="size-4 text-yellow-primary" />
+            &nbsp;
             {t('client360:client_detail.search_form.table_not_ready')}
           </span>
         ) : null}

--- a/packages/app-builder/src/components/ContinuousScreening/observability/DatasetUpdate.tsx
+++ b/packages/app-builder/src/components/ContinuousScreening/observability/DatasetUpdate.tsx
@@ -154,7 +154,7 @@ function DatasetUpdateCompletionDetails({
       ))}
       {status === 'processing' ? (
         <span>
-          {formatNumber(completion.itemsProcessed, { language: locale })} /{' '}
+          {formatNumber(completion.itemsProcessed, { language: locale })}&nbsp;/&nbsp;
           {formatNumber(completion.itemsTotal, { language: locale })}
         </span>
       ) : null}

--- a/packages/app-builder/src/components/Data/SemanticTables/Shared/DataPageHeader.tsx
+++ b/packages/app-builder/src/components/Data/SemanticTables/Shared/DataPageHeader.tsx
@@ -32,7 +32,7 @@ export function DataPageHeader({ handleOpenCreateDrawer }: { handleOpenCreateDra
             {t('data:create_table.title')}
           </Button>
         ) : null}
-      </div>{' '}
+      </div>
     </div>
   );
 }

--- a/packages/app-builder/src/components/DataModelExplorer/DataTableRender.tsx
+++ b/packages/app-builder/src/components/DataModelExplorer/DataTableRender.tsx
@@ -532,7 +532,7 @@ function DataTableActionsButton({
                     <MenuCommand.Item forceMount onSelect={() => setAnnotationMenuOpen(true)}>
                       <div className="flex flex-col">
                         <div className="flex items-center gap-sm">
-                          {t('cases:annotations.popover.annotate.title')}{' '}
+                          {t('cases:annotations.popover.annotate.title')}&nbsp;
                           <span className="text-grey-disabled text-xs">{annotationsCount}</span>
                         </div>
                         <span className="text-grey-secondary">{t('cases:annotations.popover.annotate.subtitle')}</span>

--- a/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/RulesPage.tsx
@@ -293,7 +293,7 @@ function ScenarioRuleRow({ rule, scenario, editorMode, language, org, onEditRequ
                 ) : null}
                 {rule.counterPartyId && isDataAccessorAstNode(rule.counterPartyId) ? (
                   <li className="list-item">
-                    {t('scenarios:rules.screening_view.counterparty_id')}{' '}
+                    {t('scenarios:rules.screening_view.counterparty_id')}&nbsp;
                     <Tag color="grey">{getDataAccessorDisplayName(rule.counterPartyId)}</Tag>
                   </li>
                 ) : null}
@@ -459,8 +459,9 @@ const ScreeningRuleQueryView = ({ entityType, query, preprocessing }: ScreeningR
                 <NameQueryFieldTag label={k} preprocessing={preprocessing} />
               ) : (
                 <Tag color="grey">{k}</Tag>
-              )}{' '}
-              {t('scenarios:rules.screening_view.matching')}{' '}
+              )}
+              &nbsp;
+              {t('scenarios:rules.screening_view.matching')}&nbsp;
               <span className="inline-flex gap-xs">
                 {q.children.map((node) => (
                   <DataAccessorAstNodeTag key={node.id} node={node} />

--- a/packages/app-builder/src/components/Screenings/FreeformSearch/EntityTypePopover.tsx
+++ b/packages/app-builder/src/components/Screenings/FreeformSearch/EntityTypePopover.tsx
@@ -84,7 +84,7 @@ export const EntityTypePopover = ({ disabled }: EntityTypePopoverProps) => {
                   <div className="flex flex-1 flex-col">
                     <span className="font-medium">{t(`screenings:refine_modal.schema.${schemaKey}`)}</span>
                     <span className="text-grey-placeholder text-xs">
-                      {t('screenings:refine_modal.search_by')}{' '}
+                      {t('screenings:refine_modal.search_by')}&nbsp;
                       {fieldForSchema.map((f) => t(`screenings:entity.property.${f}`)).join(', ')}
                     </span>
                   </div>

--- a/packages/app-builder/src/components/Screenings/RefineSearchModal.tsx
+++ b/packages/app-builder/src/components/Screenings/RefineSearchModal.tsx
@@ -244,7 +244,7 @@ export function EntitySelect({ name, value, onChange }: EntitySelectProps) {
                   <div className="flex flex-col">
                     <span>{t(`screenings:refine_modal.schema.${schemaKey}`)}</span>
                     <span className="text-grey-secondary text-xs">
-                      {t('screenings:refine_modal.search_by')}{' '}
+                      {t('screenings:refine_modal.search_by')}&nbsp;
                       {fieldForSchema.map((f) => t(`screenings:entity.property.${f}`)).join(', ')}
                     </span>
                   </div>

--- a/packages/app-builder/src/components/Screenings/ReviewMatchPopover.tsx
+++ b/packages/app-builder/src/components/Screenings/ReviewMatchPopover.tsx
@@ -114,7 +114,8 @@ export function ReviewMatchPopover({
                 return (
                   <div className="flex flex-col gap-sm">
                     <span className="flex items-center gap-sm">
-                      <Switch name={field.name} checked={field.state.value} onCheckedChange={field.handleChange} />{' '}
+                      <Switch name={field.name} checked={field.state.value} onCheckedChange={field.handleChange} />
+                      &nbsp;
                       {t('screenings:review_modal.whitelist_label')}
                     </span>
                     <div className="border-grey-border bg-grey-background-light flex flex-col gap-sm rounded-sm border p-sm">

--- a/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
+++ b/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
@@ -4,6 +4,7 @@ import {
   isMaxRiskLevelInRange,
   SCORING_LEVELS_COLORS,
   SCORING_LEVELS_LABEL_KEYS,
+  ScoringDryRun,
   type ScoringRulesetWithRules,
   type ScoringSettings,
   SECONDS_PER_UNIT,
@@ -11,8 +12,10 @@ import {
   secondsToDisplay,
 } from '@app-builder/models/scoring';
 import { useCommitScoringRulesetMutation } from '@app-builder/queries/scoring/commit-ruleset';
+import { useGetScoringDryRunQuery } from '@app-builder/queries/scoring/get-dry-run';
 import { useListScoringRulesetVersionsQuery } from '@app-builder/queries/scoring/list-ruleset-versions';
 import { usePrepareScoringRulesetMutation } from '@app-builder/queries/scoring/prepare-ruleset';
+import { useStartScoringDryRunMutation } from '@app-builder/queries/scoring/start-dry-run';
 import { useUpdateScoringRulesetMutation } from '@app-builder/queries/scoring/update-ruleset';
 import { type UpdateScoringRulesetPayload, updateScoringRulesetPayloadSchema } from '@app-builder/schemas/user-scoring';
 import { handleSubmit } from '@app-builder/utils/form';
@@ -22,14 +25,28 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Fragment, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
-import { Button, NumberInput, Panel, PanelSharpFactory, type SelectOption, SelectV2, Tooltip } from 'ui-design-system';
+import {
+  Button,
+  Card,
+  cn,
+  Modal,
+  NumberInput,
+  Panel,
+  PanelSharpFactory,
+  type SelectOption,
+  SelectV2,
+  Tooltip,
+} from 'ui-design-system';
 import { Icon } from 'ui-icons';
+import { pageLayoutGutter } from '../Page/page-layout';
+import { ScoringBatchTest } from './ScoringBatchTest';
 import { ScoringLevelThresholds } from './ScoringLevelThresholds';
 
 interface GeneralInfoCardProps {
   ruleset: ScoringRulesetWithRules;
   settings: ScoringSettings;
   preparationStatus: ScenarioPublicationStatus | null;
+  lastDryRun: ScoringDryRun | null;
 }
 
 function formatDuration(seconds: number, t: (key: string) => string): string | null {
@@ -38,8 +55,9 @@ function formatDuration(seconds: number, t: (key: string) => string): string | n
   return `${value} ${t(`common:duration_unit.${unit}`)}`;
 }
 
-export function GeneralInfoCard({ ruleset, settings, preparationStatus }: GeneralInfoCardProps) {
+export function GeneralInfoCard({ ruleset, settings, preparationStatus, lastDryRun }: GeneralInfoCardProps) {
   const { t } = useTranslation(['user-scoring', 'common']);
+  const [viewBatchTest, setViewBatchTest] = useState(false);
   const navigate = useAgnosticNavigation();
   const formatDateTime = useFormatDateTime();
   const prepareMutation = usePrepareScoringRulesetMutation();
@@ -52,91 +70,115 @@ export function GeneralInfoCard({ ruleset, settings, preparationStatus }: Genera
     label: v.status === 'committed' ? `V${v.version}` : 'draft',
   }));
   const [editPanelOpen, setEditPanelOpen] = useState(false);
+  const startDryRun = useStartScoringDryRunMutation();
+  const { data: newDryRun } = useGetScoringDryRunQuery(ruleset.recordType, {
+    enabled: viewBatchTest || lastDryRun != null,
+  });
 
   const handleVersionChange = (version: string) => {
     navigate(`/user-scoring/${ruleset.recordType}/${version}`);
   };
 
+  const onLaunchTests = () => {
+    setViewBatchTest(true);
+    startDryRun.mutate(ruleset.recordType, {
+      onError: () => {
+        toast.error(t('common:errors.unknown'));
+        if (lastDryRun == null) setViewBatchTest(false);
+      },
+    });
+  };
+
   return (
-    <div className="bg-surface-card border border-grey-border rounded-md p-md flex flex-col gap-md">
-      <div className="flex items-center justify-between gap-sm">
-        <div>
-          <span className="text-h3 font-semibold text-grey-primary">{t('user-scoring:ruleset.title')}</span>
+    <div className={cn('flex flex-col lg:flex-row w-full', pageLayoutGutter.gap)}>
+      <Card className="p-md flex flex-col gap-md flex-1">
+        <div className="flex items-center justify-between gap-sm">
+          <div>
+            <span className="text-h3 font-semibold text-grey-primary">{t('user-scoring:ruleset.title')}</span>
+          </div>
+          <div className="flex items-center gap-sm">
+            <SelectV2
+              options={versionOptions}
+              placeholder={t('user-scoring:ruleset.version_placeholder')}
+              value={ruleset.status === 'draft' ? 'draft' : ruleset.version.toString()}
+              onChange={handleVersionChange}
+              variant="tag"
+              menuClassName="min-w-30"
+            />
+            {ruleset.status === 'draft' && (
+              <BatchTest onLaunchTest={onLaunchTests} isLaunching={startDryRun.isPending} />
+            )}
+            {preparationStatus ? (
+              preparationStatus.status === 'required' ? (
+                <Button
+                  disabled={
+                    preparationStatus.serviceStatus === 'occupied' ||
+                    prepareMutation.isPending ||
+                    ruleset.rules.length === 0
+                  }
+                  onClick={() =>
+                    prepareMutation.mutate(ruleset.recordType, {
+                      onError: () => toast.error(t('common:errors.unknown')),
+                    })
+                  }
+                >
+                  {t('user-scoring:ruleset.prepare')}
+                </Button>
+              ) : (
+                <Button
+                  disabled={commitMutation.isPending || ruleset.rules.length === 0}
+                  onClick={() =>
+                    commitMutation.mutate(ruleset.recordType, {
+                      onError: () => toast.error(t('common:errors.unknown')),
+                    })
+                  }
+                >
+                  <Icon icon="commit" className="size-4" />
+                  {t('user-scoring:ruleset.commit')}
+                </Button>
+              )
+            ) : null}
+            <Button variant="secondary" mode="icon" onClick={() => setEditPanelOpen(true)}>
+              <Icon icon="edit" className="size-4" />
+            </Button>
+          </div>
         </div>
-        <div className="flex items-center gap-sm">
-          <SelectV2
-            options={versionOptions}
-            placeholder={t('user-scoring:ruleset.version_placeholder')}
-            value={ruleset.status === 'draft' ? 'draft' : ruleset.version.toString()}
-            onChange={handleVersionChange}
-            variant="tag"
-            menuClassName="min-w-30"
-          />
-          {preparationStatus ? (
-            preparationStatus.status === 'required' ? (
-              <Button
-                disabled={
-                  preparationStatus.serviceStatus === 'occupied' ||
-                  prepareMutation.isPending ||
-                  ruleset.rules.length === 0
-                }
-                onClick={() =>
-                  prepareMutation.mutate(ruleset.recordType, {
-                    onError: () => toast.error(t('common:errors.unknown')),
-                  })
-                }
-              >
-                {t('user-scoring:ruleset.prepare')}
-              </Button>
-            ) : (
-              <Button
-                disabled={commitMutation.isPending || ruleset.rules.length === 0}
-                onClick={() =>
-                  commitMutation.mutate(ruleset.recordType, {
-                    onError: () => toast.error(t('common:errors.unknown')),
-                  })
-                }
-              >
-                {t('user-scoring:ruleset.commit')}
-              </Button>
-            )
-          ) : null}
-          <Button variant="secondary" mode="icon" onClick={() => setEditPanelOpen(true)}>
-            <Icon icon="edit" className="size-4" />
-          </Button>
-        </div>
-      </div>
 
-      <div className="flex items-center gap-md text-s text-grey-secondary">
-        <span>
-          {t('user-scoring:ruleset.last_update')}{' '}
-          <span className="text-grey-primary">
-            {formatDateTime(ruleset.createdAt, { dateStyle: 'medium', timeStyle: 'short' })}
+        <div className="flex items-center gap-md text-s text-grey-secondary">
+          <span>
+            {t('user-scoring:ruleset.last_update')}&nbsp;
+            <span className="text-grey-primary">
+              {formatDateTime(ruleset.createdAt, { dateStyle: 'medium', timeStyle: 'short' })}
+            </span>
           </span>
-        </span>
-        {cooldownLabel ? (
-          <>
-            <span className="text-grey-border">|</span>
-            <span>
-              {t('user-scoring:ruleset.cooldown')} <span className="text-grey-primary">{cooldownLabel}</span>
-            </span>
-          </>
-        ) : null}
-        {scoringIntervalLabel ? (
-          <>
-            <span className="text-grey-border">|</span>
-            <span>
-              {t('user-scoring:ruleset.score_renew')} <span className="text-grey-primary">{scoringIntervalLabel}</span>
-            </span>
-          </>
-        ) : null}
-      </div>
+          {cooldownLabel ? (
+            <>
+              <span className="text-grey-border">|</span>
+              <span>
+                {t('user-scoring:ruleset.cooldown')} <span className="text-grey-primary">{cooldownLabel}</span>
+              </span>
+            </>
+          ) : null}
+          {scoringIntervalLabel ? (
+            <>
+              <span className="text-grey-border">|</span>
+              <span>
+                {t('user-scoring:ruleset.score_renew')}&nbsp;
+                <span className="text-grey-primary">{scoringIntervalLabel}</span>
+              </span>
+            </>
+          ) : null}
+        </div>
 
-      <RiskLevelBadges maxRiskLevel={settings.maxRiskLevel} thresholds={ruleset.thresholds} />
+        <RiskLevelBadges maxRiskLevel={settings.maxRiskLevel} thresholds={ruleset.thresholds} />
 
-      <Panel.Root open={editPanelOpen} onOpenChange={setEditPanelOpen}>
-        <EditGeneralSettingsPanel ruleset={ruleset} maxRiskLevel={settings.maxRiskLevel} />
-      </Panel.Root>
+        <Panel.Root open={editPanelOpen} onOpenChange={setEditPanelOpen}>
+          <EditGeneralSettingsPanel ruleset={ruleset} maxRiskLevel={settings.maxRiskLevel} />
+        </Panel.Root>
+      </Card>
+      {viewBatchTest || lastDryRun != null ? (
+        <ScoringBatchTest ruleset={ruleset} settings={settings} lastDryRun={newDryRun?.dryRun ?? lastDryRun} />
+      ) : null}
     </div>
   );
 }
@@ -307,5 +349,35 @@ function RiskLevelBadges({ maxRiskLevel, thresholds }: { maxRiskLevel: number; t
         })}
       </div>
     </div>
+  );
+}
+
+function BatchTest({ onLaunchTest, isLaunching }: { onLaunchTest: () => void; isLaunching: boolean }) {
+  const { t } = useTranslation(['user-scoring', 'common']);
+  return (
+    <Modal.Root>
+      <Modal.Trigger asChild>
+        <Button variant="primary" appearance="stroked">
+          {t('user-scoring:ruleset.batch_test_button')}
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Title>{t('user-scoring:ruleset.batch_test_title')}</Modal.Title>
+        <div className="flex flex-col gap-sm p-md">
+          <p>{t('user-scoring:ruleset.batch_test_description1')}</p>
+          <p>{t('user-scoring:ruleset.batch_test_description2')}</p>
+        </div>
+        <Modal.Footer>
+          <Modal.FooterButton variant="secondary" isCloseButton label={t('common:cancel')} />
+          <Modal.FooterButton
+            variant="primary"
+            onClick={onLaunchTest}
+            isCloseButton
+            isLoading={isLaunching}
+            label={t('user-scoring:ruleset.batch_test_run')}
+          />
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
   );
 }

--- a/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
+++ b/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
@@ -90,8 +90,8 @@ export function GeneralInfoCard({ ruleset, settings, preparationStatus, lastDryR
   };
 
   return (
-    <div className={cn('flex flex-col lg:flex-row w-full', pageLayoutGutter.gap)}>
-      <Card className="p-md flex flex-col gap-md flex-1">
+    <div className={cn('flex min-w-0 w-full flex-col lg:flex-row', pageLayoutGutter.gap)}>
+      <Card className="flex min-w-0 flex-1 flex-col gap-md p-md">
         <div className="flex items-center justify-between gap-sm">
           <div>
             <span className="text-h3 font-semibold text-grey-primary">{t('user-scoring:ruleset.title')}</span>

--- a/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
+++ b/packages/app-builder/src/components/UserScoring/GeneralInfoCard.tsx
@@ -4,7 +4,7 @@ import {
   isMaxRiskLevelInRange,
   SCORING_LEVELS_COLORS,
   SCORING_LEVELS_LABEL_KEYS,
-  ScoringDryRun,
+  type ScoringDryRun,
   type ScoringRulesetWithRules,
   type ScoringSettings,
   SECONDS_PER_UNIT,

--- a/packages/app-builder/src/components/UserScoring/ScoringBatchTest.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringBatchTest.tsx
@@ -1,0 +1,125 @@
+import {
+  SCORING_LEVELS_COLORS,
+  SCORING_LEVELS_LABEL_KEYS,
+  ScoringDryRun,
+  ScoringDryRunDistributionItem,
+  ScoringRulesetWithRules,
+  ScoringSettings,
+} from '@app-builder/models/scoring';
+import { formatNumber, useFormatDateTime } from '@app-builder/utils/format';
+import { ResponsivePie } from '@nivo/pie';
+import { useTranslation } from 'react-i18next';
+import { match } from 'ts-pattern';
+import { Card, Tag, Typo, useFormatLanguage } from 'ui-design-system';
+import { Spinner } from '../Spinner';
+
+interface ScoringBatchTestProps {
+  ruleset: ScoringRulesetWithRules;
+  settings: ScoringSettings;
+  lastDryRun: ScoringDryRun | null;
+}
+
+export function ScoringBatchTest({ ruleset, settings, lastDryRun }: ScoringBatchTestProps) {
+  const { t } = useTranslation(['user-scoring']);
+  const language = useFormatLanguage();
+  const formatDateTime = useFormatDateTime();
+
+  return (
+    <Card className="grid gap-sm">
+      <Typo variant="title2" className="flex items-center gap-sm p-md">
+        {t('user-scoring:batch_test.title', { name: ruleset.name })}
+        {match(lastDryRun)
+          .with({ status: 'pending' }, () => <Tag color="orange">{t('user-scoring:batch_test.pending')}</Tag>)
+          .with({ status: 'completed' }, () => <Tag color="purple">{t('user-scoring:batch_test.completed')}</Tag>)
+          .with({ status: 'running' }, () => <Tag color="green">{t('user-scoring:batch_test.running')}</Tag>)
+          .with({ status: 'cancelled' }, () => <Tag color="red">{t('user-scoring:batch_test.cancelled')}</Tag>)
+          .otherwise(() => (
+            <Spinner />
+          ))}
+      </Typo>
+      <div className="flex gap-sm justify-between">
+        <p className="text-grey-placeholder">
+          {t('user-scoring:ruleset.batch_test.progress', {
+            total: lastDryRun?.recordCount ?? 0,
+            progress: formatNumber(lastDryRun?.progress ?? 0, { language, style: 'percent' }),
+          })}
+        </p>
+        {lastDryRun?.createdAt ? <Tag color="grey">{formatDateTime(lastDryRun?.createdAt)}</Tag> : null}
+      </div>
+      <PieDistribution distribution={lastDryRun?.distribution ?? []} settings={settings} />
+    </Card>
+  );
+}
+
+function PieDistribution({
+  distribution,
+  settings,
+}: {
+  distribution: ScoringDryRunDistributionItem[];
+  settings: ScoringSettings;
+}) {
+  const { t } = useTranslation(['user-scoring', 'common']);
+  const language = useFormatLanguage();
+
+  if (!distribution.length) return <PieSkeletton />;
+  const maxRiskLevel = settings.maxRiskLevel as 3 | 4 | 5 | 6;
+  const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
+  const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
+
+  const total = distribution.reduce((sum, item) => sum + item.count, 0);
+  const pieData = distribution
+    .filter((item) => item.count > 0)
+    .map((item) => ({
+      id: item.riskLevel,
+      label: t(labelKeys[item.riskLevel] ?? item.riskLevel.toString()),
+      value: item.count,
+      color: colors[item.riskLevel] ?? '#ccc',
+    }));
+  return (
+    <div className="flex gap-sm">
+      <div className="flex flex-col gap-sm min-h-80">
+        {pieData.map((item) => (
+          <div key={item.id} className="flex items-center gap-xs">
+            <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
+            <span className="text-xs font-medium text-grey-secondary">{item.label}</span>
+          </div>
+        ))}
+      </div>
+      <ResponsivePie
+        data={pieData}
+        innerRadius={0.7}
+        padAngle={1}
+        colors={{ datum: 'data.color' }}
+        enableArcLabels={false}
+        tooltip={({ datum }) => (
+          <div className="flex items-center gap-xs bg-surface-card p-xs rounded-lg border border-grey-border shadow-sm text-s text-grey-primary whitespace-nowrap">
+            <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: datum.color }} />
+            {datum.label}: {datum.value} ({Math.round((datum.value / total) * 100)}%)
+          </div>
+        )}
+        margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+        arcLinkLabel={(datum) =>
+          formatNumber(datum.value / total, { language, style: 'percent', maximumFractionDigits: 1 })
+        }
+        activeOuterRadiusOffset={10}
+        arcLinkLabelsStraightLength={0}
+        arcLinkLabelsThickness={0}
+      />
+    </div>
+  );
+}
+
+function PieSkeletton() {
+  return (
+    <div className="flex gap-sm animate-pulse">
+      <div className="flex flex-col gap-sm min-h-80">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} className="w-8 h-4 bg-grey-placeholder rounded-xs "></div>
+        ))}
+      </div>
+      <svg className="size-80 text-grey-placeholder mx-auto" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="40" stroke="currentColor" strokeWidth="14" fill="none" />
+      </svg>
+    </div>
+  );
+}

--- a/packages/app-builder/src/components/UserScoring/ScoringBatchTest.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringBatchTest.tsx
@@ -26,8 +26,8 @@ export function ScoringBatchTest({ ruleset, settings, lastDryRun }: ScoringBatch
   const formatDateTime = useFormatDateTime();
 
   return (
-    <Card className="grid gap-sm">
-      <Typo variant="title2" className="flex items-center gap-sm p-md">
+    <Card className="grid min-w-0 flex-1 gap-sm lg:max-w-md">
+      <Typo variant="title2" className="flex min-w-0 items-center gap-sm p-md">
         {t('user-scoring:batch_test.title', { name: ruleset.name })}
         {match(lastDryRun)
           .with({ status: 'pending' }, () => <Tag color="orange">{t('user-scoring:batch_test.pending')}</Tag>)
@@ -38,8 +38,8 @@ export function ScoringBatchTest({ ruleset, settings, lastDryRun }: ScoringBatch
             <Spinner />
           ))}
       </Typo>
-      <div className="flex gap-sm justify-between">
-        <p className="text-grey-placeholder">
+      <div className="flex min-w-0 gap-sm justify-between">
+        <p className="min-w-0 text-grey-placeholder">
           {t('user-scoring:ruleset.batch_test.progress', {
             total: lastDryRun?.recordCount ?? 0,
             progress: formatNumber(lastDryRun?.progress ?? 0, { language, style: 'percent' }),
@@ -79,8 +79,8 @@ function PieDistribution({
       color: colors[item.riskLevel] ?? '#ccc',
     }));
   return (
-    <div className="flex gap-sm">
-      <div className="flex flex-col gap-sm min-h-80">
+    <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-sm">
+      <div className="flex flex-col gap-sm">
         {pieData.map((item) => (
           <div key={item.id} className="flex items-center gap-xs">
             <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
@@ -88,42 +88,46 @@ function PieDistribution({
           </div>
         ))}
       </div>
-      <ResponsivePie
-        data={pieData}
-        innerRadius={0.7}
-        padAngle={1}
-        colors={{ datum: 'data.color' }}
-        enableArcLabels={false}
-        tooltip={({ datum }) => (
-          <div className="flex items-center gap-xs bg-surface-card p-xs rounded-lg border border-grey-border shadow-sm text-s text-grey-primary whitespace-nowrap">
-            <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: datum.color }} />
-            {datum.label}: {datum.value} ({Math.round((datum.value / total) * 100)}%)
-          </div>
-        )}
-        margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
-        arcLinkLabel={(datum) =>
-          formatNumber(datum.value / total, { language, style: 'percent', maximumFractionDigits: 1 })
-        }
-        activeOuterRadiusOffset={10}
-        arcLinkLabelsStraightLength={0}
-        arcLinkLabelsThickness={0}
-        arcLinkLabelsSkipAngle={8}
-      />
+      <div className="relative h-80 min-w-0 overflow-hidden">
+        <ResponsivePie
+          data={pieData}
+          innerRadius={0.7}
+          padAngle={1}
+          colors={{ datum: 'data.color' }}
+          enableArcLabels={false}
+          tooltip={({ datum }) => (
+            <div className="flex items-center gap-xs bg-surface-card p-xs rounded-lg border border-grey-border shadow-sm text-s text-grey-primary whitespace-nowrap">
+              <span className="size-3 rounded-full shrink-0" style={{ backgroundColor: datum.color }} />
+              {datum.label}: {datum.value} ({Math.round((datum.value / total) * 100)}%)
+            </div>
+          )}
+          margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+          arcLinkLabel={(datum) =>
+            formatNumber(datum.value / total, { language, style: 'percent', maximumFractionDigits: 1 })
+          }
+          activeOuterRadiusOffset={10}
+          arcLinkLabelsStraightLength={0}
+          arcLinkLabelsThickness={0}
+          arcLinkLabelsSkipAngle={8}
+        />
+      </div>
     </div>
   );
 }
 
 function PieSkeletton() {
   return (
-    <div className="flex gap-sm animate-pulse">
-      <div className="flex flex-col gap-sm min-h-80">
+    <div className="grid min-w-0 animate-pulse grid-cols-[auto_minmax(0,1fr)] gap-sm">
+      <div className="flex flex-col gap-sm">
         {Array.from({ length: 5 }).map((_, index) => (
-          <div key={index} className="w-8 h-4 bg-grey-placeholder rounded-xs "></div>
+          <div key={index} className="h-4 w-8 rounded-xs bg-grey-placeholder"></div>
         ))}
       </div>
-      <svg className="size-80 text-grey-placeholder mx-auto" viewBox="0 0 100 100">
-        <circle cx="50" cy="50" r="40" stroke="currentColor" strokeWidth="14" fill="none" />
-      </svg>
+      <div className="flex h-80 min-w-0 items-center justify-center overflow-hidden">
+        <svg className="size-full max-h-80 max-w-80 text-grey-placeholder" viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="40" stroke="currentColor" strokeWidth="14" fill="none" />
+        </svg>
+      </div>
     </div>
   );
 }

--- a/packages/app-builder/src/components/UserScoring/ScoringBatchTest.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringBatchTest.tsx
@@ -1,10 +1,11 @@
 import {
+  isMaxRiskLevelInRange,
   SCORING_LEVELS_COLORS,
   SCORING_LEVELS_LABEL_KEYS,
-  ScoringDryRun,
-  ScoringDryRunDistributionItem,
-  ScoringRulesetWithRules,
-  ScoringSettings,
+  type ScoringDryRun,
+  type ScoringDryRunDistributionItem,
+  type ScoringRulesetWithRules,
+  type ScoringSettings,
 } from '@app-builder/models/scoring';
 import { formatNumber, useFormatDateTime } from '@app-builder/utils/format';
 import { ResponsivePie } from '@nivo/pie';
@@ -62,7 +63,9 @@ function PieDistribution({
   const language = useFormatLanguage();
 
   if (!distribution.length) return <PieSkeletton />;
-  const maxRiskLevel = settings.maxRiskLevel as 3 | 4 | 5 | 6;
+  const maxRiskLevel = settings.maxRiskLevel;
+  if (!isMaxRiskLevelInRange(maxRiskLevel)) return null;
+
   const colors = SCORING_LEVELS_COLORS[maxRiskLevel];
   const labelKeys = SCORING_LEVELS_LABEL_KEYS[maxRiskLevel];
 
@@ -104,6 +107,7 @@ function PieDistribution({
         activeOuterRadiusOffset={10}
         arcLinkLabelsStraightLength={0}
         arcLinkLabelsThickness={0}
+        arcLinkLabelsSkipAngle={8}
       />
     </div>
   );

--- a/packages/app-builder/src/components/UserScoring/ScoringRulesetPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringRulesetPage.tsx
@@ -1,6 +1,6 @@
 import { type CustomList } from '@app-builder/models/custom-list';
 import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
-import { ScoringDryRun, type ScoringRulesetWithRules, type ScoringSettings } from '@app-builder/models/scoring';
+import type { ScoringDryRun, ScoringRulesetWithRules, ScoringSettings } from '@app-builder/models/scoring';
 import { cn } from 'ui-design-system';
 import { pageLayoutGutter } from '../Page/page-layout';
 import { GeneralInfoCard } from './GeneralInfoCard';

--- a/packages/app-builder/src/components/UserScoring/ScoringRulesetPage.tsx
+++ b/packages/app-builder/src/components/UserScoring/ScoringRulesetPage.tsx
@@ -1,6 +1,8 @@
 import { type CustomList } from '@app-builder/models/custom-list';
 import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
-import { type ScoringRulesetWithRules, type ScoringSettings } from '@app-builder/models/scoring';
+import { ScoringDryRun, type ScoringRulesetWithRules, type ScoringSettings } from '@app-builder/models/scoring';
+import { cn } from 'ui-design-system';
+import { pageLayoutGutter } from '../Page/page-layout';
 import { GeneralInfoCard } from './GeneralInfoCard';
 import { RulesTable } from './RulesTable';
 
@@ -10,6 +12,7 @@ interface ScoringRulesetPageProps {
   customLists: CustomList[];
   preparationStatus: ScenarioPublicationStatus | null;
   hasValidLicense?: boolean;
+  lastDryRun: ScoringDryRun | null;
 }
 
 export function ScoringRulesetPage({
@@ -18,10 +21,16 @@ export function ScoringRulesetPage({
   customLists,
   preparationStatus,
   hasValidLicense,
+  lastDryRun,
 }: ScoringRulesetPageProps) {
   return (
-    <div className="flex flex-col gap-md">
-      <GeneralInfoCard ruleset={ruleset} settings={settings} preparationStatus={preparationStatus} />
+    <div className={cn('flex flex-col', pageLayoutGutter.gap)}>
+      <GeneralInfoCard
+        ruleset={ruleset}
+        settings={settings}
+        preparationStatus={preparationStatus}
+        lastDryRun={lastDryRun}
+      />
       <RulesTable
         ruleset={ruleset}
         maxRiskLevel={settings.maxRiskLevel}

--- a/packages/app-builder/src/locales/ar/user-scoring.json
+++ b/packages/app-builder/src/locales/ar/user-scoring.json
@@ -1,11 +1,14 @@
 {
+  "batch_test.cancelled": "ملغى",
+  "batch_test.completed": "مكتمل",
+  "batch_test.pending": "قيد الانتظار",
+  "batch_test.running": "قيد التنفيذ",
+  "batch_test.title": "[اختبار] إعادة تقسيم المخاطر لـ : {{name}}",
   "level.high": "مرتفع",
-
   "level.low": "منخفض",
   "level.medium": "متوسط",
   "level.very_high": "مرتفع جداً",
   "overview.configure_score": "تكوين النقاط",
-
   "overview.no_ruleset": "لا يوجد لديك أي مجموعة قواعد مكوّنة بعد. اختر كيانًا لإنشاء مجموعة قواعد للبدء.",
   "overview.ruleset_card.no_distribution": "لا يوجد توزيع بعد",
   "overview.ruleset_card.title": "توزيع المخاطر لـ: {{name}}",
@@ -14,7 +17,6 @@
   "risk_type.geo_risks": "المخاطر الجغرافية",
   "risk_type.service_provided": "الخدمة المقدمة",
   "risk_type.transaction_execution": "تنفيذ المعاملات",
-
   "rule_edit.cancel": "إلغاء",
   "rule_edit.model_type.aggregate": "إجمالي",
   "rule_edit.model_type.entity_tags": "وسوم الكيان",
@@ -26,11 +28,16 @@
   "rule_edit.risk_type_placeholder": "نوع المخاطر *",
   "rule_edit.save": "حفظ التغييرات",
   "ruleset.add_rule": "إضافة قاعدة",
+  "ruleset.batch_test_button": "إجراء اختبار باللوت",
+  "ruleset.batch_test_description1": "يمكنك اختبار صلاحية النقاط عن طريق اختبارها على لوحة من المستخدمين المختارة عشوائيًا.",
+  "ruleset.batch_test_description2": "سيتم إجراء الاختبار تلقائيًا في الخلفية، وسيتم عرض الإحصائيات الأولى هنا عندما تكون جاهزة للعرض.",
+  "ruleset.batch_test_run": "إجراء الاختبارات",
+  "ruleset.batch_test_title": "إجراء اختبار باللوت",
+  "ruleset.batch_test.progress": "العدد / % - الإجمالي {{total}} / {{progress}} كيان تم اختباره",
   "ruleset.cancel": "إلغاء",
   "ruleset.commit": "تأكيد",
   "ruleset.cooldown": "مدة الانتظار:",
   "ruleset.create_rule": "إنشاء قاعدة",
-
   "ruleset.edit_settings_title": "تعديل الإعدادات العامة",
   "ruleset.error": "حدث خطأ.",
   "ruleset.last_update": "آخر تحديث:",
@@ -61,7 +68,6 @@
   "section.create_panel.validate": "تحقق",
   "section.tab_overview": "نظرة عامة",
   "section.tab_scores": "نقاط {{name}}",
-
   "section.title": "تكوين النقاط",
   "settings.define_scale": "حدد مقياس مخاطر، ثم اختر الكيان الذي تريد إنشاء مجموعة القواعد عليه.",
   "settings.levels": "{{count}} مستويات المخاطر",
@@ -73,10 +79,8 @@
   "switch.and": "و",
   "switch.apply_conditions": "تطبيق الشروط التالية:",
   "switch.bool.if_false": "وإلا",
-
   "switch.bool.if_true": "إذا كان صحيحًا",
   "switch.bool.then": "إذن",
-
   "switch.configure_aggregation": "تكوين التجميع",
   "switch.depending_on": "بناءً على قيمة",
   "switch.description.else": "وإلا",
@@ -84,7 +88,6 @@
   "switch.description.if_true": "إذا كان صحيحًا",
   "switch.description.if_value": "إذا كانت القيمة {{op}}",
   "switch.description.if_value_between": "إذا كانت القيمة بين {{from}} و{{to}}",
-
   "switch.description.if_value_lte": "إذا كانت القيمة ≤ {{value}}",
   "switch.else": "وإلا",
   "switch.entity_tags.depending_on": "بناءً على وسوم الكيان",
@@ -92,7 +95,6 @@
   "switch.no_condition": "لا توجد شروط محددة",
   "switch.number.and": "و",
   "switch.number.default": "وإلا، ≥",
-
   "switch.number.first": "إذا كانت القيمة ≤",
   "switch.number.middle": "إذا كانت القيمة بين",
   "switch.number.then": "إذن",
@@ -111,7 +113,6 @@
   "switch.string.op.not_in_list": "غير موجود في القائمة",
   "switch.string.op.starts_with": "يبدأ بـ",
   "switch.string.search_placeholder": "بحث أو أدخل قيمة...",
-
   "switch.string.then": "إذن",
   "switch.then": "إذن",
   "thresholds.and": "و",

--- a/packages/app-builder/src/locales/en/user-scoring.json
+++ b/packages/app-builder/src/locales/en/user-scoring.json
@@ -1,11 +1,14 @@
 {
+  "batch_test.cancelled": "Cancelled",
+  "batch_test.completed": "Completed",
+  "batch_test.pending": "Pending",
+  "batch_test.running": "Running",
+  "batch_test.title": "[Test] Risk repartition for: {{name}}",
   "level.high": "High",
-
   "level.low": "Low",
   "level.medium": "Medium",
   "level.very_high": "Very high",
   "overview.configure_score": "Configure a score",
-
   "overview.no_ruleset": "You don't have any ruleset configured yet. Choose an entity on which to create a ruleset to start.",
   "overview.ruleset_card.no_distribution": "No distribution yet",
   "overview.ruleset_card.title": "Risk repartition for: {{name}}",
@@ -14,7 +17,6 @@
   "risk_type.geo_risks": "Geo risks",
   "risk_type.service_provided": "Service provided",
   "risk_type.transaction_execution": "Transaction execution",
-
   "rule_edit.cancel": "Cancel",
   "rule_edit.model_type.aggregate": "Aggregate",
   "rule_edit.model_type.entity_tags": "Entity tags",
@@ -26,11 +28,15 @@
   "rule_edit.risk_type_placeholder": "Risk type *",
   "rule_edit.save": "Save changes",
   "ruleset.add_rule": "Add rule",
+  "ruleset.batch_test_button": "Launch a batch test",
+  "ruleset.batch_test_description1": "You can test the relevance of the score by running it on a randomly selected panel of users.",
+  "ruleset.batch_test_description2": "The test will automatically run in the background, and you will see the first statistics appear here as soon as they are ready to be displayed.",
+  "ruleset.batch_test_run": "Launch the tests",
+  "ruleset.batch_test_title": "Launch a batch test",
   "ruleset.cancel": "Cancel",
   "ruleset.commit": "Commit",
   "ruleset.cooldown": "Cooldown:",
   "ruleset.create_rule": "Create rule",
-
   "ruleset.edit_settings_title": "Edit general settings",
   "ruleset.error": "An error occurred.",
   "ruleset.last_update": "Last update:",
@@ -61,7 +67,6 @@
   "section.create_panel.validate": "Validate",
   "section.tab_overview": "Overview",
   "section.tab_scores": "Scores {{name}}",
-
   "section.title": "Customer Scoring",
   "settings.define_scale": "Define a risk scale, then choose the entity on which you want to create the ruleset.",
   "settings.levels": "{{count}} levels of risk",
@@ -73,10 +78,8 @@
   "switch.and": "and",
   "switch.apply_conditions": "apply the following conditions:",
   "switch.bool.if_false": "otherwise",
-
   "switch.bool.if_true": "if true",
   "switch.bool.then": "then",
-
   "switch.configure_aggregation": "Configure aggregation",
   "switch.depending_on": "Depending on the value of",
   "switch.description.else": "Else",
@@ -84,7 +87,6 @@
   "switch.description.if_true": "If true",
   "switch.description.if_value": "If value {{op}}",
   "switch.description.if_value_between": "If value is between {{from}} and {{to}}",
-
   "switch.description.if_value_lte": "If value ≤ {{value}}",
   "switch.else": "Else",
   "switch.entity_tags.depending_on": "Depending on entity tags",
@@ -92,7 +94,6 @@
   "switch.no_condition": "No condition defined",
   "switch.number.and": "and",
   "switch.number.default": "otherwise, ≥ to",
-
   "switch.number.first": "if value ≤ to",
   "switch.number.middle": "if value is between",
   "switch.number.then": "then",
@@ -111,11 +112,11 @@
   "switch.string.op.not_in_list": "is not in list",
   "switch.string.op.starts_with": "starts with",
   "switch.string.search_placeholder": "Search or enter a value...",
-
   "switch.string.then": "then",
   "switch.then": "then",
   "thresholds.and": "and",
   "thresholds.between": "between",
   "thresholds.risk_levels": "Risk levels:",
-  "thresholds.title": "Score settings"
+  "thresholds.title": "Score settings",
+  "ruleset.batch_test.progress": "Count / % - total {{total}} / {{progress}} entity tested"
 }

--- a/packages/app-builder/src/locales/en/user-scoring.json
+++ b/packages/app-builder/src/locales/en/user-scoring.json
@@ -33,6 +33,7 @@
   "ruleset.batch_test_description2": "The test will automatically run in the background, and you will see the first statistics appear here as soon as they are ready to be displayed.",
   "ruleset.batch_test_run": "Launch the tests",
   "ruleset.batch_test_title": "Launch a batch test",
+  "ruleset.batch_test.progress": "Count / % - total {{total}} / {{progress}} entity tested",
   "ruleset.cancel": "Cancel",
   "ruleset.commit": "Commit",
   "ruleset.cooldown": "Cooldown:",
@@ -117,6 +118,5 @@
   "thresholds.and": "and",
   "thresholds.between": "between",
   "thresholds.risk_levels": "Risk levels:",
-  "thresholds.title": "Score settings",
-  "ruleset.batch_test.progress": "Count / % - total {{total}} / {{progress}} entity tested"
+  "thresholds.title": "Score settings"
 }

--- a/packages/app-builder/src/locales/fr/user-scoring.json
+++ b/packages/app-builder/src/locales/fr/user-scoring.json
@@ -1,11 +1,14 @@
 {
+  "batch_test.cancelled": "Annulé",
+  "batch_test.completed": "Terminé",
+  "batch_test.pending": "En attente",
+  "batch_test.running": "En cours",
+  "batch_test.title": "[Test] Répartition des risques pour : {{name}}",
   "level.high": "Élevé",
-
   "level.low": "Faible",
   "level.medium": "Moyen",
   "level.very_high": "Très élevé",
   "overview.configure_score": "Configurer un score",
-
   "overview.no_ruleset": "Vous n'avez pas encore de jeu de règles configuré. Choisissez une entité sur laquelle créer un jeu de règles pour commencer.",
   "overview.ruleset_card.no_distribution": "Aucune distribution pour l'instant",
   "overview.ruleset_card.title": "Répartition des risques pour : {{name}}",
@@ -14,7 +17,6 @@
   "risk_type.geo_risks": "Risques géographiques",
   "risk_type.service_provided": "Service fourni",
   "risk_type.transaction_execution": "Exécution des transactions",
-
   "rule_edit.cancel": "Annuler",
   "rule_edit.model_type.aggregate": "Agrégat",
   "rule_edit.model_type.entity_tags": "Tags d'entité",
@@ -26,11 +28,16 @@
   "rule_edit.risk_type_placeholder": "Type de risque *",
   "rule_edit.save": "Valider les modifications",
   "ruleset.add_rule": "Ajouter une règle",
+  "ruleset.batch_test_button": "Lancer un test par lot",
+  "ruleset.batch_test_description1": "Vous pouvez tester la pertinence du score en le testant sur un panel d’utilisateurs sélectionnés aléatoirement.",
+  "ruleset.batch_test_description2": "Le test tournera automatiquement en arrière plan, et vous verrez apparaître ici les premières statistiques lorsqu’elles seront prêtes à être affichées.",
+  "ruleset.batch_test_run": "Lancer les tests",
+  "ruleset.batch_test_title": "Lancer un test par lot",
+  "ruleset.batch_test.progress": "Nombre / % - total {{total}} / {{progress}} entité testée",
   "ruleset.cancel": "Annuler",
   "ruleset.commit": "Valider",
   "ruleset.cooldown": "Cooldown :",
   "ruleset.create_rule": "Créer une règle",
-
   "ruleset.edit_settings_title": "Modifier les paramètres généraux",
   "ruleset.error": "Une erreur est survenue.",
   "ruleset.last_update": "Dernière mise à jour :",
@@ -61,7 +68,6 @@
   "section.create_panel.validate": "Valider",
   "section.tab_overview": "Vue d'ensemble",
   "section.tab_scores": "Scores {{name}}",
-
   "section.title": "Scoring client",
   "settings.define_scale": "Définissez une échelle de risque, puis choisissez l'entité sur laquelle créer le jeu de règles.",
   "settings.levels": "{{count}} niveaux de risque",
@@ -73,10 +79,8 @@
   "switch.and": "et",
   "switch.apply_conditions": "appliquer les conditions suivantes :",
   "switch.bool.if_false": "sinon",
-
   "switch.bool.if_true": "si oui",
   "switch.bool.then": "alors",
-
   "switch.configure_aggregation": "Configurer l'agrégation",
   "switch.depending_on": "En fonction de la valeur de",
   "switch.description.else": "Sinon",
@@ -84,7 +88,6 @@
   "switch.description.if_true": "Si vrai",
   "switch.description.if_value": "Si valeur {{op}}",
   "switch.description.if_value_between": "Si valeur entre {{from}} et {{to}}",
-
   "switch.description.if_value_lte": "Si valeur ≤ {{value}}",
   "switch.else": "Sinon",
   "switch.entity_tags.depending_on": "Selon les tags d'entité",
@@ -92,7 +95,6 @@
   "switch.no_condition": "Aucune condition définie",
   "switch.number.and": "et",
   "switch.number.default": "si non, ≥ à",
-
   "switch.number.first": "si la valeur est ≤ à",
   "switch.number.middle": "si la valeur est entre",
   "switch.number.then": "alors",
@@ -111,7 +113,6 @@
   "switch.string.op.not_in_list": "n'est pas dans la liste",
   "switch.string.op.starts_with": "commence par",
   "switch.string.search_placeholder": "Rechercher ou saisir une valeur...",
-
   "switch.string.then": "alors",
   "switch.then": "alors",
   "thresholds.and": "et",

--- a/packages/app-builder/src/models/scoring/dry-run.ts
+++ b/packages/app-builder/src/models/scoring/dry-run.ts
@@ -1,4 +1,4 @@
-import { ScoringDryRun as ScoringDryRunDto } from 'marble-api';
+import type { ScoringDryRun as ScoringDryRunDto } from 'marble-api';
 
 export type ScoringDryRunStatus = ScoringDryRunDto['status'];
 

--- a/packages/app-builder/src/models/scoring/dry-run.ts
+++ b/packages/app-builder/src/models/scoring/dry-run.ts
@@ -1,0 +1,31 @@
+import { ScoringDryRun as ScoringDryRunDto } from 'marble-api';
+
+export type ScoringDryRunStatus = ScoringDryRunDto['status'];
+
+export type ScoringDryRunDistributionItem = {
+  riskLevel: number;
+  count: number;
+};
+
+export type ScoringDryRun = {
+  id: string;
+  rulesetId: string;
+  status: ScoringDryRunStatus;
+  recordCount: number;
+  progress: number;
+  distribution: ScoringDryRunDistributionItem[];
+  createdAt: string;
+};
+
+export const adaptScoringDryRun = (dto: ScoringDryRunDto): ScoringDryRun => ({
+  id: dto.id,
+  rulesetId: dto.ruleset_id,
+  status: dto.status,
+  recordCount: dto.record_count,
+  progress: dto.progress,
+  distribution: dto.distribution.map((item) => ({
+    riskLevel: item.risk_level,
+    count: item.count,
+  })),
+  createdAt: dto.created_at,
+});

--- a/packages/app-builder/src/models/scoring/index.ts
+++ b/packages/app-builder/src/models/scoring/index.ts
@@ -1,6 +1,7 @@
 export * from './ast-transform';
 export * from './conditions';
 export * from './display';
+export * from './dry-run';
 export * from './match-evaluations';
 export * from './rule-model';
 export * from './ruleset';

--- a/packages/app-builder/src/queries/scoring/get-dry-run.ts
+++ b/packages/app-builder/src/queries/scoring/get-dry-run.ts
@@ -1,0 +1,32 @@
+import { type ScoringDryRun } from '@app-builder/models/scoring';
+import { getScoringDryRunFn } from '@app-builder/server-fns/scoring';
+import { type Query, useQuery } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+
+export const SCORING_DRY_RUN_POLL_INTERVAL_MS = 1000;
+
+type ScoringDryRunQueryData = { dryRun: ScoringDryRun | null };
+
+type ScoringDryRunQuery = Query<ScoringDryRunQueryData, Error, ScoringDryRunQueryData, string[]>;
+
+type UseGetScoringDryRunQueryOptions = {
+  enabled?: boolean;
+  refetchInterval?: number | false | ((query: ScoringDryRunQuery) => number | false | undefined);
+};
+
+export const useGetScoringDryRunQuery = (recordType: string, options?: UseGetScoringDryRunQueryOptions) => {
+  const getScoringDryRun = useServerFn(getScoringDryRunFn);
+
+  return useQuery({
+    queryKey: ['scoring', 'dry-run', recordType],
+    queryFn: () => getScoringDryRun({ data: { recordType } }) as Promise<ScoringDryRunQueryData>,
+    enabled: !!recordType && (options?.enabled ?? true),
+    // forced refesh or depending of the status
+    refetchInterval:
+      options?.refetchInterval ??
+      ((query) => {
+        const status = query.state.data?.dryRun?.status;
+        return status === 'running' || status === 'pending' ? SCORING_DRY_RUN_POLL_INTERVAL_MS : false;
+      }),
+  });
+};

--- a/packages/app-builder/src/queries/scoring/get-dry-run.ts
+++ b/packages/app-builder/src/queries/scoring/get-dry-run.ts
@@ -1,11 +1,10 @@
-import { type ScoringDryRun } from '@app-builder/models/scoring';
 import { getScoringDryRunFn } from '@app-builder/server-fns/scoring';
 import { type Query, useQuery } from '@tanstack/react-query';
 import { useServerFn } from '@tanstack/react-start';
 
 export const SCORING_DRY_RUN_POLL_INTERVAL_MS = 1000;
 
-type ScoringDryRunQueryData = { dryRun: ScoringDryRun | null };
+type ScoringDryRunQueryData = Awaited<ReturnType<typeof getScoringDryRunFn>>;
 
 type ScoringDryRunQuery = Query<ScoringDryRunQueryData, Error, ScoringDryRunQueryData, string[]>;
 
@@ -19,7 +18,7 @@ export const useGetScoringDryRunQuery = (recordType: string, options?: UseGetSco
 
   return useQuery({
     queryKey: ['scoring', 'dry-run', recordType],
-    queryFn: () => getScoringDryRun({ data: { recordType } }) as Promise<ScoringDryRunQueryData>,
+    queryFn: () => getScoringDryRun({ data: { recordType } }),
     enabled: !!recordType && (options?.enabled ?? true),
     // forced refesh or depending of the status
     refetchInterval:

--- a/packages/app-builder/src/queries/scoring/start-dry-run.ts
+++ b/packages/app-builder/src/queries/scoring/start-dry-run.ts
@@ -1,0 +1,18 @@
+import { startScoringDryRunFn } from '@app-builder/server-fns/scoring';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+
+export const useStartScoringDryRunMutation = () => {
+  const startScoringDryRun = useServerFn(startScoringDryRunFn);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['scoring', 'start-dry-run'],
+    mutationFn: async (recordType: string) => {
+      return startScoringDryRun({ data: { recordType } });
+    },
+    onSuccess: (result, recordType) => {
+      queryClient.setQueryData(['scoring', 'dry-run', recordType], result);
+    },
+  });
+};

--- a/packages/app-builder/src/repositories/UserScoringRepository.ts
+++ b/packages/app-builder/src/repositories/UserScoringRepository.ts
@@ -2,9 +2,11 @@ import { type MarbleCoreApi } from '@app-builder/infra/marblecore-api';
 import { adaptNodeDto, isNotFoundHttpError } from '@app-builder/models';
 import { adaptScenarioPublicationStatus, ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
 import {
+  adaptScoringDryRun,
   adaptScoringRuleset,
   adaptScoringRulesetWithRules,
   adaptScoringSettings,
+  ScoringDryRun,
   ScoringRuleset,
   ScoringRulesetWithRules,
   ScoringSettings,
@@ -27,6 +29,8 @@ export interface UserScoringRepository {
   getScoreLatest(recordType: string, recordId: string): Promise<ScoringScore | null>;
   getScoreLatestWithEvaluation(recordType: string, recordId: string): Promise<ScoringScore | null>;
   getScoreDistribution(recordType: string): Promise<ScoreDistributionItem[]>;
+  startScoringDryRun(recordType: string): Promise<ScoringDryRun>;
+  getScoringDryRun(recordType: string): Promise<ScoringDryRun | null>;
 }
 
 export function makeGetUserScoringRepository() {
@@ -104,6 +108,19 @@ export function makeGetUserScoringRepository() {
     },
     async getScoreDistribution(recordType) {
       return marbleCoreApiClient.getScoreDistribution(recordType);
+    },
+    async startScoringDryRun(recordType) {
+      return adaptScoringDryRun(await marbleCoreApiClient.startScoringDryRun(recordType));
+    },
+    async getScoringDryRun(recordType) {
+      try {
+        return adaptScoringDryRun(await marbleCoreApiClient.getScoringDryRun(recordType));
+      } catch (err) {
+        if (isNotFoundHttpError(err)) {
+          return null;
+        }
+        throw err;
+      }
     },
   });
 }

--- a/packages/app-builder/src/repositories/UserScoringRepository.ts
+++ b/packages/app-builder/src/repositories/UserScoringRepository.ts
@@ -1,18 +1,21 @@
 import { type MarbleCoreApi } from '@app-builder/infra/marblecore-api';
 import { adaptNodeDto, isNotFoundHttpError } from '@app-builder/models';
-import { adaptScenarioPublicationStatus, ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
+import {
+  adaptScenarioPublicationStatus,
+  type ScenarioPublicationStatus,
+} from '@app-builder/models/scenario/publication';
 import {
   adaptScoringDryRun,
   adaptScoringRuleset,
   adaptScoringRulesetWithRules,
   adaptScoringSettings,
-  ScoringDryRun,
-  ScoringRuleset,
-  ScoringRulesetWithRules,
-  ScoringSettings,
-  UpdateScoringRuleset,
+  type ScoringDryRun,
+  type ScoringRuleset,
+  type ScoringRulesetWithRules,
+  type ScoringSettings,
+  type UpdateScoringRuleset,
 } from '@app-builder/models/scoring';
-import { ScoringScore } from 'marble-api';
+import type { ScoringScore } from 'marble-api';
 
 export type ScoreDistributionItem = { risk_level: number; count: number };
 

--- a/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
@@ -54,6 +54,7 @@ function UserScoringRulesetRoute() {
 
   return (
     <ScoringRulesetPage
+      key={ruleset.recordType}
       ruleset={ruleset}
       settings={settings}
       customLists={customLists}

--- a/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
@@ -4,8 +4,30 @@ import { isNotFoundHttpError } from '@app-builder/models';
 import { type ScenarioPublicationStatus } from '@app-builder/models/scenario/publication';
 import { type ScoringRulesetWithRules } from '@app-builder/models/scoring';
 import { hasAnyEntitlement } from '@app-builder/services/feature-access';
+import { normalizeTimestampForInstant } from '@app-builder/utils/datetime';
+import { tryCatch } from '@app-builder/utils/tryCatch';
 import { createFileRoute, redirect, useLoaderData } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
+import { Temporal } from 'temporal-polyfill';
+
+const DRY_RUN_STALE_LIMIT_IN_DAYS = 7;
+
+function isValidDryRun(createdAt: string | undefined): boolean {
+  if (!createdAt) return false;
+
+  const isValid = tryCatch(() => {
+    const createdAtInstant = Temporal.Instant.from(normalizeTimestampForInstant(createdAt));
+    const now = Temporal.Now.zonedDateTimeISO();
+    const windowStart = now.subtract({ days: DRY_RUN_STALE_LIMIT_IN_DAYS }).toInstant();
+    const windowEnd = now.toInstant();
+
+    return (
+      Temporal.Instant.compare(createdAtInstant, windowStart) >= 0 &&
+      Temporal.Instant.compare(createdAtInstant, windowEnd) <= 0
+    );
+  });
+  return isValid.ok && isValid.value;
+}
 
 const scoringRulesetLoader = createServerFn()
   .middleware([authMiddleware])
@@ -34,7 +56,13 @@ const scoringRulesetLoader = createServerFn()
       preparationStatus = await userScoring.getRulesetPreparationStatus(recordType);
     }
 
-    return { ruleset, customLists, preparationStatus, lastDryRun, hasValidLicense: hasAnyEntitlement(entitlements) };
+    return {
+      ruleset,
+      customLists,
+      preparationStatus,
+      lastDryRun: isValidDryRun(lastDryRun?.createdAt) ? lastDryRun : null,
+      hasValidLicense: hasAnyEntitlement(entitlements),
+    };
   });
 
 export const Route = createFileRoute('/_app/_builder/user-scoring/$recordType/$version')({

--- a/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
+++ b/packages/app-builder/src/routes/_app/_builder/user-scoring/$recordType.$version.tsx
@@ -27,13 +27,14 @@ const scoringRulesetLoader = createServerFn()
     }
 
     const customLists = await customListsRepository.listCustomLists();
+    const lastDryRun = await userScoring.getScoringDryRun(recordType);
 
     let preparationStatus: ScenarioPublicationStatus | null = null;
     if (ruleset.status === 'draft') {
       preparationStatus = await userScoring.getRulesetPreparationStatus(recordType);
     }
 
-    return { ruleset, customLists, preparationStatus, hasValidLicense: hasAnyEntitlement(entitlements) };
+    return { ruleset, customLists, preparationStatus, lastDryRun, hasValidLicense: hasAnyEntitlement(entitlements) };
   });
 
 export const Route = createFileRoute('/_app/_builder/user-scoring/$recordType/$version')({
@@ -48,7 +49,7 @@ function UserScoringRulesetRoute() {
   // During router.invalidate(), loader data can be temporarily undefined
   if (!loaderData || !parentData?.settings) return null;
 
-  const { ruleset, customLists, preparationStatus, hasValidLicense } = loaderData;
+  const { ruleset, customLists, preparationStatus, hasValidLicense, lastDryRun } = loaderData;
   const { settings } = parentData;
 
   return (
@@ -58,6 +59,7 @@ function UserScoringRulesetRoute() {
       customLists={customLists}
       preparationStatus={preparationStatus}
       hasValidLicense={hasValidLicense}
+      lastDryRun={lastDryRun}
     />
   );
 }

--- a/packages/app-builder/src/server-fns/scoring.ts
+++ b/packages/app-builder/src/server-fns/scoring.ts
@@ -139,3 +139,19 @@ export const getScoreLatestFn = createServerFn({ method: 'GET' })
       throw error;
     }
   });
+
+export const startScoringDryRunFn = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .validator(z.object({ recordType: z.string() }))
+  .handler(async ({ context, data }) => {
+    const dryRun = await context.authInfo.userScoring.startScoringDryRun(data.recordType);
+    return { dryRun };
+  });
+
+export const getScoringDryRunFn = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .validator(z.object({ recordType: z.string() }))
+  .handler(async ({ context, data }) => {
+    const dryRun = await context.authInfo.userScoring.getScoringDryRun(data.recordType);
+    return { dryRun };
+  });

--- a/packages/backoffice/.vscode/settings.json
+++ b/packages/backoffice/.vscode/settings.json
@@ -30,6 +30,14 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "editor.codeActionsOnSave": {
+    "source.organizeImports": "never",
     "source.organizeImports.biome": "explicit"
+  },
+  "js/ts.preferences.organizeImports": {
+    "caseSensitivity": "caseSensitive",
+    "caseFirst": "upper",
+    "unicodeCollation": "unicode",
+    "numericCollation": true,
+    "typeOrder": "inline"
   }
 }

--- a/packages/marble-api/openapis/marblecore-api/scoring.yml
+++ b/packages/marble-api/openapis/marblecore-api/scoring.yml
@@ -609,7 +609,7 @@ components:
           format: uuid
         status:
           type: string
-          enum: [pending, completed]
+          enum: [pending, completed, running, cancelled]
         record_count:
           type: integer
         progress:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -2167,7 +2167,7 @@ export type UpdateScoringRuleset = {
 export type ScoringDryRun = {
     id: string;
     ruleset_id: string;
-    status: "pending" | "completed";
+    status: "pending" | "completed" | "running" | "cancelled";
     record_count: number;
     progress: number;
     distribution: {


### PR DESCRIPTION
# Customer scoring dry run

## what has been done

- On a draft version of user scoring rule, a `launch batch test` button runs a dry run on a sample of data
- The result is displayed and stored
- When the user comes back the last dry run result is displayed (maybe until it is considered as stale, delay is tbd)

<img width="1229" height="567" alt="Screenshot 2026-09-02 at 16 38 26" src="https://github.com/user-attachments/assets/4a9eee07-af18-486a-8fa8-02ac14e2c9a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added batch testing for scoring rulesets, with launch controls, progress tracking, status updates, record counts, and risk-level distribution charts.
  - Added support for viewing previous and in-progress batch test results.
  - Added localized batch-testing labels and instructions in English, French, and Arabic.
  - Added additional dry-run statuses, including running and cancelled.

- **Style**
  - Improved label and metric spacing to prevent important text and numbers from wrapping unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->