### PR TITLE
Document and SAR download

### DIFF
--- a/packages/app-builder/src/components/CaseManager/CaseDocuments/CaseDocuments.tsx
+++ b/packages/app-builder/src/components/CaseManager/CaseDocuments/CaseDocuments.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next';
+import { CaseFileButton } from './CaseFileButton';
+
+type CaseDocumentsProps = {
+  files: { id: string; fileName: string }[];
+};
+
+export function CaseDocuments({ files }: CaseDocumentsProps) {
+  const { t } = useTranslation(['common']);
+
+  if (files.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col justify-start gap-sm">
+      <span className="text-default text-grey-primary px-2xs font-medium">{t('common:documents')}</span>
+      <div className="border-grey-border bg-surface-card flex flex-wrap gap-sm rounded-lg border p-md">
+        {files.map((file) => (
+          <CaseFileButton key={file.id} file={file} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/app-builder/src/components/CaseManager/CaseDocuments/CaseFileButton.tsx
+++ b/packages/app-builder/src/components/CaseManager/CaseDocuments/CaseFileButton.tsx
@@ -1,0 +1,49 @@
+import { AlreadyDownloadingError, AuthRequestError, useDownloadFile } from '@app-builder/services/DownloadFilesService';
+import { useRouter } from '@tanstack/react-router';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { Button, type ButtonV2Props, cn } from 'ui-design-system';
+import { Icon } from 'ui-icons';
+
+type CaseFileButtonProps = {
+  file: { id: string; fileName: string };
+} & ButtonV2Props;
+
+export function CaseFileButton({ file, className, ...buttonProps }: CaseFileButtonProps) {
+  const { t } = useTranslation(['cases']);
+  const router = useRouter();
+  const downloadEndpoint = router.buildLocation({
+    to: '/ressources/cases/download-file/$fileId',
+    params: { fileId: file.id },
+  });
+
+  const { downloadCaseFile, downloadingCaseFile } = useDownloadFile(downloadEndpoint.href, {
+    onError: (e) => {
+      if (e instanceof AlreadyDownloadingError) {
+        return;
+      } else if (e instanceof AuthRequestError) {
+        toast.error(t('cases:case.file.errors.downloading_link.auth_error'));
+      } else {
+        toast.error(t('cases:case.file.errors.downloading_link.unknown'));
+      }
+    },
+  });
+
+  return (
+    <Button
+      variant="secondary"
+      className={className}
+      {...buttonProps}
+      onClick={() => {
+        void downloadCaseFile();
+      }}
+      disabled={downloadingCaseFile}
+    >
+      <Icon
+        icon={downloadingCaseFile ? 'spinner' : 'download'}
+        className={cn('size-3.5', { 'animate-spin': downloadingCaseFile })}
+      />
+      {file.fileName}
+    </Button>
+  );
+}

--- a/packages/app-builder/src/components/CaseManager/PageLayout.tsx
+++ b/packages/app-builder/src/components/CaseManager/PageLayout.tsx
@@ -42,6 +42,7 @@ import {
 import { Icon } from 'ui-icons';
 import { CloseCase } from '../Cases/CloseCase';
 import { OpenCase } from '../Cases/OpenCase';
+import { SarReportDownload } from '../Cases/SarReportDownload';
 import { SnoozeCase } from '../Cases/SnoozeCase';
 import { ClientCommentForm } from './ClientComments';
 import { CommentContext } from './hooks/comment-context';
@@ -81,8 +82,10 @@ export function CaseManagerPageLayout({
     setKycEnrichmentPanelOpen(true);
   };
 
-  const sarStatus = sarReportsQuery.data?.[0]?.status;
+  const sarReport = sarReportsQuery.data?.[0];
+  const sarStatus = sarReport?.status;
   const isSarCompleted = sarStatus === 'completed';
+  const hasSarFile = sarReport?.hasFile === true;
   const sarActionText = match(sarStatus)
     .with(undefined, () => t('cases:manager.actions.create_sar'))
     .with('pending', () => t('cases:manager.actions.complete_sar'))
@@ -136,7 +139,11 @@ export function CaseManagerPageLayout({
               </Link>
             </Tabs>
             <ActionBar>
-              <ActionButton disabled={isSarCompleted} icon="plus" text={sarActionText} onClick={handleSarAction} />
+              {isSarCompleted && hasSarFile && sarReport ? (
+                <SarReportDownload variant="action" caseId={caseDetail.id} reportId={sarReport.id} />
+              ) : (
+                <ActionButton icon="plus" text={sarActionText} onClick={handleSarAction} />
+              )}
               <ActionButton
                 disabled={pivotObjects.length === 0}
                 icon="plus"
@@ -152,7 +159,7 @@ export function CaseManagerPageLayout({
             open={sarReportModalOpen}
             onOpenChange={setSarReportModalOpen}
             caseId={caseDetail.id}
-            report={sarReportsQuery.data?.[0]}
+            report={sarReport}
           />
           <KycEnrichmentPanel
             caseId={caseDetail.id}
@@ -262,7 +269,13 @@ function SarReportModal({ open, onOpenChange, caseId, report }: SarReportModalPr
             </form.Field>
           ) : null}
 
-          {newStatus === 'completed' ? (
+          {report?.hasFile ? (
+            <div className="flex justify-start">
+              <SarReportDownload caseId={caseId} reportId={report.id} />
+            </div>
+          ) : null}
+
+          {newStatus === 'completed' && !report?.hasFile ? (
             <div
               {...getRootProps()}
               className={cn(

--- a/packages/app-builder/src/components/CaseManager/PrincipalPage.tsx
+++ b/packages/app-builder/src/components/CaseManager/PrincipalPage.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Card, CtaV2ClassName, cn, Panel, Tag, TagList } from 'ui-design-system';
 import { Icon } from 'ui-icons';
 import { AiReviewCard } from './AiReview/AiReviewCard';
+import { CaseDocuments } from './CaseDocuments/CaseDocuments';
 import { CaseEvents } from './CaseEvents';
 import { CaseInfo } from './CaseInfo';
 import { CaseInvestigation } from './CaseInvestigation/CaseInvestigation';
@@ -156,6 +157,7 @@ export function CaseManagerPrincipalPage({
               ) : null}
             </Card>
           )}
+          <CaseDocuments files={caseDetail.files} />
           <CaseInvestigation root={rootRef} caseId={caseDetail.id} events={caseDetail.events} />
         </div>
       </div>

--- a/packages/app-builder/src/components/Cases/EditCaseSuspicion.tsx
+++ b/packages/app-builder/src/components/Cases/EditCaseSuspicion.tsx
@@ -1,4 +1,4 @@
-import { Callout, casesI18n } from '@app-builder/components';
+import { Callout } from '@app-builder/components';
 import { useLoaderRevalidator } from '@app-builder/contexts/LoaderRevalidatorContext';
 import { useFormDropzone } from '@app-builder/hooks/useFormDropzone';
 import { type SuspiciousActivityReport } from '@app-builder/models/cases';
@@ -7,15 +7,14 @@ import {
   editSuspicionPayloadSchema,
   useEditSuspicionMutation,
 } from '@app-builder/queries/cases/edit-suspicion';
-import { AlreadyDownloadingError, AuthRequestError, useDownloadFile } from '@app-builder/services/DownloadFilesService';
 import { useForm, useStore } from '@tanstack/react-form';
-import { ClientOnly } from '@tanstack/react-router';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { match } from 'ts-pattern';
 import { Button, cn, Modal } from 'ui-design-system';
 import { Icon } from 'ui-icons';
+import { SarReportDownload } from './SarReportDownload';
 
 type EditCaseSuspicionProps = {
   id: string;
@@ -143,9 +142,7 @@ export const EditCaseSuspicion = ({ id, reports }: EditCaseSuspicionProps) => {
                     <span className="text-xs font-medium">{t('cases:sar.status.completed')}</span>
                   </span>
                   {reports[0]?.hasFile ? (
-                    <ClientOnly>
-                      <ReportFile name={t('cases:sar.action.download')} caseId={id} reportId={reports[0]!.id} />
-                    </ClientOnly>
+                    <SarReportDownload caseId={id} reportId={reports[0]!.id} />
                   ) : (
                     <Button variant="secondary" size="small" onClick={() => setOpenReportModal(true)}>
                       <Icon icon="attachment" className="size-3.5" />
@@ -221,45 +218,5 @@ export const EditCaseSuspicion = ({ id, reports }: EditCaseSuspicionProps) => {
         </div>
       )}
     </form.Field>
-  );
-};
-
-type ReportFileProps = {
-  name: string;
-  caseId: string;
-  reportId: string;
-};
-
-const ReportFile = ({ name, caseId, reportId }: ReportFileProps) => {
-  const { t } = useTranslation(casesI18n);
-  const downloadEndpoint = `/ressources/cases/sar/download/${caseId}/${reportId}`;
-  const { downloadCaseFile, downloadingCaseFile } = useDownloadFile(downloadEndpoint, {
-    onError: (e) => {
-      if (e instanceof AlreadyDownloadingError) {
-        // Already downloading, do nothing
-        return;
-      } else if (e instanceof AuthRequestError) {
-        toast.error(t('cases:case.file.errors.downloading_link.auth_error'));
-      } else {
-        toast.error(t('cases:case.file.errors.downloading_link.unknown'));
-      }
-    },
-  });
-
-  return (
-    <Button
-      variant="secondary"
-      size="small"
-      onClick={() => {
-        void downloadCaseFile();
-      }}
-      disabled={downloadingCaseFile}
-    >
-      <Icon
-        icon={downloadingCaseFile ? 'spinner' : 'download'}
-        className={cn('size-3.5', { 'animate-spin': downloadingCaseFile })}
-      />
-      {name}
-    </Button>
   );
 };

--- a/packages/app-builder/src/components/Cases/SarReportDownload.tsx
+++ b/packages/app-builder/src/components/Cases/SarReportDownload.tsx
@@ -1,0 +1,63 @@
+import { AlreadyDownloadingError, AuthRequestError, useDownloadFile } from '@app-builder/services/DownloadFilesService';
+import { useRouter } from '@tanstack/react-router';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { ActionButton, Button, cn } from 'ui-design-system';
+import { Icon } from 'ui-icons';
+
+type SarReportDownloadProps = {
+  caseId: string;
+  reportId: string;
+  variant?: 'button' | 'action';
+};
+
+export function SarReportDownload({ caseId, reportId, variant = 'button' }: SarReportDownloadProps) {
+  const { t } = useTranslation(['cases']);
+  const router = useRouter();
+  const downloadEndpoint = router.buildLocation({
+    to: '/ressources/cases/sar/download/$caseId/$reportId',
+    params: { caseId, reportId },
+  });
+
+  const { downloadCaseFile, downloadingCaseFile } = useDownloadFile(downloadEndpoint.href, {
+    onError: (e) => {
+      if (e instanceof AlreadyDownloadingError) {
+        return;
+      } else if (e instanceof AuthRequestError) {
+        toast.error(t('cases:case.file.errors.downloading_link.auth_error'));
+      } else {
+        toast.error(t('cases:case.file.errors.downloading_link.unknown'));
+      }
+    },
+  });
+
+  if (variant === 'action') {
+    return (
+      <ActionButton
+        icon={downloadingCaseFile ? 'spinner' : 'download'}
+        text={t('cases:sar.action.download')}
+        disabled={downloadingCaseFile}
+        onClick={() => {
+          void downloadCaseFile();
+        }}
+      />
+    );
+  }
+
+  return (
+    <Button
+      variant="secondary"
+      size="small"
+      onClick={() => {
+        void downloadCaseFile();
+      }}
+      disabled={downloadingCaseFile}
+    >
+      <Icon
+        icon={downloadingCaseFile ? 'spinner' : 'download'}
+        className={cn('size-3.5', { 'animate-spin': downloadingCaseFile })}
+      />
+      {t('cases:sar.action.download')}
+    </Button>
+  );
+}


### PR DESCRIPTION
Add SAR report download functionality and integrate CaseDocuments component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Documents section to case pages, allowing users to download associated case files.
  - Added reusable SAR report download controls with button and action menu variants.
  - Completed SAR reports now provide direct download access.
  - SAR report dialogs display existing reports and show upload options only when needed.
- **Bug Fixes**
  - Improved download feedback with loading indicators, disabled controls, and localized error notifications.
  - Prevented duplicate download attempts from triggering repeated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->