### PR TITLE
remove date function for the birthdate of a person in screening rules

### DIFF
--- a/packages/app-builder/src/components/Scenario/Rules/ScreeningRuleEditPanel.tsx
+++ b/packages/app-builder/src/components/Scenario/Rules/ScreeningRuleEditPanel.tsx
@@ -656,7 +656,6 @@ export function ScreeningRuleEditPanel({
                                       onBlur={field.handleBlur}
                                       placeholder={t('scenarios:edit_sanction.birthdate_placeholder')}
                                       limit={5}
-                                      withDate
                                     />
                                     <FormErrorOrDescription errors={getFieldErrors(field.state.meta.errors)} />
                                   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date field handling in the screening rule editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->