### PR TITLE
feat(backoffice): new user section to add/edit user independently of organization

### DIFF
--- a/packages/backoffice/src/components/pages/users.tsx
+++ b/packages/backoffice/src/components/pages/users.tsx
@@ -1,0 +1,448 @@
+import { makeQueryErrorComponent } from '@bo/components/common/ErrorComponent';
+import { SuspenseQuery } from '@bo/components/core/SuspenseQuery';
+import {
+  listUsersQueryOptions,
+  useCreateGlobalUserMutationOptions,
+  useUpdateGlobalUserMutationOptions,
+} from '@bo/data/users';
+import {
+  type CreateGlobalUserPayload,
+  createGlobalUserPayloadSchema,
+  DUPLICATE_EMAIL_ERROR,
+  GLOBAL_USER_ROLES,
+  type UpdateGlobalUserPayload,
+  updateGlobalUserPayloadSchema,
+} from '@bo/schemas/user';
+import { useForm } from '@tanstack/react-form';
+import { useMutation } from '@tanstack/react-query';
+import type { UserDto } from 'marble-api/generated/marblecore-api';
+import { type ReactNode, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { Button, Input, Panel, SelectV2, Tag, Typo } from 'ui-design-system';
+import { Icon } from 'ui-icons';
+
+const UsersError = makeQueryErrorComponent(<span className="text-grey-secondary text-s">Could not load users.</span>);
+
+type PanelState = { mode: 'create' } | { mode: 'edit'; user: UserDto } | null;
+
+export function UsersPage() {
+  const [panel, setPanel] = useState<PanelState>(null);
+
+  return (
+    <div className="flex flex-col gap-lg pb-xl">
+      <div className="flex flex-wrap items-start justify-between gap-md">
+        <div className="flex max-w-2xl flex-col gap-xs">
+          <Typo variant="title1">Users</Typo>
+          <p className="text-grey-secondary text-s">
+            Provision and maintain users across Marble, including accounts that are not assigned to an organization.
+          </p>
+        </div>
+        <Button size="large" variant="primary" onClick={() => setPanel({ mode: 'create' })}>
+          <Icon icon="plus" className="size-4" />
+          Create user
+        </Button>
+      </div>
+
+      <SuspenseQuery query={listUsersQueryOptions()} fallback={<UsersSkeleton />} errorComponent={UsersError}>
+        {(users) => <UsersList users={users} onEdit={(user) => setPanel({ mode: 'edit', user })} />}
+      </SuspenseQuery>
+
+      <UserPanel state={panel} onOpenChange={(open) => (open ? undefined : setPanel(null))} />
+    </div>
+  );
+}
+
+function UsersList({ users, onEdit }: { users: UserDto[]; onEdit: (user: UserDto) => void }) {
+  const [search, setSearch] = useState('');
+  const filteredUsers = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return users;
+
+    return users.filter((user) => {
+      const name = `${user.first_name} ${user.last_name}`.toLowerCase();
+      return name.includes(term) || user.email.toLowerCase().includes(term);
+    });
+  }, [search, users]);
+
+  if (users.length === 0) {
+    return <EmptyState title="No users yet" body="Create a user to manage access across Marble." />;
+  }
+
+  return (
+    <div className="flex flex-col gap-md">
+      <div className="max-w-100">
+        <Input
+          startAdornment="search"
+          endAdornment={search ? 'cross' : undefined}
+          onEndAdornmentClick={() => setSearch('')}
+          placeholder="Search by name or email"
+          value={search}
+          onChange={(event) => setSearch(event.currentTarget.value)}
+          aria-label="Search users"
+        />
+      </div>
+
+      {filteredUsers.length === 0 ? (
+        <EmptyState title="No matches" body={`No user matches “${search.trim()}”.`} />
+      ) : (
+        <div className="border-grey-border bg-surface-card overflow-hidden rounded-lg border">
+          <div className="border-grey-border text-grey-secondary hidden grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1.25fr)_auto] gap-md border-b px-md py-sm text-xs font-semibold uppercase tracking-wider lg:grid">
+            <span>User</span>
+            <span>Role</span>
+            <span>Organization</span>
+            <span className="sr-only">Actions</span>
+          </div>
+          <ul className="divide-grey-border divide-y">
+            {filteredUsers.map((user) => (
+              <UserRow key={user.user_id} user={user} onEdit={() => onEdit(user)} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UserRow({ user, onEdit }: { user: UserDto; onEdit: () => void }) {
+  return (
+    <li className="grid grid-cols-1 gap-md px-md py-md lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1.25fr)_auto] lg:items-center">
+      <div className="flex min-w-0 flex-col gap-2xs">
+        <span className="text-grey-primary truncate text-s font-medium">
+          {user.first_name} {user.last_name}
+        </span>
+        <span className="text-grey-secondary truncate text-xs">{user.email}</span>
+        <span className="text-grey-placeholder truncate font-mono text-2xs">{user.user_id}</span>
+      </div>
+      <div className="flex items-center gap-sm lg:block">
+        <span className="text-grey-secondary text-xs font-medium lg:sr-only">Role</span>
+        <Tag color="grey" size="small">
+          {user.role}
+        </Tag>
+      </div>
+      <div className="flex min-w-0 flex-col gap-2xs">
+        <span className="text-grey-secondary text-xs font-medium lg:sr-only">Organization</span>
+        {user.organization_id !== '00000000-0000-0000-0000-000000000000' ? (
+          <span className="text-grey-secondary truncate font-mono text-xs">{user.organization_id}</span>
+        ) : (
+          <span className="text-grey-secondary text-s">Unassigned</span>
+        )}
+      </div>
+      <div className="lg:justify-self-end">
+        <Button variant="secondary" size="small" onClick={onEdit}>
+          <Icon icon="edit-square" className="size-4" />
+          Edit
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+function UserPanel({ state, onOpenChange }: { state: PanelState; onOpenChange: (open: boolean) => void }) {
+  return (
+    <Panel.Root open={state !== null} onOpenChange={onOpenChange}>
+      <Panel.Container size="medium">
+        <Panel.Content>
+          {state?.mode === 'create' ? <CreateUserPanel onClose={() => onOpenChange(false)} /> : null}
+          {state?.mode === 'edit' ? <EditUserPanel user={state.user} onClose={() => onOpenChange(false)} /> : null}
+        </Panel.Content>
+      </Panel.Container>
+    </Panel.Root>
+  );
+}
+
+function CreateUserPanel({ onClose }: { onClose: () => void }) {
+  const createUserMutation = useMutation(useCreateGlobalUserMutationOptions());
+  const form = useForm({
+    defaultValues: {
+      first_name: '',
+      last_name: '',
+      email: '',
+      role: 'VIEWER',
+    } as CreateGlobalUserPayload,
+    validators: {
+      onMount: createGlobalUserPayloadSchema,
+      onChange: createGlobalUserPayloadSchema,
+      onSubmit: createGlobalUserPayloadSchema,
+    },
+    onSubmit: async ({ value, formApi }) => {
+      if (!formApi.state.isValid) return;
+
+      try {
+        await createUserMutation.mutateAsync(value);
+        toast.success(`User ${value.email} created`);
+        onClose();
+      } catch (error) {
+        toast.error(getUserErrorMessage(error, 'creating'));
+      }
+    },
+  });
+
+  return (
+    <>
+      <PanelHeader title="Create user" description="Create an account without assigning it to an organization." />
+      <form
+        id="create-global-user-form"
+        className="grid grid-cols-1 gap-md sm:grid-cols-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void form.handleSubmit();
+        }}
+      >
+        <form.Field name="first_name">
+          {(field) => (
+            <Field label="First name" htmlFor={field.name}>
+              <Input
+                id={field.name}
+                name={field.name}
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                onBlur={field.handleBlur}
+              />
+            </Field>
+          )}
+        </form.Field>
+        <form.Field name="last_name">
+          {(field) => (
+            <Field label="Last name" htmlFor={field.name}>
+              <Input
+                id={field.name}
+                name={field.name}
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                onBlur={field.handleBlur}
+              />
+            </Field>
+          )}
+        </form.Field>
+        <form.Field name="email">
+          {(field) => (
+            <Field label="Email" htmlFor={field.name} className="sm:col-span-full">
+              <Input
+                id={field.name}
+                name={field.name}
+                type="email"
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                onBlur={field.handleBlur}
+              />
+            </Field>
+          )}
+        </form.Field>
+        <form.Field name="role">
+          {(field) => (
+            <Field label="Role" className="sm:col-span-full">
+              <SelectV2<CreateGlobalUserPayload['role']>
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="Select a role"
+                options={GLOBAL_USER_ROLES.map((role) => ({ label: role, value: role }))}
+              />
+            </Field>
+          )}
+        </form.Field>
+      </form>
+      <Panel.Footer>
+        <Panel.FooterButton isCloseButton label="Cancel" disabled={createUserMutation.isPending} />
+        <form.Subscribe selector={(formState) => formState.canSubmit}>
+          {(canSubmit) => (
+            <Panel.FooterButton
+              type="submit"
+              form="create-global-user-form"
+              label="Create user"
+              variant="primary"
+              disabled={!canSubmit || createUserMutation.isPending}
+              isLoading={createUserMutation.isPending}
+            />
+          )}
+        </form.Subscribe>
+      </Panel.Footer>
+    </>
+  );
+}
+
+function EditUserPanel({ user, onClose }: { user: UserDto; onClose: () => void }) {
+  const updateUserMutation = useMutation(useUpdateGlobalUserMutationOptions());
+  const form = useForm({
+    defaultValues: {
+      userId: user.user_id,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      email: user.email,
+      role: user.role as UpdateGlobalUserPayload['role'],
+      organization_id: user.organization_id,
+    } as UpdateGlobalUserPayload,
+    validators: {
+      onMount: updateGlobalUserPayloadSchema,
+      onChange: updateGlobalUserPayloadSchema,
+      onSubmit: updateGlobalUserPayloadSchema,
+    },
+    onSubmit: async ({ value, formApi }) => {
+      if (!formApi.state.isValid) return;
+
+      try {
+        await updateUserMutation.mutateAsync(value);
+        toast.success(`User ${value.email} updated`);
+        onClose();
+      } catch (error) {
+        toast.error(getUserErrorMessage(error, 'updating'));
+      }
+    },
+  });
+
+  return (
+    <>
+      <PanelHeader
+        title="Edit user"
+        description={
+          user.organization_id
+            ? `Organization: ${user.organization_id}`
+            : 'This user is not assigned to an organization.'
+        }
+      />
+      <form
+        id="edit-global-user-form"
+        className="grid grid-cols-1 gap-md sm:grid-cols-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void form.handleSubmit();
+        }}
+      >
+        <form.Field name="first_name">
+          {(field) => (
+            <Field label="First name" htmlFor={field.name}>
+              <Input
+                id={field.name}
+                name={field.name}
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                onBlur={field.handleBlur}
+              />
+            </Field>
+          )}
+        </form.Field>
+        <form.Field name="last_name">
+          {(field) => (
+            <Field label="Last name" htmlFor={field.name}>
+              <Input
+                id={field.name}
+                name={field.name}
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                onBlur={field.handleBlur}
+              />
+            </Field>
+          )}
+        </form.Field>
+        <form.Field name="email">
+          {(field) => (
+            <Field label="Email" htmlFor={field.name} className="sm:col-span-full">
+              <Input
+                id={field.name}
+                name={field.name}
+                type="email"
+                value={field.state.value}
+                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                onBlur={field.handleBlur}
+              />
+            </Field>
+          )}
+        </form.Field>
+        <form.Field name="role">
+          {(field) => (
+            <Field label="Role" className="sm:col-span-full">
+              <SelectV2<UpdateGlobalUserPayload['role']>
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="Select a role"
+                options={GLOBAL_USER_ROLES.map((role) => ({ label: role, value: role }))}
+              />
+            </Field>
+          )}
+        </form.Field>
+      </form>
+      <Panel.Footer>
+        <Panel.FooterButton isCloseButton label="Cancel" disabled={updateUserMutation.isPending} />
+        <form.Subscribe selector={(formState) => [formState.canSubmit, formState.isDirty] as const}>
+          {([canSubmit, isDirty]) => (
+            <Panel.FooterButton
+              type="submit"
+              form="edit-global-user-form"
+              label="Save changes"
+              variant="primary"
+              disabled={!canSubmit || !isDirty || updateUserMutation.isPending}
+              isLoading={updateUserMutation.isPending}
+            />
+          )}
+        </form.Subscribe>
+      </Panel.Footer>
+    </>
+  );
+}
+
+function PanelHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <Panel.Header>
+      <div className="flex flex-col gap-2xs">
+        <span>{title}</span>
+        <p className="text-grey-secondary text-small font-normal">{description}</p>
+      </div>
+    </Panel.Header>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  className,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className={`flex flex-col gap-xs ${className ?? ''}`}>
+      <span className="text-grey-primary text-s font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="border-grey-border bg-surface-card flex flex-col items-center gap-xs rounded-lg border border-dashed p-2xl text-center">
+      <Typo variant="subtitle1">{title}</Typo>
+      <p className="text-grey-secondary text-s">{body}</p>
+    </div>
+  );
+}
+
+function UsersSkeleton() {
+  return (
+    <div className="flex flex-col gap-md">
+      <div className="bg-grey-background-light h-10 w-100 max-w-full animate-pulse rounded-md" />
+      <div className="border-grey-border bg-surface-card divide-grey-border flex flex-col divide-y overflow-hidden rounded-lg border">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} className="flex items-center justify-between gap-md p-md">
+            <div className="flex flex-col gap-xs">
+              <div className="bg-grey-background-light h-3.5 w-40 animate-pulse rounded" />
+              <div className="bg-grey-background-light h-2.5 w-52 animate-pulse rounded" />
+            </div>
+            <div className="bg-grey-background-light h-6 w-20 animate-pulse rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getUserErrorMessage(error: unknown, action: 'creating' | 'updating') {
+  if (error instanceof Error && error.message === DUPLICATE_EMAIL_ERROR) {
+    return 'A user with this email already exists';
+  }
+
+  return `Something went wrong while ${action} the user`;
+}

--- a/packages/backoffice/src/data/users.ts
+++ b/packages/backoffice/src/data/users.ts
@@ -1,0 +1,32 @@
+import { type CreateGlobalUserPayload, type UpdateGlobalUserPayload } from '@bo/schemas/user';
+import { createGlobalUserFn, getUsersFn, updateGlobalUserFn } from '@bo/server-fns/users';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
+import { useServerFn } from '@tanstack/react-start';
+
+export const listUsersQueryOptions = () =>
+  queryOptions({
+    queryKey: ['users'],
+    queryFn: getUsersFn,
+  });
+
+export const useCreateGlobalUserMutationOptions = () => {
+  const createGlobalUser = useServerFn(createGlobalUserFn);
+
+  return mutationOptions({
+    mutationFn: (payload: CreateGlobalUserPayload) => createGlobalUser({ data: payload }),
+    meta: {
+      invalidates: () => [['users']],
+    },
+  });
+};
+
+export const useUpdateGlobalUserMutationOptions = () => {
+  const updateGlobalUser = useServerFn(updateGlobalUserFn);
+
+  return mutationOptions({
+    mutationFn: (payload: UpdateGlobalUserPayload) => updateGlobalUser({ data: payload }),
+    meta: {
+      invalidates: () => [['users']],
+    },
+  });
+};

--- a/packages/backoffice/src/routeTree.gen.ts
+++ b/packages/backoffice/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AppPublicSignInRouteImport } from './routes/_app/_public/sign-
 import { Route as ApiTrpcSplatRouteImport } from './routes/api.trpc.$'
 import { Route as AppPrivateLicensesIndexRouteImport } from './routes/_app/_private/licenses/index'
 import { Route as AppPrivateOrganizationsOrgIdRouteImport } from './routes/_app/_private/organizations/$orgId'
+import { Route as AppPrivateUsersIndexRouteImport } from './routes/_app/_private/users/index'
 import { Route as AppPrivateOrganizationsOrgIdIndexRouteImport } from './routes/_app/_private/organizations/$orgId.index'
 import { Route as AppPrivateOrganizationsOrgIdOverviewRouteImport } from './routes/_app/_private/organizations/$orgId.overview'
 import { Route as AppPrivateOrganizationsOrgIdSettingsRouteImport } from './routes/_app/_private/organizations/$orgId.settings'
@@ -66,6 +67,11 @@ const AppPrivateOrganizationsOrgIdRoute =
     path: '/organizations/$orgId',
     getParentRoute: () => AppPrivateRoute,
   } as any)
+const AppPrivateUsersIndexRoute = AppPrivateUsersIndexRouteImport.update({
+  id: '/users/',
+  path: '/users/',
+  getParentRoute: () => AppPrivateRoute,
+} as any)
 const AppPrivateOrganizationsOrgIdIndexRoute =
   AppPrivateOrganizationsOrgIdIndexRouteImport.update({
     id: '/',
@@ -98,6 +104,7 @@ export interface FileRoutesByFullPath {
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/organizations/$orgId': typeof AppPrivateOrganizationsOrgIdRouteWithChildren
   '/licenses/': typeof AppPrivateLicensesIndexRoute
+  '/users/': typeof AppPrivateUsersIndexRoute
   '/organizations/$orgId/overview': typeof AppPrivateOrganizationsOrgIdOverviewRoute
   '/organizations/$orgId/settings': typeof AppPrivateOrganizationsOrgIdSettingsRoute
   '/organizations/$orgId/users': typeof AppPrivateOrganizationsOrgIdUsersRoute
@@ -109,6 +116,7 @@ export interface FileRoutesByTo {
   '/sign-in': typeof AppPublicSignInRoute
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/licenses': typeof AppPrivateLicensesIndexRoute
+  '/users': typeof AppPrivateUsersIndexRoute
   '/organizations/$orgId/overview': typeof AppPrivateOrganizationsOrgIdOverviewRoute
   '/organizations/$orgId/settings': typeof AppPrivateOrganizationsOrgIdSettingsRoute
   '/organizations/$orgId/users': typeof AppPrivateOrganizationsOrgIdUsersRoute
@@ -125,6 +133,7 @@ export interface FileRoutesById {
   '/api/trpc/$': typeof ApiTrpcSplatRoute
   '/_app/_private/organizations/$orgId': typeof AppPrivateOrganizationsOrgIdRouteWithChildren
   '/_app/_private/licenses/': typeof AppPrivateLicensesIndexRoute
+  '/_app/_private/users/': typeof AppPrivateUsersIndexRoute
   '/_app/_private/organizations/$orgId/overview': typeof AppPrivateOrganizationsOrgIdOverviewRoute
   '/_app/_private/organizations/$orgId/settings': typeof AppPrivateOrganizationsOrgIdSettingsRoute
   '/_app/_private/organizations/$orgId/users': typeof AppPrivateOrganizationsOrgIdUsersRoute
@@ -139,6 +148,7 @@ export interface FileRouteTypes {
     | '/api/trpc/$'
     | '/organizations/$orgId'
     | '/licenses/'
+    | '/users/'
     | '/organizations/$orgId/overview'
     | '/organizations/$orgId/settings'
     | '/organizations/$orgId/users'
@@ -150,6 +160,7 @@ export interface FileRouteTypes {
     | '/sign-in'
     | '/api/trpc/$'
     | '/licenses'
+    | '/users'
     | '/organizations/$orgId/overview'
     | '/organizations/$orgId/settings'
     | '/organizations/$orgId/users'
@@ -165,6 +176,7 @@ export interface FileRouteTypes {
     | '/api/trpc/$'
     | '/_app/_private/organizations/$orgId'
     | '/_app/_private/licenses/'
+    | '/_app/_private/users/'
     | '/_app/_private/organizations/$orgId/overview'
     | '/_app/_private/organizations/$orgId/settings'
     | '/_app/_private/organizations/$orgId/users'
@@ -242,6 +254,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppPrivateOrganizationsOrgIdRouteImport
       parentRoute: typeof AppPrivateRoute
     }
+    '/_app/_private/users/': {
+      id: '/_app/_private/users/'
+      path: '/users'
+      fullPath: '/users/'
+      preLoaderRoute: typeof AppPrivateUsersIndexRouteImport
+      parentRoute: typeof AppPrivateRoute
+    }
     '/_app/_private/organizations/$orgId/': {
       id: '/_app/_private/organizations/$orgId/'
       path: '/'
@@ -301,6 +320,7 @@ interface AppPrivateRouteChildren {
   AppPrivateDashboardRoute: typeof AppPrivateDashboardRoute
   AppPrivateOrganizationsOrgIdRoute: typeof AppPrivateOrganizationsOrgIdRouteWithChildren
   AppPrivateLicensesIndexRoute: typeof AppPrivateLicensesIndexRoute
+  AppPrivateUsersIndexRoute: typeof AppPrivateUsersIndexRoute
 }
 
 const AppPrivateRouteChildren: AppPrivateRouteChildren = {
@@ -308,6 +328,7 @@ const AppPrivateRouteChildren: AppPrivateRouteChildren = {
   AppPrivateOrganizationsOrgIdRoute:
     AppPrivateOrganizationsOrgIdRouteWithChildren,
   AppPrivateLicensesIndexRoute: AppPrivateLicensesIndexRoute,
+  AppPrivateUsersIndexRoute: AppPrivateUsersIndexRoute,
 }
 
 const AppPrivateRouteWithChildren = AppPrivateRoute._addFileChildren(

--- a/packages/backoffice/src/routes/_app/_private.tsx
+++ b/packages/backoffice/src/routes/_app/_private.tsx
@@ -56,6 +56,9 @@ function RouteComponent() {
               <Link to="/licenses" className="data-[status=active]:text-purple-65">
                 Licences Management
               </Link>
+              <Link to="/users" className="data-[status=active]:text-purple-65">
+                Users
+              </Link>
             </div>
             <div className="flex items-center gap-sm ml-auto">
               <div className="flex gap-xs h-6 items-center">

--- a/packages/backoffice/src/routes/_app/_private/users/index.tsx
+++ b/packages/backoffice/src/routes/_app/_private/users/index.tsx
@@ -1,0 +1,14 @@
+import { ErrorComponent } from '@bo/components/common/ErrorComponent';
+import { UsersPage } from '@bo/components/pages/users';
+import { listUsersQueryOptions } from '@bo/data/users';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_app/_private/users/')({
+  component: UsersPage,
+  loader: ({ context }) => {
+    context.queryClient.prefetchQuery(listUsersQueryOptions());
+  },
+  errorComponent: () => {
+    return <ErrorComponent message="Something went wrong while fetching users" />;
+  },
+});

--- a/packages/backoffice/src/schemas/user.ts
+++ b/packages/backoffice/src/schemas/user.ts
@@ -8,6 +8,9 @@ const ROLE_ANALYST = 'ANALYST';
 
 export const USER_ROLES = [ROLE_ADMIN, ROLE_PUBLISHER, ROLE_BUILDER, ROLE_VIEWER, ROLE_ANALYST] as const;
 
+// Global Backoffice management can provision the internal operator role as well.
+export const GLOBAL_USER_ROLES = [...USER_ROLES, 'MARBLE_ADMIN'] as const;
+
 export const createUserPayloadSchema = z.object({
   first_name: z.string().min(1),
   last_name: z.string().min(1),
@@ -16,6 +19,22 @@ export const createUserPayloadSchema = z.object({
 });
 
 export type CreateUserPayload = z.infer<typeof createUserPayloadSchema>;
+
+const globalUserDetailsSchema = z.object({
+  first_name: z.string().min(1),
+  last_name: z.string().min(1),
+  email: z.email(),
+  role: z.enum(GLOBAL_USER_ROLES),
+});
+
+export const createGlobalUserPayloadSchema = globalUserDetailsSchema;
+export type CreateGlobalUserPayload = z.infer<typeof createGlobalUserPayloadSchema>;
+
+export const updateGlobalUserPayloadSchema = globalUserDetailsSchema.extend({
+  userId: z.uuid(),
+  organization_id: z.uuid().optional(),
+});
+export type UpdateGlobalUserPayload = z.infer<typeof updateGlobalUserPayloadSchema>;
 
 /**
  * Error code thrown by `createOrganizationUserFn` when the email is already taken, so the

--- a/packages/backoffice/src/server-fns/users.ts
+++ b/packages/backoffice/src/server-fns/users.ts
@@ -1,0 +1,60 @@
+import { env } from '@bo/env';
+import { needAuth } from '@bo/middlewares/auth';
+import { createGlobalUserPayloadSchema, DUPLICATE_EMAIL_ERROR, updateGlobalUserPayloadSchema } from '@bo/schemas/user';
+import { isRedirect } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { marblecoreApi } from 'marble-api';
+
+const CONFLICT_STATUS = 409;
+
+const isConflictError = (error: unknown) =>
+  error instanceof Error && (error as { status?: number }).status === CONFLICT_STATUS;
+
+export const getUsersFn = createServerFn({ method: 'GET' })
+  .middleware([needAuth])
+  .handler(async ({ context }) => {
+    const { users } = await marblecoreApi.listUsers({
+      baseUrl: env.API_BASE_URL,
+      fetch: context.authFetch,
+    });
+
+    return users;
+  });
+
+export const createGlobalUserFn = createServerFn({ method: 'POST' })
+  .middleware([needAuth])
+  .validator(createGlobalUserPayloadSchema)
+  .handler(async ({ context, data }) => {
+    try {
+      const { user } = await marblecoreApi.createUser(data, {
+        baseUrl: env.API_BASE_URL,
+        fetch: context.authFetch,
+      });
+
+      return user;
+    } catch (error) {
+      if (isRedirect(error)) throw error;
+      if (isConflictError(error)) throw new Error(DUPLICATE_EMAIL_ERROR);
+      throw new Error('Failed to create user');
+    }
+  });
+
+export const updateGlobalUserFn = createServerFn({ method: 'POST' })
+  .middleware([needAuth])
+  .validator(updateGlobalUserPayloadSchema)
+  .handler(async ({ context, data }) => {
+    const { userId, ...userPayload } = data;
+
+    try {
+      const { user } = await marblecoreApi.updateUser(userId, userPayload, {
+        baseUrl: env.API_BASE_URL,
+        fetch: context.authFetch,
+      });
+
+      return user;
+    } catch (error) {
+      if (isRedirect(error)) throw error;
+      if (isConflictError(error)) throw new Error(DUPLICATE_EMAIL_ERROR);
+      throw new Error('Failed to update user');
+    }
+  });

--- a/packages/marble-api/openapis/marblecore-api/admin.yml
+++ b/packages/marble-api/openapis/marblecore-api/admin.yml
@@ -725,7 +725,6 @@ components:
       required:
         - email
         - role
-        - organization_id
         - first_name
         - last_name
       properties:
@@ -756,7 +755,6 @@ components:
       required:
         - email
         - role
-        - organization_id
         - first_name
         - last_name
       properties:

--- a/packages/marble-api/src/generated/marblecore-api.ts
+++ b/packages/marble-api/src/generated/marblecore-api.ts
@@ -1751,14 +1751,14 @@ export type UserDto = {
 export type CreateUser = {
     email: string;
     role: string;
-    organization_id: string;
+    organization_id?: string;
     first_name: string;
     last_name: string;
 };
 export type UpdateUser = {
     email: string;
     role: string;
-    organization_id: string;
+    organization_id?: string;
     first_name: string;
     last_name: string;
 };


### PR DESCRIPTION
<img width="1729" height="596" alt="image" src="https://github.com/user-attachments/assets/e70680f0-be05-4a3f-823e-69b71ec21165" />
<img width="1016" height="1044" alt="image" src="https://github.com/user-attachments/assets/441a7d29-db82-41aa-91be-df8e7780a147" />
<img width="1016" height="1044" alt="image" src="https://github.com/user-attachments/assets/2ad30878-c1ed-4ba4-9e1a-37cf5adca2dc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Users section to the backoffice with navigation access.
  * View, search, create, and edit users using a dedicated management page.
  * Added form validation, success notifications, and friendly duplicate-email errors.
  * Added loading, error, empty-list, and no-search-results states.
  * Editing is restricted to saving when changes have been made.
  * Organization association is no longer required when creating or updating users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->